### PR TITLE
Kd-tree adapter

### DIFF
--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeKNearestIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeKNearestIterator.h
@@ -20,7 +20,7 @@ public:
     virtual inline ~KdTreeKNearestIterator() = default;
 
 public:
-    inline bool operator !=(const KdTreeKNearestIterator<Index, DataPoint>& other) const
+    inline bool operator !=(const KdTreeKNearestIterator& other) const
     {return m_iterator != other.m_iterator;}
     inline void operator ++() {++m_iterator;}
     inline int  operator * () const {return m_iterator->index;}

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeKNearestIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeKNearestIterator.h
@@ -8,19 +8,19 @@
 
 namespace Ponca {
 
-template <class DataPoint>
+template <typename Index, typename DataPoint>
 class KdTreeKNearestIterator
 {
 public:
     using Scalar   = typename DataPoint::Scalar;
-    using Iterator = typename limited_priority_queue<IndexSquaredDistance<Scalar>>::iterator;
+    using Iterator = typename limited_priority_queue<IndexSquaredDistance<Index, Scalar>>::iterator;
 
     inline KdTreeKNearestIterator() = default;
     inline KdTreeKNearestIterator(const Iterator& iterator) : m_iterator(iterator) {}
     virtual inline ~KdTreeKNearestIterator() = default;
 
 public:
-    inline bool operator !=(const KdTreeKNearestIterator<DataPoint>& other) const
+    inline bool operator !=(const KdTreeKNearestIterator<Index, DataPoint>& other) const
     {return m_iterator != other.m_iterator;}
     inline void operator ++() {++m_iterator;}
     inline int  operator * () const {return m_iterator->index;}

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeNearestIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeNearestIterator.h
@@ -8,11 +8,12 @@
 
 namespace Ponca {
 
+template<typename Index>
 class KdTreeNearestIterator
 {
 public:
     inline KdTreeNearestIterator() = default;
-    inline KdTreeNearestIterator(int index) : m_index(index) {}
+    inline KdTreeNearestIterator(Index index) : m_index(index) {}
     virtual inline ~KdTreeNearestIterator() = default;
 
 public:
@@ -20,10 +21,10 @@ public:
     {return m_index != other.m_index;}
     inline void operator ++(int) {++m_index;}
     inline KdTreeNearestIterator& operator ++() {++m_index; return *this;}
-    inline int  operator * () const {return m_index;}
+    inline Index operator * () const {return m_index;}
 
 protected:
-    int m_index {-1};
+    Index m_index {-1};
 };
 
 } // namespace ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeRangeIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeRangeIterator.h
@@ -22,10 +22,10 @@ public:
     inline KdTreeRangeIterator(QueryType* query, Index index = -1) :
         m_query(query), m_index(index), m_start(0), m_end(0) {}
 
-    inline bool operator !=(const KdTreeRangeIterator<DataPoint,QueryType>& other) const
+    inline bool operator !=(const KdTreeRangeIterator& other) const
     {return m_index != other.m_index;}
     inline void operator ++(int) {m_query->advance(*this);}
-    inline KdTreeRangeIterator<DataPoint,QueryType>& operator++() {m_query->advance(*this); return *this;}
+    inline KdTreeRangeIterator& operator++() {m_query->advance(*this); return *this;}
     inline Index operator *() const {return m_index;}
 
 protected:

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeRangeIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeRangeIterator.h
@@ -8,7 +8,7 @@
 
 namespace Ponca {
 
-template<class DataPoint, class QueryT_>
+template<typename Index, typename DataPoint, typename QueryT_>
 class KdTreeRangeIterator
 {
 protected:
@@ -19,19 +19,19 @@ public:
     using QueryType = QueryT_;
 
     inline KdTreeRangeIterator() = default;
-    inline KdTreeRangeIterator(QueryType* query, int index = -1) :
+    inline KdTreeRangeIterator(QueryType* query, Index index = -1) :
         m_query(query), m_index(index), m_start(0), m_end(0) {}
 
     inline bool operator !=(const KdTreeRangeIterator<DataPoint,QueryType>& other) const
     {return m_index != other.m_index;}
     inline void operator ++(int) {m_query->advance(*this);}
     inline KdTreeRangeIterator<DataPoint,QueryType>& operator++() {m_query->advance(*this); return *this;}
-    inline int operator *() const {return m_index;}
+    inline Index operator *() const {return m_index;}
 
 protected:
     QueryType* m_query {nullptr};
-    int m_index {-1};
-    int m_start {0};
-    int m_end {0};
+    Index m_index {-1};
+    Index m_start {0};
+    Index m_end {0};
 };
 } // namespace ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.h
@@ -12,18 +12,18 @@
 
 namespace Ponca {
 
-template<class DataPoint>
-class KdTreeKNearestIndexQuery : public KdTreeQuery<DataPoint>,
+template<class DataPoint, class Compatibility>
+class KdTreeKNearestIndexQuery : public KdTreeQuery<DataPoint, Compatibility>,
     public KNearestIndexQuery<typename DataPoint::Scalar>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = KNearestIndexQuery<typename DataPoint::Scalar>;
-    using QueryAccelType  = KdTreeQuery<DataPoint>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
 
-    KdTreeKNearestIndexQuery(const KdTree<DataPoint>* kdtree, int k, int index) :
-        KdTreeQuery<DataPoint>(kdtree), KNearestIndexQuery<Scalar>(k, index)
+    KdTreeKNearestIndexQuery(const KdTree<DataPoint, Compatibility>* kdtree, int k, int index) :
+        KdTreeQuery<DataPoint, Compatibility>(kdtree), KNearestIndexQuery<Scalar>(k, index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.h
@@ -12,18 +12,18 @@
 
 namespace Ponca {
 
-template<class DataPoint, class Compatibility>
-class KdTreeKNearestIndexQuery : public KdTreeQuery<DataPoint, Compatibility>,
+template<class DataPoint, class Adapter>
+class KdTreeKNearestIndexQuery : public KdTreeQuery<DataPoint, Adapter>,
     public KNearestIndexQuery<typename DataPoint::Scalar>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = KNearestIndexQuery<typename DataPoint::Scalar>;
-    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeKNearestIndexQuery(const KdTree<DataPoint, Compatibility>* kdtree, int k, int index) :
-        KdTreeQuery<DataPoint, Compatibility>(kdtree), KNearestIndexQuery<Scalar>(k, index)
+    KdTreeKNearestIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, int k, int index) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), KNearestIndexQuery<Scalar>(k, index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.h
@@ -14,22 +14,23 @@ namespace Ponca {
 
 template<class DataPoint, class Adapter>
 class KdTreeKNearestIndexQuery : public KdTreeQuery<DataPoint, Adapter>,
-    public KNearestIndexQuery<typename DataPoint::Scalar>
+    public KNearestIndexQuery<typename Adapter::IndexType, typename DataPoint::Scalar>
 {
 public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
-    using QueryType       = KNearestIndexQuery<typename DataPoint::Scalar>;
+    using QueryType       = KNearestIndexQuery<IndexType, typename DataPoint::Scalar>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeKNearestIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, int k, int index) :
-        KdTreeQuery<DataPoint, Adapter>(kdtree), KNearestIndexQuery<Scalar>(k, index)
+    KdTreeKNearestIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, IndexType k, IndexType index) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), KNearestIndexQuery<IndexType, Scalar>(k, index)
     {
     }
 
 public:
-    KdTreeKNearestIterator<DataPoint> begin();
-    KdTreeKNearestIterator<DataPoint> end();
+    KdTreeKNearestIterator<IndexType, DataPoint> begin();
+    KdTreeKNearestIterator<IndexType, DataPoint> end();
 
 protected:
     void search();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template<class DataPoint, class Compatibility>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Compatibility>::begin()
+template<class DataPoint, class Adapter>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Compatibil
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.begin());
 }
 
-template<class DataPoint, class Compatibility>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Compatibility>::end()
+template<class DataPoint, class Adapter>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Adapter>::end()
 {
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.end());
 }
 
-template<class DataPoint, class Compatibility>
-void KdTreeKNearestIndexQuery<DataPoint, Compatibility>::search()
+template<class DataPoint, class Adapter>
+void KdTreeKNearestIndexQuery<DataPoint, Adapter>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template<class DataPoint>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint>::begin()
+template<class DataPoint, class Compatibility>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint>::begin()
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.begin());
 }
 
-template<class DataPoint>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint>::end()
+template<class DataPoint, class Compatibility>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Compatibility>::end()
 {
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.end());
 }
 
-template<class DataPoint>
-void KdTreeKNearestIndexQuery<DataPoint>::search()
+template<class DataPoint, class Compatibility>
+void KdTreeKNearestIndexQuery<DataPoint, Compatibility>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
@@ -54,13 +54,13 @@ void KdTreeKNearestIndexQuery<DataPoint, Adapter>::search()
                 QueryAccelType::m_stack.push();
                 if(newOff < 0)
                 {
-                    QueryAccelType::m_stack.top().index = node.first_child_id;
-                    qnode.index         = node.first_child_id+1;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id;
+                    qnode.index         = node.inner.first_child_id+1;
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.first_child_id+1;
-                    qnode.index         = node.first_child_id;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id+1;
+                    qnode.index         = node.inner.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;
                 qnode.squared_distance         = newOff*newOff;

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestIndexQuery.hpp
@@ -5,18 +5,18 @@
 */
 
 template<class DataPoint, class Adapter>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Adapter>::begin()
+KdTreeKNearestIterator<typename Adapter::IndexType, DataPoint> KdTreeKNearestIndexQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
     this->search();
-    return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.begin());
+    return KdTreeKNearestIterator<IndexType, DataPoint>(QueryType::m_queue.begin());
 }
 
 template<class DataPoint, class Adapter>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestIndexQuery<DataPoint, Adapter>::end()
+KdTreeKNearestIterator<typename Adapter::IndexType, DataPoint> KdTreeKNearestIndexQuery<DataPoint, Adapter>::end()
 {
-    return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.end());
+    return KdTreeKNearestIterator<IndexType, DataPoint>(QueryType::m_queue.end());
 }
 
 template<class DataPoint, class Adapter>
@@ -34,33 +34,33 @@ void KdTreeKNearestIndexQuery<DataPoint, Adapter>::search()
 
         if(qnode.squared_distance < QueryType::m_queue.bottom().squared_distance)
         {
-            if(node.leaf)
+            if(node.is_leaf())
             {
                 QueryAccelType::m_stack.pop();
-                int end = node.start + node.size;
-                for(int i=node.start; i<end; ++i)
+                IndexType end = node.leaf.start + node.leaf.size;
+                for(IndexType i=node.leaf.start; i<end; ++i)
                 {
-                    int idx = indices[i];
+                    IndexType idx = indices[i];
                     if(QueryType::input() == idx) continue;
 
-                    Scalar d = (point - points[idx].pos()).squaredNorm();
+                    Scalar d = Adapter::squared_norm(point - points[idx].pos());
                     QueryType::m_queue.push({idx, d});
                 }
             }
             else
             {
                 // replace the stack top by the farthest and push the closest
-                Scalar newOff = point[node.dim] - node.splitValue;
+                Scalar newOff = point[node.inner.dim] - node.inner.split_value;
                 QueryAccelType::m_stack.push();
                 if(newOff < 0)
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId;
-                    qnode.index         = node.firstChildId+1;
+                    QueryAccelType::m_stack.top().index = node.first_child_id;
+                    qnode.index         = node.first_child_id+1;
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId+1;
-                    qnode.index         = node.firstChildId;
+                    QueryAccelType::m_stack.top().index = node.first_child_id+1;
+                    qnode.index         = node.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;
                 qnode.squared_distance         = newOff*newOff;

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.h
@@ -13,22 +13,24 @@
 namespace Ponca {
 
 template <class DataPoint, class Adapter>
-class KdTreeKNearestPointQuery : public KNearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Adapter>
+class KdTreeKNearestPointQuery : public KdTreeQuery<DataPoint, Adapter>,
+    public KNearestPointQuery<typename Adapter::IndexType, DataPoint>
 {
 public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
-    using QueryType       = KNearestPointQuery<DataPoint>;
+    using QueryType       = KNearestPointQuery<IndexType, DataPoint>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeKNearestPointQuery(const KdTree<DataPoint, Adapter>* kdtree, int k, const VectorType& point) :
-        KdTreeQuery<DataPoint, Adapter>(kdtree), KNearestPointQuery<DataPoint>(k, point)
+    KdTreeKNearestPointQuery(const KdTree<DataPoint, Adapter>* kdtree, IndexType k, const VectorType& point) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), KNearestPointQuery<IndexType, DataPoint>(k, point)
     {
     }
 
 public:
-    KdTreeKNearestIterator<DataPoint> begin();
-    KdTreeKNearestIterator<DataPoint> end();
+    KdTreeKNearestIterator<IndexType, DataPoint> begin();
+    KdTreeKNearestIterator<IndexType, DataPoint> end();
 
 protected:
    void search();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.h
@@ -12,17 +12,17 @@
 
 namespace Ponca {
 
-template <class DataPoint>
-class KdTreeKNearestPointQuery : public KNearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint>
+template <class DataPoint, class Compatibility>
+class KdTreeKNearestPointQuery : public KNearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Compatibility>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = KNearestPointQuery<DataPoint>;
-    using QueryAccelType  = KdTreeQuery<DataPoint>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
 
-    KdTreeKNearestPointQuery(const KdTree<DataPoint>* kdtree, int k, const VectorType& point) :
-        KdTreeQuery<DataPoint>(kdtree), KNearestPointQuery<DataPoint>(k, point)
+    KdTreeKNearestPointQuery(const KdTree<DataPoint, Compatibility>* kdtree, int k, const VectorType& point) :
+        KdTreeQuery<DataPoint, Compatibility>(kdtree), KNearestPointQuery<DataPoint>(k, point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.h
@@ -12,17 +12,17 @@
 
 namespace Ponca {
 
-template <class DataPoint, class Compatibility>
-class KdTreeKNearestPointQuery : public KNearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Compatibility>
+template <class DataPoint, class Adapter>
+class KdTreeKNearestPointQuery : public KNearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Adapter>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = KNearestPointQuery<DataPoint>;
-    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeKNearestPointQuery(const KdTree<DataPoint, Compatibility>* kdtree, int k, const VectorType& point) :
-        KdTreeQuery<DataPoint, Compatibility>(kdtree), KNearestPointQuery<DataPoint>(k, point)
+    KdTreeKNearestPointQuery(const KdTree<DataPoint, Adapter>* kdtree, int k, const VectorType& point) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), KNearestPointQuery<DataPoint>(k, point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint, class Compatibility>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Compatibility>::begin()
+template <class DataPoint, class Adapter>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Compatibil
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.begin());
 }
 
-template <class DataPoint, class Compatibility>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Compatibility>::end()
+template <class DataPoint, class Adapter>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Adapter>::end()
 {
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.end());
 }
 
-template <class DataPoint, class Compatibility>
-void KdTreeKNearestPointQuery<DataPoint, Compatibility>::search()
+template <class DataPoint, class Adapter>
+void KdTreeKNearestPointQuery<DataPoint, Adapter>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint>::begin()
+template <class DataPoint, class Compatibility>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint>::begin()
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.begin());
 }
 
-template <class DataPoint>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint>::end()
+template <class DataPoint, class Compatibility>
+KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Compatibility>::end()
 {
     return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.end());
 }
 
