### PR TITLE
Fix eigen transitive in Ponca::SpatialPartitioning

### DIFF
--- a/cmake/PoncaConfigureCommon.cmake
+++ b/cmake/PoncaConfigureCommon.cmake
@@ -21,8 +21,6 @@ set_target_properties(Common PROPERTIES
   INTERFACE_COMPILE_FEATURES cxx_std_11
 )
 
-#target_link_libraries(Fitting PUBLIC INTERFACE Eigen3::Eigen)
-
 install(TARGETS Common
     EXPORT CommonTargets
     LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}

--- a/cmake/PoncaConfigureSpatialPartitioning.cmake
+++ b/cmake/PoncaConfigureSpatialPartitioning.cmake
@@ -36,7 +36,10 @@ set_target_properties(SpatialPartitioning PROPERTIES
   INTERFACE_COMPILE_FEATURES cxx_std_11
 )
 
-target_link_libraries(SpatialPartitioning PUBLIC INTERFACE Eigen3::Eigen)
+if(Eigen3_FOUND)
+    message("Compiling with installed Eigen package, enable transitive linking (Version ${Eigen3_VERSION}, path: ${Eigen3_DIR})")
+    target_link_libraries(SpatialPartitioning PUBLIC INTERFACE Eigen3::Eigen)
+endif()
 
 install(TARGETS SpatialPartitioning
     EXPORT SpatialPartitioningTargets


### PR DESCRIPTION
Replace 

```cmake
target_link_libraries(SpatialPartitioning PUBLIC INTERFACE Eigen3::Eigen)
``` 

by 

```cmake
if(Eigen3_FOUND)
    # ...
    target_link_libraries(SpatialPartitioning PUBLIC INTERFACE Eigen3::Eigen)
endif()
```

in `ConfigureSpatialPartitioning.cmake`. 