### PR TITLE
Use variadic template for basket extensions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ Current head (v.1.2 RC)
 - Examples
     - Fix example cuda/ponca_ssgls (#109)
 
+- Bug-fixes and code improvements
+    - [fitting] Use variadic template for basket extensions (#85)
+
 --------------------------------------------------------------------------------
 v.1.1 RC
 This release improves the Spatial Partitioning Package with new features and
@@ -31,7 +34,6 @@ improved doc, as well as several bug fixes and API improvements.
     - [fitting] Fix a bug in dtau computation for scale-only derivation (#98)
     - [fitting] Fix a bug in MlsSphereFitDer weight derivatives (#97)
     - [ci] Fix Compiler is out of heap space error on Github (MSVC), by splitting tests (#87)
-    - [fitting] Use variadic template for basket extensions (#85)
 
 - Tests
     - Fix WeightKernel test (failing on windows due to finite differences) (#91)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ improved doc, as well as several bug fixes and API improvements.
     - [fitting] Fix a bug in dtau computation for scale-only derivation (#98)
     - [fitting] Fix a bug in MlsSphereFitDer weight derivatives (#97)
     - [ci] Fix Compiler is out of heap space error on Github (MSVC), by splitting tests (#87)
+    - [fitting] Use variadic template for basket extensions (#85)
 
 - Tests
     - Fix WeightKernel test (failing on windows due to finite differences) (#91)

--- a/tests/src/basket.cpp
+++ b/tests/src/basket.cpp
@@ -193,14 +193,6 @@ void hasSamePlaneDerivatives(const Fit1& fit1, const Fit2& fit2) {
     VERIFY(dnor1.isApprox( dnor2 ));
 }
 
-// For BasketAutoDiff
-template <class P, class W, typename T>
-struct TestExt0 : public T
-{
-    template <class D, class W_, int Di, typename TT>
-    using DDerType = OrientedSphereDerImpl<D, W_, Di, TT>;
-};
-
 template<typename Scalar, int Dim>
 void callSubTests()
 {
@@ -237,10 +229,6 @@ void callSubTests()
     using HybridScaleDiff = BasketDiff<Hybrid, FitScaleDer, CovariancePlaneDer>;
     using HybridSpaceDiff = BasketDiff<Hybrid, FitSpaceDer, CovariancePlaneDer>;
     using HybridScaleSpaceDiff = BasketDiff<Hybrid, FitScaleSpaceDer, CovariancePlaneDer>;
-
-    //! [BasketAutoDiff]
-    using AutoDiff = BasketAutoDiff<Point, WeightFunc, FitScaleDer, TestExt0, OrientedSphereFit>;
-    //! [BasketAutoDiff]
 
     KdTree<Point>tree;
     Scalar scale = generateData(tree);

--- a/tests/src/basket.cpp
+++ b/tests/src/basket.cpp
@@ -193,6 +193,14 @@ void hasSamePlaneDerivatives(const Fit1& fit1, const Fit2& fit2) {
     VERIFY(dnor1.isApprox( dnor2 ));
 }
 
+// For BasketAutoDiff
+template <class P, class W, typename T>
+struct TestExt0 : public T
+{
+    template <class D, class W_, int Di, typename TT>
+    using DDerType = OrientedSphereDerImpl<D, W_, Di, TT>;
+};
+
 template<typename Scalar, int Dim>
 void callSubTests()
 {
@@ -229,6 +237,10 @@ void callSubTests()
     using HybridScaleDiff = BasketDiff<Hybrid, FitScaleDer, CovariancePlaneDer>;
     using HybridSpaceDiff = BasketDiff<Hybrid, FitSpaceDer, CovariancePlaneDer>;
     using HybridScaleSpaceDiff = BasketDiff<Hybrid, FitScaleSpaceDer, CovariancePlaneDer>;
+
+    //! [BasketAutoDiff]
+    using AutoDiff = BasketAutoDiff<Point, WeightFunc, FitScaleDer, TestExt0, OrientedSphereFit>;
+    //! [BasketAutoDiff]
 
     KdTree<Point>tree;
     Scalar scale = generateData(tree);


### PR DESCRIPTION
This PR changes the hard-coded extension list for the `Basket` and `BasketDiff` types to a variadic list.