-template <class DataPoint>
-void KdTreeKNearestPointQuery<DataPoint>::search()
+template <class DataPoint, class Compatibility>
+void KdTreeKNearestPointQuery<DataPoint, Compatibility>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
@@ -58,7 +58,7 @@ void KdTreeKNearestPointQuery<DataPoint, Adapter>::search()
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.first_child_id+1;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id+1;
                     qnode.index         = node.inner.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestPointQuery.hpp
@@ -5,18 +5,18 @@
 */
 
 template <class DataPoint, class Adapter>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Adapter>::begin()
+KdTreeKNearestIterator<typename Adapter::IndexType, DataPoint> KdTreeKNearestPointQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
     this->search();
-    return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.begin());
+    return KdTreeKNearestIterator<IndexType, DataPoint>(QueryType::m_queue.begin());
 }
 
 template <class DataPoint, class Adapter>
-KdTreeKNearestIterator<DataPoint> KdTreeKNearestPointQuery<DataPoint, Adapter>::end()
+KdTreeKNearestIterator<typename Adapter::IndexType, DataPoint> KdTreeKNearestPointQuery<DataPoint, Adapter>::end()
 {
-    return KdTreeKNearestIterator<DataPoint>(QueryType::m_queue.end());
+    return KdTreeKNearestIterator<IndexType, DataPoint>(QueryType::m_queue.end());
 }
 
 template <class DataPoint, class Adapter>
@@ -34,32 +34,32 @@ void KdTreeKNearestPointQuery<DataPoint, Adapter>::search()
 
         if(qnode.squared_distance < QueryType::m_queue.bottom().squared_distance)
         {
-            if(node.leaf)
+            if(node.is_leaf())
             {
                 QueryAccelType::m_stack.pop();
-                int end = node.start + node.size;
-                for(int i=node.start; i<end; ++i)
+                IndexType end = node.leaf.start + node.leaf.size;
+                for(IndexType i=node.leaf.start; i<end; ++i)
                 {
-                    int idx = indices[i];
+                    IndexType idx = indices[i];
 
-                    Scalar d = (point - points[idx].pos()).squaredNorm();
+                    Scalar d = Adapter::squared_norm(point - points[idx].pos());
                     QueryType::m_queue.push({idx, d});
                 }
             }
             else
             {
                 // replace the stack top by the farthest and push the closest
-                Scalar newOff = point[node.dim] - node.splitValue;
+                Scalar newOff = point[node.inner.dim] - node.inner.split_value;
                 QueryAccelType::m_stack.push();
                 if(newOff < 0)
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId;
-                    qnode.index         = node.firstChildId+1;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id;
+                    qnode.index         = node.inner.first_child_id+1;
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId+1;
-                    qnode.index         = node.firstChildId;
+                    QueryAccelType::m_stack.top().index = node.first_child_id+1;
+                    qnode.index         = node.inner.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;
                 qnode.squared_distance         = newOff*newOff;

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.h
@@ -12,17 +12,17 @@
 
 namespace Ponca {
 
-template <class DataPoint, class Compatibility>
-class KdTreeNearestIndexQuery : public KdTreeQuery<DataPoint, Compatibility>, public NearestIndexQuery<typename DataPoint::Scalar>
+template <class DataPoint, class Adapter>
+class KdTreeNearestIndexQuery : public KdTreeQuery<DataPoint, Adapter>, public NearestIndexQuery<typename DataPoint::Scalar>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = NearestIndexQuery<typename DataPoint::Scalar>;
-    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeNearestIndexQuery(const KdTree<DataPoint, Compatibility>* kdtree, int index) :
-        KdTreeQuery<DataPoint, Compatibility>(kdtree), NearestIndexQuery<Scalar>(index)
+    KdTreeNearestIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, int index) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), NearestIndexQuery<Scalar>(index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.h
@@ -13,22 +13,24 @@
 namespace Ponca {
 
 template <class DataPoint, class Adapter>
-class KdTreeNearestIndexQuery : public KdTreeQuery<DataPoint, Adapter>, public NearestIndexQuery<typename DataPoint::Scalar>
+class KdTreeNearestIndexQuery : public KdTreeQuery<DataPoint, Adapter>,
+    public NearestIndexQuery<typename Adapter::IndexType, typename DataPoint::Scalar>
 {
 public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
-    using QueryType       = NearestIndexQuery<typename DataPoint::Scalar>;
+    using QueryType       = NearestIndexQuery<IndexType, typename DataPoint::Scalar>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeNearestIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, int index) :
-        KdTreeQuery<DataPoint, Adapter>(kdtree), NearestIndexQuery<Scalar>(index)
+    KdTreeNearestIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, IndexType index) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), NearestIndexQuery<IndexType, Scalar>(index)
     {
     }
 
 public:
-    KdTreeNearestIterator begin();
-    KdTreeNearestIterator end();
+    KdTreeNearestIterator<IndexType> begin();
+    KdTreeNearestIterator<IndexType> end();
 
 protected:
     void search();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.h
@@ -12,17 +12,17 @@
 
 namespace Ponca {
 
-template <class DataPoint>
-class KdTreeNearestIndexQuery : public KdTreeQuery<DataPoint>, public NearestIndexQuery<typename DataPoint::Scalar>
+template <class DataPoint, class Compatibility>
+class KdTreeNearestIndexQuery : public KdTreeQuery<DataPoint, Compatibility>, public NearestIndexQuery<typename DataPoint::Scalar>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = NearestIndexQuery<typename DataPoint::Scalar>;
-    using QueryAccelType  = KdTreeQuery<DataPoint>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
 
-    KdTreeNearestIndexQuery(const KdTree<DataPoint>* kdtree, int index) :
-        KdTreeQuery<DataPoint>(kdtree), NearestIndexQuery<Scalar>(index)
+    KdTreeNearestIndexQuery(const KdTree<DataPoint, Compatibility>* kdtree, int index) :
+        KdTreeQuery<DataPoint, Compatibility>(kdtree), NearestIndexQuery<Scalar>(index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint, class Compatibility>
-KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Compatibility>::begin()
+template <class DataPoint, class Adapter>
+KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Compatibility>::begin()
     return KdTreeNearestIterator(QueryType::m_nearest);
 }
 
-template <class DataPoint, class Compatibility>
-KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Compatibility>::end()
+template <class DataPoint, class Adapter>
+KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Adapter>::end()
 {
     return KdTreeNearestIterator(QueryType::m_nearest + 1);
 }
 
-template <class DataPoint, class Compatibility>
-void KdTreeNearestIndexQuery<DataPoint, Compatibility>::search()
+template <class DataPoint, class Adapter>
+void KdTreeNearestIndexQuery<DataPoint, Adapter>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint>
-KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint>::begin()
+template <class DataPoint, class Compatibility>
+KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint>::begin()
     return KdTreeNearestIterator(QueryType::m_nearest);
 }
 
-template <class DataPoint>
-KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint>::end()
+template <class DataPoint, class Compatibility>
+KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Compatibility>::end()
 {
     return KdTreeNearestIterator(QueryType::m_nearest + 1);
 }
 
-template <class DataPoint>
-void KdTreeNearestIndexQuery<DataPoint>::search()
+template <class DataPoint, class Compatibility>
+void KdTreeNearestIndexQuery<DataPoint, Compatibility>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestIndexQuery.hpp
@@ -5,18 +5,18 @@
 */
 
 template <class DataPoint, class Adapter>
-KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Adapter>::begin()
+KdTreeNearestIterator<typename Adapter::IndexType> KdTreeNearestIndexQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
     this->search();
-    return KdTreeNearestIterator(QueryType::m_nearest);
+    return KdTreeNearestIterator<IndexType>(QueryType::m_nearest);
 }
 
 template <class DataPoint, class Adapter>
-KdTreeNearestIterator KdTreeNearestIndexQuery<DataPoint, Adapter>::end()
+KdTreeNearestIterator<typename Adapter::IndexType> KdTreeNearestIndexQuery<DataPoint, Adapter>::end()
 {
-    return KdTreeNearestIterator(QueryType::m_nearest + 1);
+    return KdTreeNearestIterator<IndexType>(QueryType::m_nearest + 1);
 }
 
 template <class DataPoint, class Adapter>
