### PR TITLE
Kd-tree documentation and small fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ improved doc.
 
 - Bug-fixes and code improvements
     - [spatialPartitioning] Fix unwanted function hiding with DryFit::setWeightFunc (#86)
+    - [spatialPartitioning] Fix missing include directive in kdTreeTraits.h (#92)
     - [fitting] Fix a potential bug when using multi-pass fitting (#89)
     - [fitting] Fix a bug in CovarianceFit (#93)
     - [fitting] Remove deadcode in Basket (#86)
@@ -22,7 +23,7 @@ improved doc.
     - Fix WeightKernel test (failing on windows due to finite differences) (#91)
 
 -Docs
-    - [spatialPartitioning] Update module page with a minimal doc and examples (#86)
+    - [spatialPartitioning] Update module page with a minimal doc and examples (#86, #92)
     - [spatialPartitioning] Add NanoFlann example (#86)
 
 --------------------------------------------------------------------------------

--- a/Ponca/src/Fitting/mean.h
+++ b/Ponca/src/Fitting/mean.h
@@ -87,7 +87,7 @@ namespace Ponca {
             PROVIDES_MEAN_POSITION_DERIVATIVE,    /*!< \brief Provides derivative of the mean position*/
         };
 
-        /*! \brief Derivatives of the of the input points vectors */
+        /*! \brief Derivatives of the input points vectors */
         VectorArray m_dSumP {VectorArray::Zero()};
 
     public:

--- a/Ponca/src/Fitting/orientedSphereFit.h
+++ b/Ponca/src/Fitting/orientedSphereFit.h
@@ -135,7 +135,7 @@ public:
 
 }; //class OrientedSphereDerImpl
 
-/// \brief Helper alias for Plane fitting on 3D points using CovariancePlaneFitImpl
+/// \brief Helper alias for Oriented Sphere fitting on 3D points using OrientedSphereDerImpl
     template < class DataPoint, class _WFunctor, int DiffType, typename T>
     using OrientedSphereDer =
         OrientedSphereDerImpl<DataPoint, _WFunctor, DiffType,

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -300,7 +300,7 @@ protected:
     NodeContainer m_nodes;
     IndexContainer m_indices;
 
-    LeafSizeType m_min_cell_size;
+    LeafSizeType m_min_cell_size; ///< Minimal number of points per leaf
     NodeCountType m_leaf_count; ///< Number of leaves in the Kdtree (computed during construction)
 };
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
@@ -4,7 +4,10 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+
 #pragma once
+
+#include <Eigen/Geometry>
 
 namespace Ponca {
 #ifndef PARSED_WITH_DOXYGEN

--- a/doc/src/example.mdoc
+++ b/doc/src/example.mdoc
@@ -18,6 +18,7 @@
     - \subpage example_cu_ssc_page : Calculate Screen Space Curvature using CUDA/C++.
     - \subpage example_python_ssc_page : Calculate Screen Space Curvature using CUDA/Python.
   - @ref spatialpartitioning "Spatial Partitioning Module"
+    - \subpage example_cxx_neighbor_search : Nearest, k-nearest and range neighbor searches using Ponca::KdTree.
     - \subpage example_cxx_nanoflann_page : Comparison between Nanoflann and Ponca KdTree APIs.
 
  */

--- a/doc/src/example_cxx_neighbor_search.mdoc
+++ b/doc/src/example_cxx_neighbor_search.mdoc
@@ -1,0 +1,14 @@
+/*
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+
+/*!
+  \page example_cxx_neighbor_search Ponca::KdTree neighbor searches
+
+  This is an example of how to use Ponca::KdTree to perform nearest, k-nearest and range neighbor search.
+
+  \include cpp/ponca_neighbor_search.cpp
+*/

--- a/doc/src/ponca_module_spatialpartitioning.mdoc
+++ b/doc/src/ponca_module_spatialpartitioning.mdoc
@@ -42,8 +42,12 @@ namespace Ponca
   \note As queries are objets that are independent from the KdTree, they can be created and used in parallel from
   multiple threads.
 
+  \warning Queries from an index (KdTreeKNearestIndexQuery, KdTreeNearestIndexQuery and KdTreeRangeIndexQuery) do not iterate on the queried index.
+
   \subsection spatialpartitioning_kdtree_examples Examples
-  KdTree usage is demonstrated both in tests and examples:
+
+  Several KdTree queries are illustrated in the example \ref example_cxx_neighbor_search.
+  KdTree usage is also demonstrated both in tests and examples:
    - `tests/src/basket.cpp`
    - `tests/src/kdtree_knearest.cpp`
    - `tests/src/kdtree_nearest.cpp`
@@ -54,6 +58,16 @@ namespace Ponca
   Ponca::KdTreeBase is a customizable version of Ponca::KdTree, which can be controlled using `Traits`.
   See KdTreeDefaultTraits for customization API.
 
+  \subsection spatialpartitioning_kdtree_implementation Implementation details
+
+  The kd-tree is a binary search tree that
+  - is balanced (cuts at the median at each node)
+  - cuts along the dimension that extends the most at each node
+  - has a maximal depth (KdTreeDefaultTraits::MAX_DEPTH)
+  - has a minimal number of points per leaf (KdTreeBase::m_min_cell_size)
+  - only stores points in the leafs
+  - uses depth-first search with a static stack for queries
+  - keeps the initial order of points
 
   <center>[\ref user_manual_page "Go back to user manual"]</center>
  */

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -34,5 +34,13 @@ target_include_directories(ponca_fit_line PRIVATE ${PONCA_src_ROOT})
 add_dependencies(ponca-examples ponca_fit_line)
 ponca_handle_eigen_dependency(ponca_fit_line)
 
+set(ponca_neighbor_search_SRCS
+    ponca_neighbor_search.cpp
+)
+add_executable(ponca_neighbor_search ${ponca_neighbor_search_SRCS})
+target_include_directories(ponca_neighbor_search PRIVATE ${PONCA_src_ROOT})
+add_dependencies(ponca-examples ponca_neighbor_search)
+ponca_handle_eigen_dependency(ponca_neighbor_search)
+
 add_subdirectory(pcl)
 add_subdirectory(nanoflann)

--- a/examples/cpp/ponca_neighbor_search.cpp
+++ b/examples/cpp/ponca_neighbor_search.cpp
@@ -1,0 +1,74 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#include <iostream>
+#include <Ponca/SpatialPartitioning>
+#include <Eigen/Core>
+
+struct DataPoint
+{
+    enum {Dim = 3};
+    using Scalar = float;
+    using VectorType = Eigen::Vector<Scalar,Dim>;
+    inline const auto& pos() const {return m_pos;}
+    VectorType m_pos;
+};
+
+int main()
+{
+    // generate N random points
+    constexpr int N = 1e5;
+    std::vector<DataPoint> points(N);
+    std::generate(points.begin(), points.end(), [](){
+        return DataPoint{100 * DataPoint::VectorType::Random()};});
+
+    // build the k-d tree
+    const Ponca::KdTree<DataPoint> kdtree(points);
+
+    // neighbor searches are done below from these arbitrary index and point
+    const int query_idx = 10;
+    const DataPoint::VectorType query_pt{-10.0, 0.5, 75.0};
+
+    //
+    // nearest neighbor search
+    //
+    std::cout << "the nearest neighbor of the point at index " << query_idx << " is at index "
+              << *kdtree.nearest_neighbor(query_idx).begin() << std::endl;
+    std::cout << "the nearest neighbor of the point (" << query_pt.transpose() << ") is at index "
+              << *kdtree.nearest_neighbor(query_pt).begin() << std::endl;
+
+    //
+    // k-nearest neighbor search
+    //
+    constexpr int k = 10;
+    std::cout << "the " << k << "-nearest neighbors of the point at index " << query_idx << " are at indices: ";
+    for(int neighbor_idx : kdtree.k_nearest_neighbors(query_idx, k)) {
+        std::cout << neighbor_idx << ", ";
+    }
+    std::cout << std::endl;
+    std::cout << "the " << k << "-nearest neighbors of the point (" << query_pt.transpose() << ") are at indices: ";
+    for(auto neighbor_idx : kdtree.k_nearest_neighbors(query_pt, k)) {
+        std::cout << neighbor_idx << ", ";
+    }
+    std::cout << std::endl;
+
+    //
+    // range neighbor search
+    //
+    constexpr DataPoint::Scalar radius = 5.25;
+    std::cout << "the neighbors of the point at index " << query_idx << " at a distance " << radius << " are at indices: ";
+    for(int neighbor_idx : kdtree.range_neighbors(query_idx, radius)) {
+        std::cout << neighbor_idx << ", ";
+    }
+    std::cout << std::endl;
+    std::cout << "the neighbors of the point (" << query_pt.transpose() << ") at a distance " << radius << " are at indices: ";
+    for(auto neighbor_idx : kdtree.range_neighbors(query_pt, radius)) {
+        std::cout << neighbor_idx << ", ";
+    }
+    std::cout << std::endl;
+
+    return 1;
+}

--- a/tests/src/algebraicsphere_primitive.cpp
+++ b/tests/src/algebraicsphere_primitive.cpp
@@ -7,7 +7,7 @@
 
 /*!
     \file test/Grenaille/okabe_primitive.cpp
-    \brief Test validity Plane Primitive
+    \brief Test validity Algebraic Sphere Primitive
  */
 
 #include "../common/testing.h"

--- a/tests/src/dnormal_sphere.cpp
+++ b/tests/src/dnormal_sphere.cpp
@@ -25,7 +25,7 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
     typedef typename DataPoint::VectorType VectorType;
     typedef typename DataPoint::MatrixType MatrixType;
 
-    //generate sampled plane
+    //generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar radius = Eigen::internal::random<Scalar>(1,10);


### PR DESCRIPTION
This PR 
- add a small `Ponca::KdTree` example to illustrate the use of neighbor searches 
- improve the documentation of the kd-tree (warning about index iterators + implementation details) 
- add a missing include (for using `Eigen::AxisAligned`)
- fix a few comments