### PR TITLE
Update nbNeighbors when using multiple pass

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ improved doc.
 
 - Bug-fixes and code improvements
     - [spatialPartitioning] Fix unwanted function hiding with DryFit::setWeightFunc (#86)
+    - [fitting] Fix a potential bug when using multi-pass fitting (#89)
     - [fitting] Remove deadcode in Basket (#86)
     - [ci] Fix Compiler is out of heap space error on Github (MSVC), by splitting tests (#87)
 

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -155,8 +155,6 @@ namespace internal
 
         if (wres.first > Scalar(0.)) {
             Base::addLocalNeighbor(wres.first, wres.second, _nei, dw);
-            Base::m_sumW += (wres.first);
-            ++(Base::m_nbNeighbors);
             return true;
         }
         return false;
@@ -222,7 +220,10 @@ namespace internal
         WRITE_BASKET_FUNCTIONS;
 
         /// \brief Add a neighbor to perform the fit
-        /// When using by hand, don't forget to set m_nbNeighbors to 0 when performing a new pass (see PONCA::NEED_OTHER_PASS).
+        ///
+        /// When called directly, don't forget to call PrimitiveBase::startNewPass when starting multiple passes
+        /// \see compute Prefer when using a range of Points
+        /// \see computeWithIds Prefer when using a range of ids
         /// \return false if param nei is not a valid neighbor (weight = 0)
         PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {
             // compute weight
@@ -230,8 +231,6 @@ namespace internal
 
             if (wres.first > Scalar(0.)) {
                 Base::addLocalNeighbor(wres.first, wres.second, _nei);
-                Base::m_sumW += (wres.first);
-                ++(Base::m_nbNeighbors);
                 return true;
             }
             return false;

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -48,6 +48,7 @@ namespace internal
     FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end){                           \
         FIT_RESULT res = UNDEFINED;                                                                   \
         do {                                                                                          \
+            Self::startNewPass();                                                                     \
             for (auto it = begin; it != end; ++it){                                                   \
                 Self::addNeighbor(*it);                                                               \
             }                                                                                         \
@@ -65,6 +66,7 @@ namespace internal
     FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){                          \
         FIT_RESULT res = UNDEFINED;                                                                   \
         do {                                                                                          \
+            Self::startNewPass();                                                                     \
             for (const auto& i : ids){                                                                \
                 this->addNeighbor(points[i]);                                                         \
             }                                                                                         \
@@ -220,6 +222,7 @@ namespace internal
         WRITE_BASKET_FUNCTIONS;
 
         /// \brief Add a neighbor to perform the fit
+        /// When using by hand, don't forget to set m_nbNeighbors to 0 when performing a new pass (see PONCA::NEED_OTHER_PASS).
         /// \return false if param nei is not a valid neighbor (weight = 0)
         PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {
             // compute weight

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -41,7 +41,7 @@ namespace internal
 #define WRITE_BASKET_FUNCTIONS                                                                        \
     /*! \brief Convenience function for STL-like iterators               */                           \
     /*! Add neighbors stored in a container using STL-like iterators, and call finalize at the end.*/ \
-    /*! The fit is evaluated multiple time if needed (see NEED_OTHER_PASS)*/                          \
+    /*! The fit is evaluated multiple time if needed (see #NEED_OTHER_PASS)*/                         \
     /*! \see addNeighbor() */                                                                         \
     template <typename IteratorBegin, typename IteratorEnd>                                           \
     PONCA_MULTIARCH inline                                                                            \
@@ -147,7 +147,7 @@ namespace internal
 
     WRITE_BASKET_FUNCTIONS
 
-    /// Hide Basket::addNeighbor
+    /// \copydoc Basket::addNeighbor
     PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {
         // compute weight
         auto wres = Base::m_w.w(_nei.pos(), _nei);

--- a/Ponca/src/Fitting/covarianceFit.hpp
+++ b/Ponca/src/Fitting/covarianceFit.hpp
@@ -36,14 +36,14 @@ CovarianceFitBase<DataPoint, _WFunctor, T>::finalize ()
 {
     // handle specific configurations
     // With less than 3 neighbors the fitting is undefined
-    if(Base::finalize() != STABLE || Base::m_nbNeighbors < 3)
+    if(Base::finalize() != STABLE || Base::getNumNeighbors() < 3)
     {
         return Base::m_eCurrentState = UNDEFINED;
     }
 
     // Center the covariance on the centroid
     auto centroid = Base::barycenter();
-    m_cov = m_cov/Base::m_sumW - centroid * centroid.transpose();
+    m_cov = m_cov/Base::getWeightSum() - centroid * centroid.transpose();
 
 #ifdef __CUDACC__
     m_solver.computeDirect(m_cov);

--- a/Ponca/src/Fitting/curvatureEstimation.hpp
+++ b/Ponca/src/Fitting/curvatureEstimation.hpp
@@ -141,10 +141,10 @@ NormalCovarianceCurvatureEstimator<DataPoint, _WFunctor, DiffType, T>::finalize 
     if(this->isReady())
     {
         // center of gravity (mean)
-        m_cog /= Base::m_sumW;
+        m_cog /= Base::getWeightSum();
 
         // Center the covariance on the centroid
-        m_cov = m_cov/Base::m_sumW - m_cog * m_cog.transpose();
+        m_cov = m_cov/Base::getWeightSum() - m_cog * m_cog.transpose();
 
         m_solver.computeDirect(m_cov);
 
@@ -252,10 +252,10 @@ ProjectedNormalCovarianceCurvatureEstimator<DataPoint, _WFunctor, DiffType, T>::
     else if(m_pass == SECOND_PASS)
     {
         // center of gravity (mean)
-        m_cog /= Base::m_sumW;
+        m_cog /= Base::getWeightSum();
 
         // Center the covariance on the centroid
-        m_cov = m_cov/Base::m_sumW - m_cog * m_cog.transpose();
+        m_cov = m_cov/Base::getWeightSum() - m_cog * m_cog.transpose();
 
         m_solver.computeDirect(m_cov);
 

--- a/Ponca/src/Fitting/defines.h
+++ b/Ponca/src/Fitting/defines.h
@@ -64,9 +64,9 @@ using VectorArray = typename Base::VectorArray;     /*!< \brief Alias to vector 
 
 // FIT API DOCUMENTATION
 #define PONCA_FITTING_APIDOC_SETWFUNC \
-/*! Init the WeightFunc, without changing the other internal states. \warning Must be called be for any computation */
+/*! Init the WeightFunc, without changing the other internal states. Calls #startNewPass internally. \warning Must be called be for any computation (and before #init). */
 #define PONCA_FITTING_APIDOC_INIT \
-/*! Set the evaluation position and reset the internal states. \warning Must be called be for any computation */
+/*! Set the evaluation position and reset the internal states. \warning Must be called be for any computation (but after #setWeightFunc) */
 #define PONCA_FITTING_APIDOC_ADDNEIGHBOR \
 /*! Add a neighbor to perform the fit \return false if param nei is not a valid neighbour (weight = 0) */
 #define PONCA_FITTING_APIDOC_ADDNEIGHBOR_DER \

--- a/Ponca/src/Fitting/mean.h
+++ b/Ponca/src/Fitting/mean.h
@@ -38,7 +38,7 @@ namespace Ponca {
         /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
         ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in \f$\mathbf{x}\f$'s neighborhood
         PONCA_MULTIARCH inline VectorType barycenter() const {
-            return (m_sumP / Base::m_sumW);
+            return (m_sumP / Base::getWeightSum());
         }
 
     }; //class MeanPosition
@@ -117,7 +117,7 @@ namespace Ponca {
         /// \note This code is not directly tested, but rather indirectly by testing CovariancePlaneDer::dNormal()
         PONCA_MULTIARCH VectorArray barycenterDerivatives() const
         {
-            return ( m_dSumP - Base::barycenter() * Base::m_dSumW ) / Base::m_sumW;
+            return ( m_dSumP - Base::barycenter() * Base::m_dSumW ) / Base::getWeightSum();
         }
 
     }; //class MeanPositionDer

--- a/Ponca/src/Fitting/meanPlaneFit.h
+++ b/Ponca/src/Fitting/meanPlaneFit.h
@@ -43,7 +43,7 @@ public:
         if(Base::finalize() == STABLE)
         {
             if (Base::plane().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-            Base::setPlane(Base::m_sumN / Base::m_sumW, Base::barycenter());
+            Base::setPlane(Base::m_sumN / Base::getWeightSum(), Base::barycenter());
         }
         return Base::m_eCurrentState;
     }

--- a/Ponca/src/Fitting/mlsSphereFitDer.hpp
+++ b/Ponca/src/Fitting/mlsSphereFitDer.hpp
@@ -84,24 +84,24 @@ MlsSphereFitDer<DataPoint, _WFunctor, DiffType, T>::finalize()
             sumd2SumPdSumP += m_d2SumP.template block<DerDim,DerDim>(0,i*DerDim)*Base::m_sumP(i);
         }
 
-        Scalar invSumW = Scalar(1.)/Base::m_sumW;
+        Scalar invSumW = Scalar(1.)/Base::getWeightSum();
 
         Matrix d2Nume = m_d2SumDotPN
             - invSumW*invSumW*invSumW*invSumW*(
-                    Base::m_sumW*Base::m_sumW*(  Base::m_sumW*(sumdSumPdSumN+sumdSumPdSumN.transpose()+sumd2SumPdSumN+sumd2SumNdSumP)
+                    Base::getWeightSum()*Base::getWeightSum()*(  Base::getWeightSum()*(sumdSumPdSumN+sumdSumPdSumN.transpose()+sumd2SumPdSumN+sumd2SumNdSumP)
                                                + Base::m_dSumW.transpose()*(Base::m_sumN.transpose()*Base::m_dSumP + Base::m_sumP.transpose()*Base::m_dSumN)
                                                - (Base::m_sumP.transpose()*Base::m_sumN)*m_d2SumW.transpose()
                                                - (Base::m_dSumN.transpose()*Base::m_sumP + Base::m_dSumP.transpose()*Base::m_sumN)*Base::m_dSumW)
-                    - Scalar(2.)*Base::m_sumW*Base::m_dSumW.transpose()*(Base::m_sumW*(Base::m_sumN.transpose()*Base::m_dSumP + Base::m_sumP.transpose()*Base::m_dSumN)
+                    - Scalar(2.)*Base::getWeightSum()*Base::m_dSumW.transpose()*(Base::getWeightSum()*(Base::m_sumN.transpose()*Base::m_dSumP + Base::m_sumP.transpose()*Base::m_dSumN)
                                                                          - (Base::m_sumP.transpose()*Base::m_sumN)*Base::m_dSumW));
 
         Matrix d2Deno = m_d2SumDotPP
             - invSumW*invSumW*invSumW*invSumW*(
-                Base::m_sumW*Base::m_sumW*(  Scalar(2.)*Base::m_sumW*(sumdSumPdSumP+sumd2SumPdSumP)
+                Base::getWeightSum()*Base::getWeightSum()*(  Scalar(2.)*Base::getWeightSum()*(sumdSumPdSumP+sumd2SumPdSumP)
                                            + Scalar(2.)*Base::m_dSumW.transpose()*(Base::m_sumP.transpose()*Base::m_dSumP)
                                            - (Base::m_sumP.transpose()*Base::m_sumP)*m_d2SumW.transpose()
                                            - Scalar(2.)*(Base::m_dSumP.transpose()*Base::m_sumP)*Base::m_dSumW)
-                - Scalar(2.)*Base::m_sumW*Base::m_dSumW.transpose()*(Scalar(2.)*Base::m_sumW*Base::m_sumP.transpose()*Base::m_dSumP
+                - Scalar(2.)*Base::getWeightSum()*Base::m_dSumW.transpose()*(Scalar(2.)*Base::getWeightSum()*Base::m_sumP.transpose()*Base::m_dSumP
                                                                      - (Base::m_sumP.transpose()*Base::m_sumP)*Base::m_dSumW));
 
         Scalar deno2 = Base::m_deno*Base::m_deno;

--- a/Ponca/src/Fitting/orientedSphereFit.hpp
+++ b/Ponca/src/Fitting/orientedSphereFit.hpp
@@ -41,17 +41,17 @@ OrientedSphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     PONCA_MULTIARCH_STD_MATH(abs);
 
     // Compute status
-    if(Base::finalize() != STABLE  || Base::m_nbNeighbors < 3)
+    if(Base::finalize() != STABLE  || Base::getNumNeighbors() < 3)
         return Base::m_eCurrentState;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::m_nbNeighbors < 6 ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 6 ? UNSTABLE : STABLE;
 
     // 1. finalize sphere fitting
     Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision();
 
-    Scalar invSumW = Scalar(1.)/Base::m_sumW;
+    Scalar invSumW = Scalar(1.)/Base::getWeightSum();
 
     m_nume = (m_sumDotPN - invSumW * Base::m_sumP.dot(Base::m_sumN));
     Scalar den1 = invSumW * Base::m_sumP.dot(Base::m_sumP);
@@ -126,7 +126,7 @@ OrientedSphereDerImpl<DataPoint, _WFunctor, DiffType, T>::finalize()
     // Test if base finalize end on a viable case (stable / unstable)
     if (this->isReady())
     {
-        Scalar invSumW = Scalar(1.)/Base::m_sumW;
+        Scalar invSumW = Scalar(1.)/Base::getWeightSum();
 
         Scalar nume  = Base::m_sumDotPN - invSumW*Base::m_sumP.dot(Base::m_sumN);
         Scalar deno  = Base::m_sumDotPP - invSumW*Base::m_sumP.dot(Base::m_sumP);
@@ -135,11 +135,11 @@ OrientedSphereDerImpl<DataPoint, _WFunctor, DiffType, T>::finalize()
         // issues for spacial derivatives because, (d sum w_i P_i)/(d x) is supposed to be tangent to the surface whereas
         // "sum w_i N_i" is normal to the surface...
         m_dNume = m_dSumDotPN
-            - invSumW*invSumW * ( Base::m_sumW * ( Base::m_sumN.transpose() * Base::m_dSumP + Base::m_sumP.transpose() * m_dSumN )
+            - invSumW*invSumW * ( Base::getWeightSum() * ( Base::m_sumN.transpose() * Base::m_dSumP + Base::m_sumP.transpose() * m_dSumN )
             - Base::m_dSumW*Base::m_sumP.dot(Base::m_sumN) );
 
         m_dDeno = m_dSumDotPP
-            - invSumW*invSumW*(   Scalar(2.) * Base::m_sumW * Base::m_sumP.transpose() * Base::m_dSumP
+            - invSumW*invSumW*(   Scalar(2.) * Base::getWeightSum() * Base::m_sumP.transpose() * Base::m_dSumP
             - Base::m_dSumW*Base::m_sumP.dot(Base::m_sumP) );
 
         m_dUq =  Scalar(.5) * (deno * m_dNume - m_dDeno * nume)/(deno*deno);

--- a/Ponca/src/Fitting/sphereFit.hpp
+++ b/Ponca/src/Fitting/sphereFit.hpp
@@ -41,12 +41,12 @@ FIT_RESULT
 SphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
 {
     // Compute status
-    if(Base::finalize() != STABLE || Base::m_nbNeighbors < 3)
+    if(Base::finalize() != STABLE || Base::getNumNeighbors() < 3)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::m_nbNeighbors < 6 ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 6 ? UNSTABLE : STABLE;
 
     MatrixA matC;
     matC.setIdentity();

--- a/Ponca/src/Fitting/unorientedSphereFit.hpp
+++ b/Ponca/src/Fitting/unorientedSphereFit.hpp
@@ -90,15 +90,15 @@ UnorientedSphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     constexpr int Dim = DataPoint::Dim;
 
     // Compute status
-    if(Base::finalize() != STABLE || Base::m_nbNeighbors < 3)
+    if(Base::finalize() != STABLE || Base::getNumNeighbors() < 3)
         return Base::m_eCurrentState;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::m_nbNeighbors < 6 ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 6 ? UNSTABLE : STABLE;
 
     // 1. finalize sphere fitting
-    Scalar invSumW = Scalar(1.) / Base::m_sumW;
+    Scalar invSumW = Scalar(1.) / Base::getWeightSum();
 
 
     MatrixBB Q;
@@ -200,16 +200,16 @@ OrientedSphereDer<DataPoint, _WFunctor, T, Type>::finalize()
     if (this->isReady())
     {
 
-        Scalar invSumW = Scalar(1.)/Base::m_sumW;
+        Scalar invSumW = Scalar(1.)/Base::getWeightSum();
 
         Scalar nume  = Base::m_sumDotPN - invSumW*Base::m_sumP.dot(Base::m_sumN);
         Scalar deno  = Base::m_sumDotPP - invSumW*Base::m_sumP.dot(Base::m_sumP);
 
-        ScalarArray dNume = m_dSumDotPN - invSumW*invSumW * ( Base::m_sumW * (
+        ScalarArray dNume = m_dSumDotPN - invSumW*invSumW * ( Base::getWeightSum() * (
                                                             Base::m_sumN.transpose() * m_dSumP +
                                                             Base::m_sumP.transpose() * m_dSumN )
                                                             - m_dSumW*Base::m_sumP.dot(Base::m_sumN) );
-        ScalarArray dDeno = m_dSumDotPP - invSumW*invSumW*( Scalar(2.)*Base::m_sumW * Base::m_sumP.transpose()*m_dSumP
+        ScalarArray dDeno = m_dSumDotPP - invSumW*invSumW*( Scalar(2.)*Base::getWeightSum() * Base::m_sumP.transpose()*m_dSumP
                                                             - m_dSumW*Base::m_sumP.dot(Base::m_sumP) );
 
         m_dUq =  Scalar(.5) * (deno * dNume - dDeno * nume)/(deno*deno);

--- a/doc/src/ponca_module_fitting.mdoc
+++ b/doc/src/ponca_module_fitting.mdoc
@@ -159,6 +159,7 @@ namespace Ponca
   Some methods require multiple fitting passes, e.g. \ref MongePatch.
   This is directly handled by the `compute` method.
   If you don't use it, you need to check if `eResults == NEED_ANOTHER_PASS` and repeat the `addNeighbor()`/`finalize()` steps.
+  Don't forget to call `startNewPass()` at each iteration.
 
   \warning You should avoid data of low magnitude (i.e., 1 should be a significant value) to get good results; thus rescaling might be necessary.
 

--- a/examples/cpp/nanoflann/ponca_nanoflann.cpp
+++ b/examples/cpp/nanoflann/ponca_nanoflann.cpp
@@ -124,6 +124,7 @@ f.init(_p);
 // Compute
 auto res = Ponca::UNDEFINED;
 do {
+    f.startNewPass();
     for (const auto& r : resultSet.m_indices_dists){
         f.addNeighbor(_vecs[r.first]);
     }

--- a/tests/src/gls_paraboloid_der.cpp
+++ b/tests/src/gls_paraboloid_der.cpp
@@ -149,7 +149,7 @@ void testFunction(bool isSigned = true)
         // Take into account centered basis:
 //         if(k>0) uc        += -f.m_ul(k-1) * h + f.m_uq * h * h;
 //         if(k>0) ul[k-1]   -= 2. * f.m_uq * h;
-//         if(k>0) sumP[k-1] += f.m_sumW * h;
+//         if(k>0) sumP[k-1] += f.getWeightSum() * h;
 
 //         dSumP.col(k)  = ( f.m_cog      - ref_fit.m_cog ) / h;
 //         dSumP.col(k)  = ( sumP      - ref_fit.m_sumP  ) / h;


### PR DESCRIPTION
This little modification fix this bug : 
- When using several pass, the basket multiplies the number of neighbors with the number of pass. 
Be careful, when you're using addNeighbor by hand, don't forget to update the m_nbNeighbors by hand too when using other pass.