### PR TITLE
[doc] Remove explicit link to mathjax

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1233,7 +1233,7 @@ USE_MATHJAX            = YES
 # installing MathJax.  However, it is strongly recommended to install a local
 # copy of MathJax from http://www.mathjax.org before deployment.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        =
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or MathJax extension
 # names that should be enabled during MathJax rendering.


### PR DESCRIPTION
Remove explicit link to insecure link for mathjax (`http`).

Closes #37 