@@ -37,16 +37,16 @@ void KdTreeNearestIndexQuery<DataPoint, Adapter>::search()
 
         if(qnode.squared_distance < QueryType::m_squared_distance)
         {
-            if(node.leaf)
+            if(node.is_leaf())
             {
                 QueryAccelType::m_stack.pop();
-                int end = node.start + node.size;
-                for(int i=node.start; i<end; ++i)
+                IndexType end = node.leaf.start + node.leaf.size;
+                for(IndexType i=node.leaf.start; i<end; ++i)
                 {
-                    int idx = indices[i];
+                    IndexType idx = indices[i];
                     if(QueryType::input() == idx) continue;
 
-                    Scalar d = (point - points[idx].pos()).squaredNorm();
+                    Scalar d = Adapter::squared_norm(point - points[idx].pos());
                     if(d < QueryType::m_squared_distance)
                     {
                         QueryType::m_nearest = idx;
@@ -57,17 +57,17 @@ void KdTreeNearestIndexQuery<DataPoint, Adapter>::search()
             else
             {
                 // replace the stack top by the farthest and push the closest
-                Scalar newOff = point[node.dim] - node.splitValue;
+                Scalar newOff = point[node.inner.dim] - node.inner.split_value;
                 QueryAccelType::m_stack.push();
                 if(newOff < 0)
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId;
-                    qnode.index         = node.firstChildId+1;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id;
+                    qnode.index         = node.inner.first_child_id+1;
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId+1;
-                    qnode.index         = node.firstChildId;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id+1;
+                    qnode.index         = node.inner.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;
                 qnode.squared_distance         = newOff*newOff;

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.h
@@ -12,17 +12,17 @@
 
 namespace Ponca {
 
-template <class DataPoint, class Compatibility>
-class KdTreeNearestPointQuery : public NearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Compatibility>
+template <class DataPoint, class Adapter>
+class KdTreeNearestPointQuery : public NearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Adapter>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = NearestPointQuery<DataPoint>;
-    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
-    KdTreeNearestPointQuery(const KdTree<DataPoint, Compatibility>* kdtree, const VectorType& point) :
-        KdTreeQuery<DataPoint, Compatibility>(kdtree), NearestPointQuery<DataPoint>(point)
+    KdTreeNearestPointQuery(const KdTree<DataPoint, Adapter>* kdtree, const VectorType& point) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), NearestPointQuery<DataPoint>(point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.h
@@ -13,22 +13,24 @@
 namespace Ponca {
 
 template <class DataPoint, class Adapter>
-class KdTreeNearestPointQuery : public NearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Adapter>
+class KdTreeNearestPointQuery : public KdTreeQuery<DataPoint, Adapter>,
+    public NearestPointQuery<typename Adapter::IndexType, DataPoint>
 {
 public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
-    using QueryType       = NearestPointQuery<DataPoint>;
+    using QueryType       = NearestPointQuery<IndexType, DataPoint>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
 
     KdTreeNearestPointQuery(const KdTree<DataPoint, Adapter>* kdtree, const VectorType& point) :
-        KdTreeQuery<DataPoint, Adapter>(kdtree), NearestPointQuery<DataPoint>(point)
+        KdTreeQuery<DataPoint, Adapter>(kdtree), NearestPointQuery<IndexType, DataPoint>(point)
     {
     }
 
 public:
-    KdTreeNearestIterator begin();
-    KdTreeNearestIterator end();
+    KdTreeNearestIterator<IndexType> begin();
+    KdTreeNearestIterator<IndexType> end();
 
 protected:
     void search();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.h
@@ -12,17 +12,17 @@
 
 namespace Ponca {
 
-template <class DataPoint>
-class KdTreeNearestPointQuery : public NearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint>
+template <class DataPoint, class Compatibility>
+class KdTreeNearestPointQuery : public NearestPointQuery<DataPoint>, public KdTreeQuery<DataPoint, Compatibility>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = NearestPointQuery<DataPoint>;
-    using QueryAccelType  = KdTreeQuery<DataPoint>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
 
-    KdTreeNearestPointQuery(const KdTree<DataPoint>* kdtree, const VectorType& point) :
-        KdTreeQuery<DataPoint>(kdtree), NearestPointQuery<DataPoint>(point)
+    KdTreeNearestPointQuery(const KdTree<DataPoint, Compatibility>* kdtree, const VectorType& point) :
+        KdTreeQuery<DataPoint, Compatibility>(kdtree), NearestPointQuery<DataPoint>(point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint>
-KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint>::begin()
+template <class DataPoint, class Compatibility>
+KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint>::begin()
     return KdTreeNearestIterator(QueryType::m_nearest);
 }
 
-template <class DataPoint>
-KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint>::end()
+template <class DataPoint, class Compatibility>
+KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Compatibility>::end()
 {
     return KdTreeNearestIterator(QueryType::m_nearest + 1);
 }
 
-template <class DataPoint>
-void KdTreeNearestPointQuery<DataPoint>::search()
+template <class DataPoint, class Compatibility>
+void KdTreeNearestPointQuery<DataPoint, Compatibility>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestPointQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint, class Compatibility>
-KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Compatibility>::begin()
+template <class DataPoint, class Adapter>
+KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -13,14 +13,14 @@ KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Compatibility>::begin()
     return KdTreeNearestIterator(QueryType::m_nearest);
 }
 
-template <class DataPoint, class Compatibility>
-KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Compatibility>::end()
+template <class DataPoint, class Adapter>
+KdTreeNearestIterator KdTreeNearestPointQuery<DataPoint, Adapter>::end()
 {
     return KdTreeNearestIterator(QueryType::m_nearest + 1);
 }
 
-template <class DataPoint, class Compatibility>
-void KdTreeNearestPointQuery<DataPoint, Compatibility>::search()
+template <class DataPoint, class Adapter>
+void KdTreeNearestPointQuery<DataPoint, Adapter>::search()
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
@@ -13,13 +13,13 @@
 namespace Ponca {
 
 
-template <class DataPoint, class Compatibility>
-class KdTreeRangeIndexQuery : public KdTreeQuery<DataPoint, Compatibility>, public RangeIndexQuery<typename DataPoint::Scalar>
+template <class DataPoint, class Adapter>
+class KdTreeRangeIndexQuery : public KdTreeQuery<DataPoint, Adapter>, public RangeIndexQuery<typename DataPoint::Scalar>
 {
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = RangeIndexQuery<typename DataPoint::Scalar>;
-    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
     using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangeIndexQuery>;
 
 protected:
@@ -27,8 +27,8 @@ protected:
 
 public:
 
-    KdTreeRangeIndexQuery(const KdTree<DataPoint, Compatibility>* kdtree, Scalar radius, int index) :
-        KdTreeQuery<DataPoint, Compatibility>(kdtree), RangeIndexQuery<Scalar>(radius, index)
+    KdTreeRangeIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, Scalar radius, int index) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), RangeIndexQuery<Scalar>(radius, index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
@@ -13,13 +13,13 @@
 namespace Ponca {
 
 
-template <class DataPoint>
-class KdTreeRangeIndexQuery : public KdTreeQuery<DataPoint>, public RangeIndexQuery<typename DataPoint::Scalar>
+template <class DataPoint, class Compatibility>
+class KdTreeRangeIndexQuery : public KdTreeQuery<DataPoint, Compatibility>, public RangeIndexQuery<typename DataPoint::Scalar>
 {
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = RangeIndexQuery<typename DataPoint::Scalar>;
-    using QueryAccelType  = KdTreeQuery<DataPoint>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
     using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangeIndexQuery>;
 
 protected:
@@ -27,8 +27,8 @@ protected:
 
 public:
 
-    KdTreeRangeIndexQuery(const KdTree<DataPoint>* kdtree, Scalar radius, int index) :
-        KdTreeQuery<DataPoint>(kdtree), RangeIndexQuery<Scalar>(radius, index)
+    KdTreeRangeIndexQuery(const KdTree<DataPoint, Compatibility>* kdtree, Scalar radius, int index) :
+        KdTreeQuery<DataPoint, Compatibility>(kdtree), RangeIndexQuery<Scalar>(radius, index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
@@ -12,23 +12,25 @@
 
 namespace Ponca {
 
-
 template <class DataPoint, class Adapter>
-class KdTreeRangeIndexQuery : public KdTreeQuery<DataPoint, Adapter>, public RangeIndexQuery<typename DataPoint::Scalar>
+class KdTreeRangeIndexQuery : public KdTreeQuery<DataPoint, Adapter>,
+    public RangeIndexQuery<typename Adapter::IndexType, typename DataPoint::Scalar>
 {
+public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = RangeIndexQuery<typename DataPoint::Scalar>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
-    using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangeIndexQuery>;
+    using Iterator        = KdTreeRangeIterator<IndexType, DataPoint, KdTreeRangeIndexQuery>;
 
 protected:
     friend Iterator;
 
 public:
 
-    KdTreeRangeIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, Scalar radius, int index) :
-        KdTreeQuery<DataPoint, Adapter>(kdtree), RangeIndexQuery<Scalar>(radius, index)
+    KdTreeRangeIndexQuery(const KdTree<DataPoint, Adapter>* kdtree, Scalar radius, IndexType index) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), RangeIndexQuery<IndexType, Scalar>(radius, index)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.h
@@ -20,7 +20,7 @@ public:
     using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
-    using QueryType       = RangeIndexQuery<typename DataPoint::Scalar>;
+    using QueryType       = RangeIndexQuery<IndexType, typename DataPoint::Scalar>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
     using Iterator        = KdTreeRangeIterator<IndexType, DataPoint, KdTreeRangeIndexQuery>;
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template<class DataPoint, class Compatibility>
-typename KdTreeRangeIndexQuery<DataPoint, Compatibility>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::begin()
+template<class DataPoint, class Adapter>
+typename KdTreeRangeIndexQuery<DataPoint, Adapter>::Iterator KdTreeRangeIndexQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -14,14 +14,14 @@ typename KdTreeRangeIndexQuery<DataPoint, Compatibility>::Iterator KdTreeRangeIn
     return it;
 }
 
-template<class DataPoint, class Compatibility>
-typename KdTreeRangeIndexQuery<DataPoint, Compatibility>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::end()
+template<class DataPoint, class Adapter>
+typename KdTreeRangeIndexQuery<DataPoint, Adapter>::Iterator KdTreeRangeIndexQuery<DataPoint, Adapter>::end()
 {
     return Iterator(this, QueryAccelType::m_kdtree->point_count());
 }
 
-template<class DataPoint, class Compatibility>
-void KdTreeRangeIndexQuery<DataPoint, Compatibility>::advance(Iterator& it)
+template<class DataPoint, class Adapter>
+void KdTreeRangeIndexQuery<DataPoint, Adapter>::advance(Iterator& it)
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
@@ -28,9 +28,9 @@ void KdTreeRangeIndexQuery<DataPoint, Adapter>::advance(Iterator& it)
     const auto& indices = QueryAccelType::m_kdtree->index_data();
     const auto& point   = points[QueryType::input()].pos();
 
-    for(int i=it.m_start; i<it.m_end; ++i)
+    for(IndexType i=it.m_start; i<it.m_end; ++i)
     {
-        int idx = indices[i];
+        IndexType idx = indices[i];
         if(idx == QueryType::input()) continue;
 
         Scalar d = (point - points[idx].pos()).squaredNorm();
@@ -49,17 +49,17 @@ void KdTreeRangeIndexQuery<DataPoint, Adapter>::advance(Iterator& it)
 
         if(qnode.squared_distance < QueryType::m_squared_radius)
         {
-            if(node.leaf)
+            if(node.is_leaf())
             {
                 QueryAccelType::m_stack.pop();
-                it.m_start = node.start;
-                it.m_end   = node.start + node.size;
-                for(int i=it.m_start; i<it.m_end; ++i)
+                it.m_start = node.leaf.start;
+                it.m_end   = node.leaf.start + node.leaf.size;
+                for(IndexType i=it.m_start; i<it.m_end; ++i)
                 {
-                    int idx = indices[i];
+                    IndexType idx = indices[i];
                     if(idx == QueryType::input()) continue;
 
-                    Scalar d = (point - points[idx].pos()).squaredNorm();
+                    Scalar d = Adapter::squared_norm(point - points[idx].pos());
                     if(d < QueryType::m_squared_radius)
                     {
                         it.m_index = idx;
@@ -71,17 +71,17 @@ void KdTreeRangeIndexQuery<DataPoint, Adapter>::advance(Iterator& it)
             else
             {
                 // replace the stack top by the farthest and push the closest
-                Scalar newOff = point[node.dim] - node.splitValue;
+                Scalar newOff = point[node.inner.dim] - node.inner.split_value;
                 QueryAccelType::m_stack.push();
                 if(newOff < 0)
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId;
-                    qnode.index         = node.firstChildId+1;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id;
+                    qnode.index         = node.inner.first_child_id+1;
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId+1;
-                    qnode.index         = node.firstChildId;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id+1;
+                    qnode.index         = node.inner.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;
                 qnode.squared_distance         = newOff*newOff;
@@ -92,5 +92,5 @@ void KdTreeRangeIndexQuery<DataPoint, Adapter>::advance(Iterator& it)
             QueryAccelType::m_stack.pop();
         }
     }
-    it.m_index = static_cast<int>(points.size());
+    it.m_index = static_cast<IndexType>(points.size());
 }

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template<class DataPoint>
-typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPoint>::begin()
+template<class DataPoint, class Compatibility>
+typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -14,14 +14,14 @@ typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPo
     return it;
 }
 
-template<class DataPoint>
-typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPoint>::end()
+template<class DataPoint, class Compatibility>
+typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::end()
 {
     return Iterator(this, QueryAccelType::m_kdtree->point_count());
 }
 
-template<class DataPoint>
-void KdTreeRangeIndexQuery<DataPoint>::advance(Iterator& it)
+template<class DataPoint, class Compatibility>
+void KdTreeRangeIndexQuery<DataPoint, Compatibility>::advance(Iterator& it)
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeIndexQuery.hpp
@@ -5,7 +5,7 @@
 */
 
 template<class DataPoint, class Compatibility>
-typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::begin()
+typename KdTreeRangeIndexQuery<DataPoint, Compatibility>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -15,7 +15,7 @@ typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPo
 }
 
 template<class DataPoint, class Compatibility>
-typename KdTreeRangeIndexQuery<DataPoint>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::end()
+typename KdTreeRangeIndexQuery<DataPoint, Compatibility>::Iterator KdTreeRangeIndexQuery<DataPoint, Compatibility>::end()
 {
     return Iterator(this, QueryAccelType::m_kdtree->point_count());
 }

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
@@ -12,14 +12,14 @@
 
 namespace Ponca {
 
-template <class DataPoint>
-class KdTreeRangePointQuery : public KdTreeQuery<DataPoint>, public RangePointQuery<DataPoint>
+template <class DataPoint, class Compatibility>
+class KdTreeRangePointQuery : public KdTreeQuery<DataPoint, Compatibility>, public RangePointQuery<DataPoint>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = RangePointQuery<DataPoint>;
-    using QueryAccelType  = KdTreeQuery<DataPoint>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
     using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangePointQuery>;
 
 
@@ -28,8 +28,8 @@ protected:
 
 public:
 
-    inline KdTreeRangePointQuery(const KdTree<DataPoint>* kdtree, Scalar radius, const VectorType& point) :
-        KdTreeQuery<DataPoint>(kdtree), RangePointQuery<DataPoint>(radius, point)
+    inline KdTreeRangePointQuery(const KdTree<DataPoint, Compatibility>* kdtree, Scalar radius, const VectorType& point) :
+        KdTreeQuery<DataPoint, Compatibility>(kdtree), RangePointQuery<DataPoint>(radius, point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
@@ -12,14 +12,14 @@
 
 namespace Ponca {
 
-template <class DataPoint, class Compatibility>
-class KdTreeRangePointQuery : public KdTreeQuery<DataPoint, Compatibility>, public RangePointQuery<DataPoint>
+template <class DataPoint, class Adapter>
+class KdTreeRangePointQuery : public KdTreeQuery<DataPoint, Adapter>, public RangePointQuery<DataPoint>
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = RangePointQuery<DataPoint>;
-    using QueryAccelType  = KdTreeQuery<DataPoint, Compatibility>;
+    using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
     using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangePointQuery>;
 
 
@@ -28,8 +28,8 @@ protected:
 
 public:
 
-    inline KdTreeRangePointQuery(const KdTree<DataPoint, Compatibility>* kdtree, Scalar radius, const VectorType& point) :
-        KdTreeQuery<DataPoint, Compatibility>(kdtree), RangePointQuery<DataPoint>(radius, point)
+    inline KdTreeRangePointQuery(const KdTree<DataPoint, Adapter>* kdtree, Scalar radius, const VectorType& point) :
+        KdTreeQuery<DataPoint, Adapter>(kdtree), RangePointQuery<DataPoint>(radius, point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
@@ -20,9 +20,9 @@ public:
     using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
-    using QueryType       = RangePointQuery<DataPoint>;
+    using QueryType       = RangePointQuery<IndexType, DataPoint>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
-    using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangePointQuery>;
+    using Iterator        = KdTreeRangeIterator<IndexType, DataPoint, KdTreeRangePointQuery>;
 
 protected:
     friend Iterator;

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.h
@@ -13,15 +13,16 @@
 namespace Ponca {
 
 template <class DataPoint, class Adapter>
-class KdTreeRangePointQuery : public KdTreeQuery<DataPoint, Adapter>, public RangePointQuery<DataPoint>
+class KdTreeRangePointQuery : public KdTreeQuery<DataPoint, Adapter>,
+    public RangePointQuery<typename Adapter::IndexType, DataPoint>
 {
 public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
     using QueryType       = RangePointQuery<DataPoint>;
     using QueryAccelType  = KdTreeQuery<DataPoint, Adapter>;
     using Iterator        = KdTreeRangeIterator<DataPoint, KdTreeRangePointQuery>;
-
 
 protected:
     friend Iterator;
@@ -29,7 +30,7 @@ protected:
 public:
 
     inline KdTreeRangePointQuery(const KdTree<DataPoint, Adapter>* kdtree, Scalar radius, const VectorType& point) :
-        KdTreeQuery<DataPoint, Adapter>(kdtree), RangePointQuery<DataPoint>(radius, point)
+        KdTreeQuery<DataPoint, Adapter>(kdtree), RangePointQuery<IndexType, DataPoint>(radius, point)
     {
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint, class Compatibility>
-typename KdTreeRangePointQuery<DataPoint, Compatibility>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::begin()
+template <class DataPoint, class Adapter>
+typename KdTreeRangePointQuery<DataPoint, Adapter>::Iterator KdTreeRangePointQuery<DataPoint, Adapter>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -14,14 +14,14 @@ typename KdTreeRangePointQuery<DataPoint, Compatibility>::Iterator KdTreeRangePo
     return it;
 }
 
-template <class DataPoint, class Compatibility>
-typename KdTreeRangePointQuery<DataPoint, Compatibility>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::end()
+template <class DataPoint, class Adapter>
+typename KdTreeRangePointQuery<DataPoint, Adapter>::Iterator KdTreeRangePointQuery<DataPoint, Adapter>::end()
 {
     return Iterator(this, QueryAccelType::m_kdtree->point_count());
 }
 
-template <class DataPoint, class Compatibility>
-void KdTreeRangePointQuery<DataPoint, Compatibility>::advance(Iterator& it)
+template <class DataPoint, class Adapter>
+void KdTreeRangePointQuery<DataPoint, Adapter>::advance(Iterator& it)
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
@@ -5,7 +5,7 @@
 */
 
 template <class DataPoint, class Compatibility>
-typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::begin()
+typename KdTreeRangePointQuery<DataPoint, Compatibility>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -15,7 +15,7 @@ typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPo
 }
 
 template <class DataPoint, class Compatibility>
-typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::end()
+typename KdTreeRangePointQuery<DataPoint, Compatibility>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::end()
 {
     return Iterator(this, QueryAccelType::m_kdtree->point_count());
 }

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
@@ -30,9 +30,9 @@ void KdTreeRangePointQuery<DataPoint, Adapter>::advance(Iterator& it)
 
     for(int i=it.m_start; i<it.m_end; ++i)
     {
-        int idx = indices[i];
+        IndexType idx = indices[i];
 
-        Scalar d = (point - points[idx].pos()).squaredNorm();
+        Scalar d = Adapter::squared_norm(point - points[idx].pos());
         if(d < QueryType::m_squared_radius)
         {
             it.m_index = idx;
@@ -48,14 +48,14 @@ void KdTreeRangePointQuery<DataPoint, Adapter>::advance(Iterator& it)
 
         if(qnode.squared_distance < QueryType::m_squared_radius)
         {
-            if(node.leaf)
+            if(node.is_leaf())
             {
                 QueryAccelType::m_stack.pop();
-                it.m_start = node.start;
-                it.m_end   = node.start + node.size;
-                for(int i=it.m_start; i<it.m_end; ++i)
+                it.m_start = node.leaf.start;
+                it.m_end   = node.leaf.start + node.leaf.size;
+                for(IndexType i=it.m_start; i<it.m_end; ++i)
                 {
-                    int idx = indices[i];
+                    IndexType idx = indices[i];
 
                     Scalar d = (point - points[idx].pos()).squaredNorm();
                     if(d < QueryType::m_squared_radius)
@@ -69,17 +69,17 @@ void KdTreeRangePointQuery<DataPoint, Adapter>::advance(Iterator& it)
             else
             {
                 // replace the stack top by the farthest and push the closest
-                Scalar newOff = point[node.dim] - node.splitValue;
+                Scalar newOff = point[node.inner.dim] - node.inner.split_value;
                 QueryAccelType::m_stack.push();
                 if(newOff < 0)
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId;
-                    qnode.index         = node.firstChildId+1;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id;
+                    qnode.index         = node.inner.first_child_id+1;
                 }
                 else
                 {
-                    QueryAccelType::m_stack.top().index = node.firstChildId+1;
-                    qnode.index         = node.firstChildId;
+                    QueryAccelType::m_stack.top().index = node.inner.first_child_id+1;
+                    qnode.index         = node.inner.first_child_id;
                 }
                 QueryAccelType::m_stack.top().squared_distance = qnode.squared_distance;
                 qnode.squared_distance         = newOff*newOff;
@@ -90,5 +90,5 @@ void KdTreeRangePointQuery<DataPoint, Adapter>::advance(Iterator& it)
             QueryAccelType::m_stack.pop();
         }
     }
-    it.m_index = static_cast<int>(points.size());
+    it.m_index = static_cast<IndexType>(points.size());
 }

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangePointQuery.hpp
@@ -4,8 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template <class DataPoint>
-typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPoint>::begin()
+template <class DataPoint, class Compatibility>
+typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::begin()
 {
     QueryAccelType::reset();
     QueryType::reset();
@@ -14,14 +14,14 @@ typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPo
     return it;
 }
 
-template <class DataPoint>
-typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPoint>::end()
+template <class DataPoint, class Compatibility>
+typename KdTreeRangePointQuery<DataPoint>::Iterator KdTreeRangePointQuery<DataPoint, Compatibility>::end()
 {
     return Iterator(this, QueryAccelType::m_kdtree->point_count());
 }
 
-template <class DataPoint>
-void KdTreeRangePointQuery<DataPoint>::advance(Iterator& it)
+template <class DataPoint, class Compatibility>
+void KdTreeRangePointQuery<DataPoint, Compatibility>::advance(Iterator& it)
 {
     const auto& nodes   = QueryAccelType::m_kdtree->node_data();
     const auto& points  = QueryAccelType::m_kdtree->point_data();

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -28,7 +28,6 @@
 #define PCA_KDTREE_MAX_DEPTH 32
 
 namespace Ponca {
-///
 template <typename DataPoint>
 struct DefaultKdTreeAdapter
 {
@@ -46,8 +45,9 @@ public:
     typedef std::vector<DataPoint> PointContainer;
     typedef std::vector<int>       IndexContainer;
 
-    typedef std::vector<DefaultKdTreeNode<DataPoint, AabbType>> NodeContainer;
+    typedef std::vector<KdTreeNode<DataPoint>> NodeContainer;
 
+public:
     static DimType max_dim(const VectorType& vec)
     {
         DimType dim;
@@ -103,39 +103,38 @@ public:
     };
 
     template<typename PointUserContainer>
-    inline KdTree(PointUserContainer&& points): // PointUserContainer => Given by user, transformed to PointContainer
+    inline KdTree(PointUserContainer points): // PointUserContainer => Given by user, transformed to PointContainer
         m_points(PointContainer()),
         m_nodes(NodeContainer()),
         m_indices(IndexContainer()),
         m_min_cell_size(64),
         m_leaf_count(0)
     {
-        this->build(std::forward<PointUserContainer>(points));
+        this->build(std::move(points));
     };
 
     template<typename PointUserContainer, typename IndexUserContainer>
-    inline KdTree(PointUserContainer&& points, IndexUserContainer sampling): // PointUserContainer => Given by user, transformed to PointContainer
-                                                                             // IndexUserContainer => Given by user, transformed to IndexContainer
+    inline KdTree(PointUserContainer points, IndexUserContainer sampling): // PointUserContainer => Given by user, transformed to PointContainer
+                                                                           // IndexUserContainer => Given by user, transformed to IndexContainer
         m_points(),
         m_nodes(),
         m_indices(),
         m_min_cell_size(64),
         m_leaf_count(0)
     {
-        buildWithSampling(std::forward<PointUserContainer>(points), std::move(sampling));
+        buildWithSampling(std::move(points), std::move(sampling));
     };
 
     inline void clear();
 
     struct DefaultConverter{
         template <typename Input>
-        inline void operator()( Input&& i, PointContainer & o ) {
-            typedef typename std::remove_cv<typename std::remove_reference<Input>::type>::type InputContainer;
-            if constexpr ( std::is_same<InputContainer, PointContainer>::value )
-                o = i;
+        inline void operator()( Input i, PointContainer & o ) {
+            if constexpr ( std::is_same<Input, PointContainer>::value )
+                o = std::move(i);
             else
                 std::transform(i.cbegin(), i.cend(), std::back_inserter(o),
-                               [](const typename InputContainer::value_type &p) -> DataPoint { return DataPoint(p); });
+                               [](const typename Input::value_type &p) -> DataPoint { return DataPoint(p); });
         }
     };
 
@@ -143,9 +142,9 @@ public:
     /// \tparam PointUserContainer Input point container, transformed to PointContainer
     /// \param points Input points
     template<typename PointUserContainer>
-    inline void build(PointUserContainer&& points)
+    inline void build(PointUserContainer points)
     {
-        build(std::forward<PointUserContainer>(points), DefaultConverter());
+        build(std::move(points), DefaultConverter());
     }
 
     ///
@@ -154,17 +153,17 @@ public:
     /// \param points Input points
     /// \param c Cast/Convert input point type to DataType
     template<typename PointUserContainer, typename Converter>
-    inline void build(PointUserContainer&& points, Converter c);
+    inline void build(PointUserContainer points, Converter c);
 
     /// \tparam PointUserContainer Input point, transformed to PointContainer
     /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
     /// \param points Input points
     /// \param sampling Indices of points used in the tree
     template<typename PointUserContainer, typename IndexUserContainer>
-    inline void buildWithSampling(PointUserContainer&& points,
+    inline void buildWithSampling(PointUserContainer points,
                                   IndexUserContainer sampling)
     {
-        buildWithSampling(std::forward<PointUserContainer>(points), std::move(sampling), DefaultConverter());
+        buildWithSampling(std::move(points), std::move(sampling), DefaultConverter());
     }
 
     /// \tparam PointUserContainer Input point, transformed to PointContainer
@@ -174,7 +173,7 @@ public:
     /// \param sampling Indices of points used in the tree
     /// \param c Cast/Convert input point type to DataType
     template<typename PointUserContainer, typename IndexUserContainer, typename Converter>
-    inline void buildWithSampling(PointUserContainer&& points,
+    inline void buildWithSampling(PointUserContainer points,
                                   IndexUserContainer sampling,
                                   Converter c);
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -37,7 +37,7 @@ private:
     typedef typename DataPoint::VectorType VectorType;
 
 public:
-    typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> Aabb;
+    typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
 
     typedef int DimType;
     typedef int DepthType;
@@ -46,7 +46,7 @@ public:
     typedef std::vector<DataPoint> PointContainer;
     typedef std::vector<int>       IndexContainer;
 
-    typedef std::vector<DefaultKdTreeNode<DataPoint, Aabb>> NodeContainer;
+    typedef std::vector<DefaultKdTreeNode<DataPoint, AabbType>> NodeContainer;
 
     static void max_dim(const VectorType& vec, Scalar& scalar)
     {
@@ -66,6 +66,8 @@ public:
     typedef          _DataPoint            DataPoint;
     typedef typename DataPoint::Scalar     Scalar; // Scalar given by user
     typedef typename DataPoint::VectorType VectorType; // VectorType given by user
+
+    typedef typename Adapter::AabbType AabbType;
 
     typedef typename Adapter::DimType   DimType;
     typedef typename Adapter::DepthType DepthType;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -247,6 +247,7 @@ public:
 
     inline void set_min_cell_size(LeafSizeType min_cell_size)
     {
+        PONCA_DEBUG_ASSERT(min_cell_size > 0);
         m_min_cell_size = min_cell_size;
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -8,9 +8,6 @@
 
 #include "./kdTreeNode.h"
 
-#include <Eigen/Eigen>
-#include <Eigen/Geometry> // aabb
-
 #include <memory>
 #include <numeric>
 #include <type_traits>

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -12,8 +12,9 @@
 #include <Eigen/Geometry> // aabb
 
 #include <memory>
-#include <vector>
 #include <numeric>
+#include <type_traits>
+#include <vector>
 
 #include "../../Common/Assert.h"
 
@@ -28,22 +29,53 @@
 
 namespace Ponca {
 ///
+template <typename DataPoint>
+struct DefaultKdTreeCompatibility
+{
+    typedef typename DataPoint::Scalar     Scalar;
+    typedef typename DataPoint::VectorType VectorType;
+
+    typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
+
+    typedef int DimType;
+    typedef int DepthType;
+
+    // Containers
+    typedef std::vector<DataPoint>                 PointContainer;
+    typedef std::vector<int>                       IndexContainer;
+    typedef std::vector<DefaultKdTreeNode<Scalar>> NodeContainer;
+};
+
+///
 /// \tparam DataPoint
 ///
 /// \todo Better handle sampling: do not store non-selected points (requires to store original indices
-template<class _DataPoint>
+template<class _DataPoint,
+         class Compatibility = DefaultKdTreeCompatibility<DataPoint>>
 class KdTree
 {
 public:
-    typedef          _DataPoint            DataPoint;
-    typedef typename DataPoint::Scalar     Scalar;  // Scalar given by user
-    typedef typename DataPoint::VectorType VectorType;  // VectorType given by user
+    typedef          _DataPoint                DataPoint;
+    typedef typename Compatibility::Scalar     Scalar; // Scalar given by user
+    typedef typename Compatibility::VectorType VectorType; // VectorType given by user
 
-    typedef typename Eigen::AlignedBox<Scalar, DataPoint::Dim> Aabb; // Intersections
+    typedef typename Compatibility::AabbType Aabb; // Intersections
 
-    typedef typename std::vector<DataPoint> PointContainer; // Container for VectorType used inside the KdTree
-    typedef typename std::vector<int> IndexContainer; // Container for indices used inside the KdTree
-    typedef typename std::vector<KdTreeNode<Scalar>> NodeContainer;  // Container for nodes used inside the KdTree
+    typedef typename Compatibility::DepthType DepthType;
+
+    typedef typename Compatibility::PointContainer PointContainer; // Container for VectorType used inside the KdTree
+    typedef typename Compatibility::IndexContainer IndexContainer; // Container for indices used inside the KdTree
+    typedef typename Compatibility::NodeContainer  NodeContainer; // Container for nodes used inside the KdTree
+
+    typedef typename IndexContainer::value_type IndexType;
+    typedef typename NodeContainer::value_type  NodeType;
+    typedef typename PointContainer::size_type  PointCountType;
+    typedef typename IndexContainer::size_type  IndexCountType;
+    typedef typename NodeContainer::size_type   NodeCountType;
+
+    typedef typename NodeType::LeafSizeType LeafSizeType;
+
+    static_assert(std::is_same_v<typename PointContainer::value_type, DataPoint>, "Point container must contain DataPoints");
 
     inline KdTree():
         m_points(PointContainer()),
@@ -133,10 +165,25 @@ public:
 
     // Accessors ---------------------------------------------------------------
 public:
-    inline int node_count() const;
-    inline int index_count() const;
-    inline int point_count() const;
-    inline int leaf_count() const;
+    inline NodeCountType node_count() const
+    {
+        return m_nodes.size();
+    }
+
+    inline IndexCountType index_count() const
+    {
+        return m_indices.size();
+    }
+
+    inline PointCountType point_count() const
+    {
+        return m_points.size();
+    }
+
+    inline LeafCountType leaf_count() const
+    {
+        return m_leaf_count;
+    }
 
     inline PointContainer& point_data()
     {
@@ -155,7 +202,7 @@ public:
 
     inline NodeContainer& node_data()
     {
-        return *m_nodes.get();
+        return m_nodes;
     }
 
     inline const IndexContainer& index_data() const
@@ -170,13 +217,20 @@ public:
 
     // Parameters --------------------------------------------------------------
 public:
-    inline int min_cell_size() const;
-    inline void set_min_cell_size(int min_cell_size);
+    inline LeafSizeType min_cell_size() const
+    {
+        return m_min_cell_size;
+    }
+
+    inline void set_min_cell_size(int min_cell_size)
+    {
+        m_min_cell_size = min_cell_size;
+    }
 
     // Internal ----------------------------------------------------------------
 public:
-    inline void build_rec(int node_id, int start, int end, int level);
-    inline int partition(int start, int end, int dim, Scalar value);
+    inline void build_rec(NodeCountType node_id, IndexCountType start, IndexCountType end, DepthType level);
+    inline IndexCountType partition(IndexCountType start, IndexCountType end, DimType dim, Scalar value);
 
 
     // Query -------------------------------------------------------------------
@@ -218,8 +272,8 @@ protected:
     NodeContainer m_nodes;
     IndexContainer m_indices;
 
-    int m_min_cell_size;
-    int m_leaf_count; ///< Number of leafs in the Kdtree (computed during construction)
+    LeafSizeType m_min_cell_size;
+    LeafCountType m_leaf_count; ///< Number of leaves in the Kdtree (computed during construction)
 };
 
 #include "./kdTree.hpp"

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -271,7 +271,7 @@ protected:
     IndexContainer m_indices;
 
     LeafSizeType m_min_cell_size;
-    LeafCountType m_leaf_count; ///< Number of leaves in the Kdtree (computed during construction)
+    NodeCountType m_leaf_count; ///< Number of leaves in the Kdtree (computed during construction)
 };
 
 #include "./kdTree.hpp"

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -38,16 +38,22 @@ private:
 public:
     typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
 
+    typedef int IndexType;
     typedef int DimType;
     typedef int DepthType;
 
     // Containers
     typedef std::vector<DataPoint> PointContainer;
-    typedef std::vector<int>       IndexContainer;
+    typedef std::vector<IndexType> IndexContainer;
 
     typedef std::vector<DefaultKdTreeNode<DataPoint>> NodeContainer;
 
 public:
+    static Scalar squared_norm(const VectorType& vec)
+    {
+        return vec.squaredNorm();
+    }
+
     static DimType max_dim(const VectorType& vec)
     {
         DimType dim;
@@ -76,6 +82,7 @@ public:
 
     typedef typename Adapter::AabbType AabbType;
 
+    typedef typename Adapter::IndexType IndexType;
     typedef typename Adapter::DimType   DimType;
     typedef typename Adapter::DepthType DepthType;
 
@@ -83,16 +90,18 @@ public:
     typedef typename Adapter::IndexContainer IndexContainer; // Container for indices used inside the KdTree
     typedef typename Adapter::NodeContainer  NodeContainer; // Container for nodes used inside the KdTree
 
-    typedef typename IndexContainer::value_type IndexType;
-    typedef typename NodeContainer::value_type  NodeType;
-    typedef typename PointContainer::size_type  PointCountType;
-    typedef typename IndexContainer::size_type  IndexCountType;
-    typedef typename NodeContainer::size_type   NodeCountType;
+    typedef typename NodeContainer::value_type NodeType;
+    typedef typename PointContainer::size_type PointCountType;
+    typedef typename IndexContainer::size_type IndexCountType;
+    typedef typename NodeContainer::size_type  NodeCountType;
 
     typedef typename NodeType::LeafSizeType LeafSizeType;
 
     static_assert(std::is_same<typename PointContainer::value_type, DataPoint>::value,
         "PointContainer must contain DataPoints");
+    
+    static_assert(std::is_signed<IndexType>::value, "Index type must be signed");
+    static_assert(std::is_same<typename IndexContainer::value_type, IndexType>::value, "Index type mismatch");
 
     inline KdTree():
         m_points(PointContainer()),
@@ -260,12 +269,12 @@ public:
 
     // Query -------------------------------------------------------------------
 public :
-    KdTreeKNearestPointQuery<DataPoint, Adapter> k_nearest_neighbors(const VectorType& point, int k) const
+    KdTreeKNearestPointQuery<DataPoint, Adapter> k_nearest_neighbors(const VectorType& point, QueryIndexType k) const
     {
         return KdTreeKNearestPointQuery<DataPoint, Adapter>(this, k, point);
     }
 
-    KdTreeKNearestIndexQuery<DataPoint, Adapter> k_nearest_neighbors(int index, int k) const
+    KdTreeKNearestIndexQuery<DataPoint, Adapter> k_nearest_neighbors(QueryIndexType index, QueryIndexType k) const
     {
         return KdTreeKNearestIndexQuery<DataPoint, Adapter>(this, k, index);
     }
@@ -275,7 +284,7 @@ public :
         return KdTreeNearestPointQuery<DataPoint, Adapter>(this, point);
     }
 
-    KdTreeNearestIndexQuery<DataPoint, Adapter> nearest_neighbor(int index) const
+    KdTreeNearestIndexQuery<DataPoint, Adapter> nearest_neighbor(QueryIndexType index) const
     {
         return KdTreeNearestIndexQuery<DataPoint, Adapter>(this, index);
     }
@@ -285,7 +294,7 @@ public :
         return KdTreeRangePointQuery<DataPoint, Adapter>(this, r, point);
     }
 
-    KdTreeRangeIndexQuery<DataPoint, Adapter> range_neighbors(int index, Scalar r) const
+    KdTreeRangeIndexQuery<DataPoint, Adapter> range_neighbors(QueryIndexType index, Scalar r) const
     {
         return KdTreeRangeIndexQuery<DataPoint, Adapter>(this, r, index);
     }

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -91,7 +91,8 @@ public:
 
     typedef typename NodeType::LeafSizeType LeafSizeType;
 
-    static_assert(std::is_same<typename PointContainer::value_type, DataPoint>::value, "Point container must contain DataPoints");
+    static_assert(std::is_same<typename PointContainer::value_type, DataPoint>::value,
+        "PointContainer must contain DataPoints");
 
     inline KdTree():
         m_points(PointContainer()),
@@ -127,10 +128,12 @@ public:
 
     inline void clear();
 
-    struct DefaultConverter{
+    struct DefaultConverter
+    {
         template <typename Input>
-        inline void operator()( Input i, PointContainer & o ) {
-            if constexpr ( std::is_same<Input, PointContainer>::value )
+        inline void operator()(Input i, PointContainer& o)
+        {
+            if constexpr (std::is_same<Input, PointContainer>::value)
                 o = std::move(i);
             else
                 std::transform(i.cbegin(), i.cend(), std::back_inserter(o),

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -233,34 +233,34 @@ public:
 
     // Query -------------------------------------------------------------------
 public :
-    KdTreeKNearestPointQuery<DataPoint> k_nearest_neighbors(const VectorType& point, int k) const
+    KdTreeKNearestPointQuery<DataPoint, Compatibility> k_nearest_neighbors(const VectorType& point, int k) const
     {
-        return KdTreeKNearestPointQuery<DataPoint>(this, k, point);
+        return KdTreeKNearestPointQuery<DataPoint, Compatibility>(this, k, point);
     }
 
-    KdTreeKNearestIndexQuery<DataPoint> k_nearest_neighbors(int index, int k) const
+    KdTreeKNearestIndexQuery<DataPoint, Compatibility> k_nearest_neighbors(int index, int k) const
     {
-        return KdTreeKNearestIndexQuery<DataPoint>(this, k, index);
+        return KdTreeKNearestIndexQuery<DataPoint, Compatibility>(this, k, index);
     }
 
-    KdTreeNearestPointQuery<DataPoint> nearest_neighbor(const VectorType& point) const
+    KdTreeNearestPointQuery<DataPoint, Compatibility> nearest_neighbor(const VectorType& point) const
     {
-        return KdTreeNearestPointQuery<DataPoint>(this, point);
+        return KdTreeNearestPointQuery<DataPoint, Compatibility>(this, point);
     }
 
-    KdTreeNearestIndexQuery<DataPoint> nearest_neighbor(int index) const
+    KdTreeNearestIndexQuery<DataPoint, Compatibility> nearest_neighbor(int index) const
     {
-        return KdTreeNearestIndexQuery<DataPoint>(this, index);
+        return KdTreeNearestIndexQuery<DataPoint, Compatibility>(this, index);
     }
 
-    KdTreeRangePointQuery<DataPoint> range_neighbors(const VectorType& point, Scalar r) const
+    KdTreeRangePointQuery<DataPoint, Compatibility> range_neighbors(const VectorType& point, Scalar r) const
     {
-        return KdTreeRangePointQuery<DataPoint>(this, r, point);
+        return KdTreeRangePointQuery<DataPoint, Compatibility>(this, r, point);
     }
 
-    KdTreeRangeIndexQuery<DataPoint> range_neighbors(int index, Scalar r) const
+    KdTreeRangeIndexQuery<DataPoint, Compatibility> range_neighbors(int index, Scalar r) const
     {
-        return KdTreeRangeIndexQuery<DataPoint>(this, r, index);
+        return KdTreeRangeIndexQuery<DataPoint, Compatibility>(this, r, index);
     }
     
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -89,7 +89,6 @@ public:
         m_nodes(NodeContainer()),
         m_indices(IndexContainer()),
         m_min_cell_size(64),
-        m_max_depth(PCA_KDTREE_MAX_DEPTH),
         m_leaf_count(0)
     {
     };
@@ -100,7 +99,6 @@ public:
         m_nodes(NodeContainer()),
         m_indices(IndexContainer()),
         m_min_cell_size(64),
-        m_max_depth(PCA_KDTREE_MAX_DEPTH),
         m_leaf_count(0)
     {
         this->build(std::forward<PointUserContainer>(points));
@@ -113,7 +111,6 @@ public:
         m_nodes(),
         m_indices(),
         m_min_cell_size(64),
-        m_max_depth(PCA_KDTREE_MAX_DEPTH),
         m_leaf_count(0)
     {
         buildWithSampling(std::forward<PointUserContainer>(points), std::move(sampling));
@@ -239,20 +236,9 @@ public:
         return m_min_cell_size;
     }
 
-    inline void set_min_cell_size(int min_cell_size)
+    inline void set_min_cell_size(LeafSizeType min_cell_size)
     {
         m_min_cell_size = min_cell_size;
-    }
-
-    inline DepthType max_depth() const
-    {
-        return m_max_depth;
-    }
-    
-    inline void set_max_depth(DepthType max_depth)
-    {
-        PONCA_ASSERT(max_depth <= PCA_KDTREE_MAX_DEPTH);
-        m_max_depth = max_depth;
     }
 
     // Internal ----------------------------------------------------------------
@@ -300,7 +286,6 @@ protected:
     IndexContainer m_indices;
 
     LeafSizeType m_min_cell_size;
-    DepthType m_max_depth;
     NodeCountType m_leaf_count; ///< Number of leaves in the Kdtree (computed during construction)
 };
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -57,7 +57,7 @@ public:
 
     static Scalar vec_component(const VectorType& vec, DimType dim)
     {
-        vec.maxCoeff(scalar);
+        return vec(dim);
     }
 };
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -50,7 +50,7 @@ struct DefaultKdTreeCompatibility
 ///
 /// \todo Better handle sampling: do not store non-selected points (requires to store original indices
 template<class _DataPoint,
-         class Compatibility = DefaultKdTreeCompatibility<DataPoint>>
+         class Compatibility = DefaultKdTreeCompatibility<_DataPoint>>
 class KdTree
 {
 public:
@@ -178,7 +178,7 @@ public:
         return m_points.size();
     }
 
-    inline LeafCountType leaf_count() const
+    inline NodeCountType leaf_count() const
     {
         return m_leaf_count;
     }

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -269,12 +269,12 @@ public:
 
     // Query -------------------------------------------------------------------
 public :
-    KdTreeKNearestPointQuery<DataPoint, Adapter> k_nearest_neighbors(const VectorType& point, QueryIndexType k) const
+    KdTreeKNearestPointQuery<DataPoint, Adapter> k_nearest_neighbors(const VectorType& point, IndexType k) const
     {
         return KdTreeKNearestPointQuery<DataPoint, Adapter>(this, k, point);
     }
 
-    KdTreeKNearestIndexQuery<DataPoint, Adapter> k_nearest_neighbors(QueryIndexType index, QueryIndexType k) const
+    KdTreeKNearestIndexQuery<DataPoint, Adapter> k_nearest_neighbors(IndexType index, IndexType k) const
     {
         return KdTreeKNearestIndexQuery<DataPoint, Adapter>(this, k, index);
     }
@@ -284,7 +284,7 @@ public :
         return KdTreeNearestPointQuery<DataPoint, Adapter>(this, point);
     }
 
-    KdTreeNearestIndexQuery<DataPoint, Adapter> nearest_neighbor(QueryIndexType index) const
+    KdTreeNearestIndexQuery<DataPoint, Adapter> nearest_neighbor(IndexType index) const
     {
         return KdTreeNearestIndexQuery<DataPoint, Adapter>(this, index);
     }
@@ -294,7 +294,7 @@ public :
         return KdTreeRangePointQuery<DataPoint, Adapter>(this, r, point);
     }
 
-    KdTreeRangeIndexQuery<DataPoint, Adapter> range_neighbors(QueryIndexType index, Scalar r) const
+    KdTreeRangeIndexQuery<DataPoint, Adapter> range_neighbors(IndexType index, Scalar r) const
     {
         return KdTreeRangeIndexQuery<DataPoint, Adapter>(this, r, index);
     }

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -48,7 +48,14 @@ public:
 
     typedef std::vector<DefaultKdTreeNode<DataPoint, AabbType>> NodeContainer;
 
-    static void max_dim(const VectorType& vec, Scalar& scalar)
+    static DimType max_dim(const VectorType& vec)
+    {
+        DimType dim;
+        vec.maxCoeff(dim);
+        return dim;
+    }
+
+    static Scalar vec_component(const VectorType& vec, DimType dim)
     {
         vec.maxCoeff(scalar);
     }

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -57,7 +57,7 @@ public:
     static DimType max_dim(const VectorType& vec)
     {
         DimType dim;
-        vec.maxCoeff(dim);
+        vec.maxCoeff(&dim);
         return dim;
     }
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -74,7 +74,7 @@ public:
         m_nodes(NodeContainer()),
         m_indices(IndexContainer()),
         m_min_cell_size(64),
-		m_max_depth(PCA_KDTREE_MAX_DEPTH),
+        m_max_depth(PCA_KDTREE_MAX_DEPTH),
         m_leaf_count(0)
     {
     };
@@ -85,7 +85,7 @@ public:
         m_nodes(NodeContainer()),
         m_indices(IndexContainer()),
         m_min_cell_size(64),
-		m_max_depth(PCA_KDTREE_MAX_DEPTH),
+        m_max_depth(PCA_KDTREE_MAX_DEPTH),
         m_leaf_count(0)
     {
         this->build(points);
@@ -98,7 +98,7 @@ public:
         m_nodes(),
         m_indices(),
         m_min_cell_size(64),
-		m_max_depth(PCA_KDTREE_MAX_DEPTH),
+        m_max_depth(PCA_KDTREE_MAX_DEPTH),
         m_leaf_count(0)
     {
         buildWithSampling(points, sampling);
@@ -222,16 +222,16 @@ public:
         m_min_cell_size = min_cell_size;
     }
 
-	inline DepthType max_depth() const
-	{
-		return m_max_depth;
-	}
-	
-	inline void set_max_depth(DepthType max_depth)
-	{
-		PONCA_ASSERT(max_depth <= PCA_KDTREE_MAX_DEPTH);
-		m_max_depth = max_depth;
-	}
+    inline DepthType max_depth() const
+    {
+        return m_max_depth;
+    }
+    
+    inline void set_max_depth(DepthType max_depth)
+    {
+        PONCA_ASSERT(max_depth <= PCA_KDTREE_MAX_DEPTH);
+        m_max_depth = max_depth;
+    }
 
     // Internal ----------------------------------------------------------------
 public:
@@ -278,7 +278,7 @@ protected:
     IndexContainer m_indices;
 
     LeafSizeType m_min_cell_size;
-	DepthType m_max_depth;
+    DepthType m_max_depth;
     NodeCountType m_leaf_count; ///< Number of leaves in the Kdtree (computed during construction)
 };
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -100,6 +100,7 @@ public:
     static_assert(std::is_same<typename PointContainer::value_type, DataPoint>::value,
         "PointContainer must contain DataPoints");
     
+    // Queries use a value of -1 for invalid indices
     static_assert(std::is_signed<IndexType>::value, "Index type must be signed");
     static_assert(std::is_same<typename IndexContainer::value_type, IndexType>::value, "Index type mismatch");
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -45,7 +45,7 @@ public:
     typedef std::vector<DataPoint> PointContainer;
     typedef std::vector<int>       IndexContainer;
 
-    typedef std::vector<KdTreeNode<DataPoint>> NodeContainer;
+    typedef std::vector<DefaultKdTreeNode<DataPoint>> NodeContainer;
 
 public:
     static DimType max_dim(const VectorType& vec)

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -121,7 +121,7 @@ public:
     struct DefaultConverter{
         template <typename Input>
         inline void operator()( Input&& i, PointContainer & o ) {
-            typedef InputContainer = typename std::remove_cv<typename std::remove_reference<Input>::type>::type;
+            typedef typename std::remove_cv<typename std::remove_reference<Input>::type>::type InputContainer;
             if constexpr ( std::is_same<InputContainer, PointContainer>::value )
                 o = i;
             else

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -35,15 +35,14 @@ struct DefaultKdTreeCompatibility
     typedef typename DataPoint::Scalar     Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
-
     typedef int DimType;
     typedef int DepthType;
 
     // Containers
-    typedef std::vector<DataPoint>                 PointContainer;
-    typedef std::vector<int>                       IndexContainer;
-    typedef std::vector<DefaultKdTreeNode<Scalar>> NodeContainer;
+    typedef std::vector<DataPoint> PointContainer;
+    typedef std::vector<int>       IndexContainer;
+
+    typedef std::vector<DefaultKdTreeNode<DataPoint>> NodeContainer;
 };
 
 ///
@@ -59,8 +58,7 @@ public:
     typedef typename Compatibility::Scalar     Scalar; // Scalar given by user
     typedef typename Compatibility::VectorType VectorType; // VectorType given by user
 
-    typedef typename Compatibility::AabbType Aabb; // Intersections
-
+    typedef typename Compatibility::DimType   DimType;
     typedef typename Compatibility::DepthType DepthType;
 
     typedef typename Compatibility::PointContainer PointContainer; // Container for VectorType used inside the KdTree

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -7,31 +7,6 @@
 // KdTree ----------------------------------------------------------------------
 
 template<class DataPoint>
-int KdTree<DataPoint>::node_count() const
-{
-    return static_cast<int>(m_nodes.size());
-}
-
-template<class DataPoint>
-int KdTree<DataPoint>::index_count() const
-{
-    return static_cast<int>(m_indices.size());
-}
-
-template<class DataPoint>
-int KdTree<DataPoint>::point_count() const
-{
-    return static_cast<int>(m_points.size());
-}
-
-
-template<class DataPoint>
-int KdTree<DataPoint>::leaf_count() const
-{
-    return m_leaf_count;
-}
-
-template<class DataPoint>
 void KdTree<DataPoint>::clear()
 {
     m_points.clear();
@@ -44,9 +19,9 @@ template<class DataPoint>
 template<typename PointUserContainer, typename Converter>
 inline void KdTree<DataPoint>::build(const PointUserContainer& points, Converter c)
 {
-    std::vector<int> ids(points.size());
+    IndexContainer ids(points.size());
     std::iota(ids.begin(), ids.end(), 0);
-    this->buildWithSampling(points, ids, c);
+    this->buildWithSampling(points, std::move(ids), c);
 }
 
 template<class DataPoint>
@@ -63,7 +38,6 @@ inline void KdTree<DataPoint>::buildWithSampling(const PointUserContainer& point
     m_nodes = NodeContainer();
     m_nodes.reserve(4 * point_count() / m_min_cell_size);
     m_nodes.emplace_back();
-    m_nodes.back().leaf = false;
 
     m_indices = IndexContainer(sampling);//move operator ou std copy
 
@@ -80,7 +54,6 @@ inline void KdTree<DataPoint>::rebuild(const IndexUserContainer & sampling)
 
     m_nodes.clear();
     m_nodes.emplace_back();
-    m_nodes.back().leaf = false;
 
     m_indices = sampling;
 
@@ -120,13 +93,13 @@ bool KdTree<DataPoint>::valid() const
         }
         b[idx] = true;
     }
-        
-    for(int n=0;n<node_count();++n)
+
+    for(NodeCountType n=0;n<node_count();++n)
     {
-        const KdTreeNode<Scalar>& node = m_nodes.operator[](n);
-        if(node.leaf)
+        const NodeType& node = m_nodes.operator[](n);
+        if(node.is_leaf())
         {
-            if(index_count() <= node.start || index_count() < node.start+node.size)
+            if(index_count() <= node.leaf.start || index_count() < node.leaf.start+node.leaf.size)
             {
                 PONCA_DEBUG_ERROR;
                 return false;
@@ -134,12 +107,12 @@ bool KdTree<DataPoint>::valid() const
         }
         else
         {
-            if(node.dim < 0 || 2 < node.dim)
+            if(node.inner.dim < 0 || 2 < node.inner.dim)
             {
                 PONCA_DEBUG_ERROR;
                 return false;
             }
-            if(node_count() <= node.firstChildId || node_count() <= node.firstChildId+1u)
+            if(node_count() <= node.inner.first_child_id || node_count() <= node.inner.first_child_id+1)
             {
                 PONCA_DEBUG_ERROR;
                 return false;
@@ -157,110 +130,76 @@ std::string KdTree<DataPoint>::to_string() const
     
     std::stringstream str;
     str << "indices (" << index_count() << ") :\n";
-    for(int i=0; i<index_count(); ++i)
+    for(IndexCountType i=0; i<index_count(); ++i)
     {
         str << "  " << i << ": " << m_indices.operator[](i) << "\n";
     }
     str << "nodes (" << node_count() << ") :\n";
-    for(int n=0; n< node_count(); ++n)
+    for(NodeCountType n=0; n< node_count(); ++n)
     {
-        const KdTreeNode<Scalar>& node = m_nodes.operator[](n);
-        if(node.leaf)
+        const NodeType& node = m_nodes.operator[](n);
+        if(node.is_leaf())
         {
-            int end = node.start + node.size;
-            str << "  leaf: start=" << node.start << " end=" << end << " (size=" << node.size << ")\n";
+            auto end = node.leaf.start + node.leaf.size;
+            str << "  leaf: start=" << node.leaf.start << " end=" << end << " (size=" << node.leaf.size << ")\n";
         }
         else
         {
-            str << "  node: dim=" << node.dim << " split=" << node.splitValue << " child=" << node.firstChildId << "\n";
+            str << "  node: dim=" << node.inner.dim << " split=" << node.inner.split_value << " child=" << node.inner.first_child_id << "\n";
         }
     }
     return str.str();
 }
 
 template<class DataPoint>
-int KdTree<DataPoint>::min_cell_size() const
+void KdTree<DataPoint>::build_rec(NodeCountType node_id, IndexCountType start, IndexCountType end, DepthType level)
 {
-    return m_min_cell_size;
+    NodeType& node = m_nodes[node_id];
+    for(IndexCountType i=start; i<end; ++i)
+        node.aabb.extend(m_points[m_indices[i]].pos());
+
+	if (end-start <= m_min_cell_size || level >= PCA_KDTREE_MAX_DEPTH)
+	{
+		PONCA_ASSERT_MSG(end-start <= std::numeric_limits<LeafSizeType>::max(), "Leaf size overflow");
+
+		node.set_is_leaf(true);
+
+		node.leaf.start = start;
+		node.leaf.size = static_cast<LeafSizeType>(end-start);
+		++m_leaf_count;
+	}
+	else
+	{
+		node.set_is_leaf(false);
+
+		DimType dim;
+		(Scalar(0.5) * (node.aabb.max() - node.aabb.min())).maxCoeff(&dim);
+		node.inner.dim = dim;
+		node.inner.split_value = node.aabb.center()(dim);
+
+		IndexCountType mid_id = this->partition(start, end, dim, node.inner.split_value);
+		node.inner.first_child_id = m_nodes.size();
+		m_nodes.emplace_back();
+		m_nodes.emplace_back();
+
+		build_rec(node.inner.first_child_id, start, mid_id, level+1);
+		build_rec(node.inner.first_child_id+1, mid_id, end, level+1);
+	}
 }
 
 template<class DataPoint>
-void KdTree<DataPoint>::set_min_cell_size(int min_cell_size)
-{
-    m_min_cell_size = min_cell_size;
-}
-
-template<class DataPoint>
-void KdTree<DataPoint>::build_rec(int node_id, int start, int end, int level)
-{   
-    KdTreeNode<Scalar>& node = m_nodes[node_id];
-    Aabb aabb;
-    for(int i=start; i<end; ++i)
-        aabb.extend(m_points[m_indices[i]].pos());
-    
-    int dim;
-    (Scalar(0.5) * (aabb.max() - aabb.min())).maxCoeff(&dim);
-    node.dim = dim;
-    node.splitValue = aabb.center()(dim);
-    
-    int midId = this->partition(start, end, dim, node.splitValue);
-    node.firstChildId = m_nodes.size();
-    
-    {
-        KdTreeNode<Scalar> n;
-        n.size = 0;
-        m_nodes.push_back(n);
-        m_nodes.push_back(n);
-    }
-    {
-        // left child
-        int childId = m_nodes[node_id].firstChildId;
-        KdTreeNode<Scalar>& child = m_nodes[childId];
-        if(midId-start <= m_min_cell_size || level >= PCA_KDTREE_MAX_DEPTH)
-        {
-            child.leaf = 1;
-            child.start = start;
-            child.size = midId-start;
-            m_leaf_count++;
-        }
-        else
-        {
-            child.leaf = 0;
-            this->build_rec(childId, start, midId, level+1);
-        }
-    }
-    {
-        // right child
-        int childId = m_nodes[node_id].firstChildId+1;
-        KdTreeNode<Scalar>& child = m_nodes[childId];
-        if(end-midId <= m_min_cell_size || level >= PCA_KDTREE_MAX_DEPTH)
-        {
-            child.leaf = 1;
-            child.start = midId;
-            child.size = end-midId;
-            m_leaf_count++;
-        }
-        else
-        {
-            child.leaf = 0;
-            this->build_rec(childId, midId, end, level+1);
-        }
-    }
-}
-
-template<class DataPoint>
-int KdTree<DataPoint>::partition(int start, int end, int dim, Scalar value)
+auto KdTree<DataPoint>::partition(IndexCountType start, IndexCountType end, DimType dim, Scalar value)
+	-> IndexCountType
 {
     const auto& points = m_points;
     auto& indices  = m_indices;
     
-    auto it = std::partition(indices.begin()+start, indices.begin()+end, [&](int i)
+    auto it = std::partition(indices.begin()+start, indices.begin()+end, [&](IndexType i)
     {
         return points[i].pos()[dim] < value;
     });
         
     auto distance = std::distance(m_indices.begin(), it);
     
-    return static_cast<int>(distance);
+    return static_cast<IndexCountType>(distance);
 }
-

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -27,8 +27,8 @@ inline void KdTree<DataPoint, Compatibility>::build(const PointUserContainer& po
 template<class DataPoint, class Compatibility>
 template<typename PointUserContainer, typename IndexUserContainer, typename Converter>
 inline void KdTree<DataPoint, Compatibility>::buildWithSampling(const PointUserContainer& points,
-                                                                 const IndexUserContainer& sampling,
-                                                                 Converter c)
+                                                                const IndexUserContainer& sampling,
+                                                                Converter c)
 {
     this->clear();
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -174,12 +174,12 @@ void KdTree<DataPoint, Adapter>::build_rec(NodeCountType node_id, IndexCountType
 
         DimType dim;
         if constexpr (std::is_floating_point<Scalar>::value)
-            Adapter::max_dim(Scalar(0.5) * (node.aabb.max() - node.aabb.min()), dim);
+            dim = Adapter::max_dim(Scalar(0.5) * (node.aabb.max() - node.aabb.min()));
         else
-            Adapter::max_dim((node.aabb.max() - node.aabb.min()) / Scalar(2), dim);
+            dim = Adapter::max_dim((node.aabb.max() - node.aabb.min()) / Scalar(2));
 
         node.inner.dim = dim;
-        node.inner.split_value = node.aabb.center()(dim);
+        node.inner.split_value = Adapter::vec_component(node.aabb.center(), dim);
 
         IndexCountType mid_id = this->partition(start, end, dim, node.inner.split_value);
         node.inner.first_child_id = m_nodes.size();

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -173,14 +173,14 @@ void KdTree<DataPoint, Adapter>::build_rec(NodeCountType node_id, IndexCountType
         node.set_is_leaf(false);
 
         DimType dim;
-		if constexpr (std::is_floating_point<Scalar>::value)
-		{
-			(Scalar(0.5) * (node.aabb.max() - node.aabb.min())).maxCoeff(&dim);
-		}
-		else
-		{
-			((node.aabb.max() - node.aabb.min()) / Scalar(2.0)).maxCoeff(&dim);
-		}
+        if constexpr (std::is_floating_point<Scalar>::value)
+        {
+            (Scalar(0.5) * (node.aabb.max() - node.aabb.min())).maxCoeff(&dim);
+        }
+        else
+        {
+            ((node.aabb.max() - node.aabb.min()) / Scalar(2.0)).maxCoeff(&dim);
+        }
         node.inner.dim = dim;
         node.inner.split_value = node.aabb.center()(dim);
 
@@ -196,7 +196,7 @@ void KdTree<DataPoint, Adapter>::build_rec(NodeCountType node_id, IndexCountType
 
 template<class DataPoint, class Adapter>
 auto KdTree<DataPoint, Adapter>::partition(IndexCountType start, IndexCountType end, DimType dim, Scalar value)
-	-> IndexCountType
+    -> IndexCountType
 {
     const auto& points = m_points;
     auto& indices  = m_indices;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -158,7 +158,7 @@ void KdTree<DataPoint, Adapter>::build_rec(NodeCountType node_id, IndexCountType
     for(IndexCountType i=start; i<end; ++i)
         node.aabb.extend(m_points[m_indices[i]].pos());
 
-    if (end-start <= m_min_cell_size || level >= m_max_depth)
+    if (end-start <= m_min_cell_size || level >= PCA_KDTREE_MAX_DEPTH)
     {
         PONCA_ASSERT_MSG(end-start <= std::numeric_limits<LeafSizeType>::max(), "Leaf size overflow");
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -160,8 +160,6 @@ void KdTree<DataPoint, Adapter>::build_rec(NodeCountType node_id, IndexCountType
 
     if (end-start <= m_min_cell_size || level >= PCA_KDTREE_MAX_DEPTH)
     {
-        PONCA_ASSERT_MSG(end-start <= std::numeric_limits<LeafSizeType>::max(), "Leaf size overflow");
-
         node.set_is_leaf(true);
 
         node.leaf.start = start;
@@ -200,9 +198,9 @@ auto KdTree<DataPoint, Adapter>::partition(IndexCountType start, IndexCountType 
     
     auto it = std::partition(indices.begin()+start, indices.begin()+end, [&](IndexType i)
     {
-        return points[i].pos()[dim] < value;
+        return Adapter::vec_component(points[i].pos(), dim) < value;
     });
-        
+
     auto distance = std::distance(m_indices.begin(), it);
     
     return static_cast<IndexCountType>(distance);

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -29,7 +29,7 @@ struct DefaultKdTreeLeafNode
     SizeType     size;
 };
 
-template<typename DataPoint, typename Aabb>
+template<typename DataPoint, typename AabbType>
 struct DefaultKdTreeNode
 {
 private:
@@ -41,7 +41,7 @@ private:
 public:
     typedef typename LeafType::SizeType LeafSizeType;
 
-    Aabb aabb;
+    AabbType aabb;
     union
     {
         InnerType inner;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -10,7 +10,7 @@ namespace Ponca {
 template<typename Scalar>
 struct DefaultKdTreeInnerNode
 {
-    Scalar split_value;
+    Scalar       split_value;
     unsigned int first_child_id:24;
     unsigned int dim:2;
     unsigned int leaf:1;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -10,40 +10,45 @@ namespace Ponca {
 template<typename Scalar>
 struct DefaultKdTreeInnerNode
 {
-	Scalar split_value;
-	unsigned int first_child_id:24;
-	unsigned int dim:2;
+    Scalar split_value;
+    unsigned int first_child_id:24;
+    unsigned int dim:2;
 
 private:
-	template <typename _Scalar>
-	friend struct KdTreeNode;
+    template <typename DataPoint>
+    friend struct KdTreeNode;
 
-	unsigned int leaf:1;
+    unsigned int leaf:1;
 };
 
 struct DefaultKdTreeLeafNode
 {
-	using SizeType = unsigned short;
+    using SizeType = unsigned short;
 
-	unsigned int start;
-	SizeType     size;
+    unsigned int start;
+    SizeType     size;
 };
 
-template<typename Scalar, typename Aabb>
+template<typename DataPoint>
 struct DefaultKdTreeNode
 {
-	typedef DefaultKdTreeInnerNode<Scalar>  InnerType;
-	typedef DefaultKdTreeLeafNode           LeafType;
-	typedef typename LeafNodeType::SizeType LeafSizeType;
+private:
+    typedef typename DataPoint::Scalar Scalar;
 
+    typedef DefaultKdTreeInnerNode<Scalar> InnerType;
+    typedef DefaultKdTreeLeafNode          LeafType;
+
+public:
+    typedef typename LeafType::SizeType               LeafSizeType;
+    typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
+
+    AabbType aabb;
     union {
-		InnerType inner;
+        InnerType inner;
         LeafType  leaf;
     };
 
-	Aabb aabb;
-
-	bool is_leaf() const { return inner.leaf; }
-	void set_is_leaf(bool new_is_leaf) { inner.leaf = new_is_leaf; }
+    bool is_leaf() const { return inner.leaf; }
+    void set_is_leaf(bool new_is_leaf) { inner.leaf = new_is_leaf; }
 };
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -46,7 +46,7 @@ public:
 
     AabbType aabb;
     union
-	{
+    {
         InnerType inner;
         LeafType  leaf;
     };

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <Eigen/Geometry> // aabb
-
 namespace Ponca {
 template<typename Scalar>
 struct DefaultKdTreeInnerNode
@@ -31,7 +29,7 @@ struct DefaultKdTreeLeafNode
     SizeType     size;
 };
 
-template<typename DataPoint>
+template<typename DataPoint, typename Aabb>
 struct DefaultKdTreeNode
 {
 private:
@@ -41,10 +39,9 @@ private:
     typedef DefaultKdTreeLeafNode          LeafType;
 
 public:
-    typedef typename LeafType::SizeType               LeafSizeType;
-    typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
+    typedef typename LeafType::SizeType LeafSizeType;
 
-    AabbType aabb;
+    Aabb aabb;
     union
     {
         InnerType inner;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -13,11 +13,6 @@ struct DefaultKdTreeInnerNode
     Scalar split_value;
     unsigned int first_child_id:24;
     unsigned int dim:2;
-
-private:
-    template <typename DataPoint>
-    friend struct KdTreeNode;
-
     unsigned int leaf:1;
 };
 
@@ -29,7 +24,7 @@ struct DefaultKdTreeLeafNode
     SizeType     size;
 };
 
-template<typename DataPoint, typename AabbType>
+template<typename DataPoint>
 struct DefaultKdTreeNode
 {
 private:
@@ -41,7 +36,6 @@ private:
 public:
     typedef typename LeafType::SizeType LeafSizeType;
 
-    AabbType aabb;
     union
     {
         InnerType inner;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -45,7 +45,8 @@ public:
     typedef Eigen::AlignedBox<Scalar, DataPoint::Dim> AabbType;
 
     AabbType aabb;
-    union {
+    union
+	{
         InnerType inner;
         LeafType  leaf;
     };

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -6,24 +6,44 @@
 
 #pragma once
 
-#include "../defines.h"
-
 namespace Ponca {
 template<typename Scalar>
-struct KdTreeNode
+struct DefaultKdTreeInnerNode
 {
-    union {
-        struct {
-            Scalar       splitValue;
-            unsigned int   firstChildId:24;
-            unsigned int   dim:2;
-            unsigned int   leaf:1;
-        };
-        struct {
-            unsigned int   start;
-            unsigned short size;
-        };
-    };
+	Scalar split_value;
+	unsigned int first_child_id:24;
+	unsigned int dim:2;
+
+private:
+	template <typename _Scalar>
+	friend struct KdTreeNode;
+
+	unsigned int leaf:1;
 };
 
-}   
+struct DefaultKdTreeLeafNode
+{
+	using SizeType = unsigned short;
+
+	unsigned int start;
+	SizeType     size;
+};
+
+template<typename Scalar, typename Aabb>
+struct DefaultKdTreeNode
+{
+	typedef DefaultKdTreeInnerNode<Scalar>  InnerType;
+	typedef DefaultKdTreeLeafNode           LeafType;
+	typedef typename LeafNodeType::SizeType LeafSizeType;
+
+    union {
+		InnerType inner;
+        LeafType  leaf;
+    };
+
+	Aabb aabb;
+
+	bool is_leaf() const { return inner.leaf; }
+	void set_is_leaf(bool new_is_leaf) { inner.leaf = new_is_leaf; }
+};
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeNode.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <Eigen/Geometry> // aabb
+
 namespace Ponca {
 template<typename Scalar>
 struct DefaultKdTreeInnerNode

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
@@ -13,16 +13,16 @@
 #define PCA_KDTREE_MAX_DEPTH 32
 
 namespace Ponca {
-template <class DataPoint, class Compatibility> class KdTree;
+template <class DataPoint, class Adapter> class KdTree;
 
-template <class DataPoint, class Compatibility>
+template <class DataPoint, class Adapter>
 class KdTreeQuery
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
 
-    explicit inline KdTreeQuery(const KdTree<DataPoint, Compatibility>* kdtree) : m_kdtree( kdtree ), m_stack() {}
+    explicit inline KdTreeQuery(const KdTree<DataPoint, Adapter>* kdtree) : m_kdtree( kdtree ), m_stack() {}
 
 protected:
     /// \brief Init stack for a new search
@@ -31,7 +31,7 @@ protected:
         m_stack.push({0,0});
     }
 
-    const KdTree<DataPoint, Compatibility>* m_kdtree { nullptr };
+    const KdTree<DataPoint, Adapter>* m_kdtree { nullptr };
     Stack<IndexSquaredDistance<typename DataPoint::Scalar>, 2 * PCA_KDTREE_MAX_DEPTH> m_stack;
 };
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
@@ -19,6 +19,7 @@ template <class DataPoint, class Adapter>
 class KdTreeQuery
 {
 public:
+    using IndexType       = typename Adapter::IndexType;
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
 
@@ -32,7 +33,7 @@ protected:
     }
 
     const KdTree<DataPoint, Adapter>* m_kdtree { nullptr };
-    Stack<IndexSquaredDistance<typename DataPoint::Scalar>, 2 * PCA_KDTREE_MAX_DEPTH> m_stack;
+    Stack<IndexSquaredDistance<IndexType, Scalar>, 2 * PCA_KDTREE_MAX_DEPTH> m_stack;
 };
 
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
@@ -15,14 +15,14 @@
 namespace Ponca {
 template <class DataPoint, class Compatibility> class KdTree;
 
-template <class DataPoint>
+template <class DataPoint, class Compatibility>
 class KdTreeQuery
 {
 public:
     using Scalar          = typename DataPoint::Scalar;
     using VectorType      = typename DataPoint::VectorType;
 
-    explicit inline KdTreeQuery(const KdTree<DataPoint>* kdtree) : m_kdtree( kdtree ), m_stack() {}
+    explicit inline KdTreeQuery(const KdTree<DataPoint, Compatibility>* kdtree) : m_kdtree( kdtree ), m_stack() {}
 
 protected:
     /// \brief Init stack for a new search
@@ -31,7 +31,7 @@ protected:
         m_stack.push({0,0});
     }
 
-    const KdTree<DataPoint>* m_kdtree { nullptr };
+    const KdTree<DataPoint, Compatibility>* m_kdtree { nullptr };
     Stack<IndexSquaredDistance<typename DataPoint::Scalar>, 2 * PCA_KDTREE_MAX_DEPTH> m_stack;
 };
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeQuery.h
@@ -13,7 +13,7 @@
 #define PCA_KDTREE_MAX_DEPTH 32
 
 namespace Ponca {
-template<class DataPoint> class KdTree;
+template <class DataPoint, class Compatibility> class KdTree;
 
 template <class DataPoint>
 class KdTreeQuery

--- a/Ponca/src/SpatialPartitioning/indexSquaredDistance.h
+++ b/Ponca/src/SpatialPartitioning/indexSquaredDistance.h
@@ -7,16 +7,18 @@
 #pragma once
 
 #include <limits>
+#include <type_traits>
+
 #include "./defines.h"
 
 namespace Ponca {
 
 /// \brief Associates an index with a distance
-template<typename Scalar>
+template<typename Index, typename Scalar>
 struct IndexSquaredDistance
 {
     //// Index of the closest point
-    int index {-1};
+    Index index {-1};
 
     /// Distance to the closest point
     Scalar squared_distance { std::numeric_limits<Scalar>::max() };

--- a/Ponca/src/SpatialPartitioning/query.h
+++ b/Ponca/src/SpatialPartitioning/query.h
@@ -20,10 +20,10 @@ namespace Ponca {
 /// \note For internal use only
 #define DECLARE_INDEX_QUERY_CLASS(OUT_TYPE) \
 /*! \brief Base Query class combining QueryInputIsIndex and QueryOutputIs##OUT_TYPE##. */    \
-template <typename Scalar>                                 \
-struct  OUT_TYPE##IndexQuery : Query<QueryInputIsIndex, QueryOutputIs##OUT_TYPE<Scalar>> \
+template <typename Index, typename Scalar> \
+struct  OUT_TYPE##IndexQuery : Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>> \
 { \
-    using Base = Query<QueryInputIsIndex, QueryOutputIs##OUT_TYPE<Scalar>>; \
+    using Base = Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>>; \
     using Base::Base; \
 };
 
@@ -33,11 +33,11 @@ struct  OUT_TYPE##IndexQuery : Query<QueryInputIsIndex, QueryOutputIs##OUT_TYPE<
 /// \note For internal use only
 #define DECLARE_POINT_QUERY_CLASS(OUT_TYPE) \
 /*! \brief Base Query class combining QueryInputIsPosition and QueryOutputIs##OUT_TYPE##. */    \
-template <typename DataPoint>                                \
+template <typename Index, typename DataPoint> \
 struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
-                                     QueryOutputIs##OUT_TYPE<typename DataPoint::Scalar>> \
+                                     QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>> \
 { \
-    using Base = Query<QueryInputIsPosition<DataPoint>, QueryOutputIs##OUT_TYPE<typename DataPoint::Scalar>>; \
+    using Base = Query<QueryInputIsPosition<DataPoint>, QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>>; \
     using Base::Base; \
 };
 
@@ -80,8 +80,9 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
 
 
 /// \brief Base class for queries storing points
-    struct QueryInputIsIndex : public QueryInput<int> {
-        using Base = QueryInput<int>;
+    template <typename Index>
+    struct QueryInputIsIndex : public QueryInput<Index> {
+        using Base = QueryInput<Index>;
         using InputType = typename Base::InputType;
 
         inline QueryInputIsIndex(const InputType &point = -1)
@@ -99,7 +100,7 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
     };
 
 /// \brief Base class for range queries
-    template<typename Scalar>
+    template<typename Index, typename Scalar>
     struct QueryOutputIsRange : public QueryOutputBase {
         using OutputParameter = Scalar;
 
@@ -121,13 +122,13 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
     };
 
 /// \brief Base class for nearest queries
-    template<typename Scalar>
+    template<typename Index, typename Scalar>
     struct QueryOutputIsNearest : public QueryOutputBase {
         using OutputParameter = typename QueryOutputBase::DummyOutputParameter;
 
         QueryOutputIsNearest() {}
 
-        int get() const { return m_nearest; }
+        Index get() const { return m_nearest; }
 
     protected:
         /// \brief Reset Query for a new search
@@ -136,18 +137,18 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
             m_squared_distance = std::numeric_limits<Scalar>::max();
         }
 
-        int m_nearest {-1};
+        Index m_nearest {-1};
         Scalar m_squared_distance {std::numeric_limits<Scalar>::max()};
     };
 
 /// \brief Base class for knearest queries
-    template<typename Scalar>
+    template<typename Index, typename Scalar>
     struct QueryOutputIsKNearest : public QueryOutputBase {
-        using OutputParameter = int;
+        using OutputParameter = Index;
 
         inline QueryOutputIsKNearest(OutputParameter k = 0) : m_queue(k) {}
 
-        inline limited_priority_queue<IndexSquaredDistance<Scalar>> &queue() { return m_queue; }
+        inline limited_priority_queue<IndexSquaredDistance<Index, Scalar>> &queue() { return m_queue; }
 
     protected:
         /// \brief Reset Query for a new search
@@ -155,7 +156,7 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
             m_queue.clear();
             m_queue.push({-1,std::numeric_limits<Scalar>::max()});
         }
-        limited_priority_queue<IndexSquaredDistance<Scalar>> m_queue;
+        limited_priority_queue<IndexSquaredDistance<Index, Scalar>> m_queue;
     };
 
 


### PR DESCRIPTION
This PR:

1. Adds an `Adapter` template parameter to the kd-tree to allow using custom types and containers (see `DefaultKdTreeAdapter` and `DefaultKdTreeNode` for an example).
2. Allows moving points and samples into the kd-tree to minimize the number of copies.
