### PR TITLE
Change curvature convention to kmin <= kmax

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ improved doc.
 - API
     - [spatialPartitioning] Add kd-tree traits type (#80)
     - [fitting] Add Primitive::getNumNeighbors (#86)
+    - [fitting] Change naming convention and rational for principal curvatures in CurvatureEstimatorBase (#94)
 
 - Bug-fixes and code improvements
     - [spatialPartitioning] Fix unwanted function hiding with DryFit::setWeightFunc (#86)

--- a/Ponca/src/Fitting/curvature.h
+++ b/Ponca/src/Fitting/curvature.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "./defines.h"
-#include "../Common/Assert.h"
 
 #include <Eigen/Eigenvalues>
 #include <Eigen/Core>
@@ -77,7 +76,9 @@ namespace Ponca
     protected:
         /// \brief Set curvature values. To be called in finalize() by child classes
         ///
-        /// \warning Require \f$ k_{\min} <= k_{\max} \f$ and \f$ v_{\min} . v_{\max} = 0 \f$
+        /// If the given parameters are such that \f$ k_{\min} > k_{\max} \f$, then this
+        /// method swap the two curvature values and directions and store them such that
+        /// \f$ k_{\min} <= k_{\max} \f$.
         ///
         PONCA_MULTIARCH inline void setCurvatureValues(Scalar kmin, Scalar kmax, const VectorType& vmin, const VectorType& vmax);
     };

--- a/Ponca/src/Fitting/curvature.h
+++ b/Ponca/src/Fitting/curvature.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "./defines.h"
+#include "../Common/Assert.h"
 
 #include <Eigen/Eigenvalues>
 #include <Eigen/Core>
@@ -16,7 +17,8 @@ namespace Ponca
     template < class DataPoint, class _WFunctor, int DiffType, typename T>
 /**
  *
- * \brief Base class for any 3d curvature estimator: holds \f$k_1\f$, \f$k_2\f$ and associated vectors
+ * \brief Base class for any 3d curvature estimator: holds \f$k_{\min}\f$, \f$k_{\max}\f$ and associated vectors,
+ * such that \f$ k_{\min} <= k_{\max} \f$
  */
     class CurvatureEstimatorBase : public T
     {
@@ -30,14 +32,14 @@ namespace Ponca
         };
 
     private:
-        /// \brief Principal curvature with highest absolute magnitude
-        Scalar m_k1 {0},
-        /// \brief Principal curvature with smallest absolute magnitude
-        m_k2 {0};
-        /// \brief Direction associated to the principal curvature with highest absolute magnitude
-        VectorType m_v1 {VectorType::Zero()},
-        /// \brief Direction associated to the principal curvature with highest smallest magnitude
-        m_v2 {VectorType::Zero()};
+        /// \brief Minimal principal curvature
+        Scalar m_kmin {0},
+        /// \brief Maximal principal curvature
+        m_kmax {0};
+        /// \brief Direction associated to the minimal principal curvature
+        VectorType m_vmin {VectorType::Zero()},
+        /// \brief Direction associated to the maximal principal curvature
+        m_vmax {VectorType::Zero()};
 
         /// \brief Internal state indicating if the curvature are set to default (false), or have been computed (true)
         bool m_isValid {false};
@@ -54,38 +56,30 @@ namespace Ponca
         /**************************************************************************/
         /* Use results                                                            */
         /**************************************************************************/
-        //! \brief Returns an estimate of the first principal curvature value
-        //!
-        //! It is the greatest curvature in <b>absolute value</b>.
-        PONCA_MULTIARCH inline Scalar k1() const { return m_k1; }
+        //! \brief Returns an estimate of the minimal principal curvature value
+        PONCA_MULTIARCH inline Scalar kmin() const { return m_kmin; }
 
-        //! \brief Returns an estimate of the second principal curvature value
-        //!
-        //! It is the smallest curvature in <b>absolute value</b>.
-        PONCA_MULTIARCH inline Scalar k2() const { return m_k2; }
+        //! \brief Returns an estimate of the maximal principal curvature value
+        PONCA_MULTIARCH inline Scalar kmax() const { return m_kmax; }
 
-        //! \brief Returns an estimate of the first principal curvature direction
-        //!
-        //! It is the greatest curvature in <b>absolute value</b>.
-        PONCA_MULTIARCH inline VectorType k1Direction() const { return m_v1; }
+        //! \brief Returns an estimate of the minimal principal curvature direction
+        PONCA_MULTIARCH inline VectorType kminDirection() const { return m_vmin; }
 
-        //! \brief Returns an estimate of the second principal curvature direction
-        //!
-        //! It is the smallest curvature in <b>absolute value</b>.
-        PONCA_MULTIARCH inline VectorType k2Direction() const { return m_v2; }
+        //! \brief Returns an estimate of the maximal principal curvature direction
+        PONCA_MULTIARCH inline VectorType kmaxDirection() const { return m_vmax; }
 
         //! \brief Returns an estimate of the mean curvature
-        PONCA_MULTIARCH inline Scalar kMean() const { return (m_k1 + m_k2)/Scalar(2);}
+        PONCA_MULTIARCH inline Scalar kMean() const { return (m_kmin + m_kmax)/Scalar(2);}
 
         //! \brief Returns an estimate of the Gaussian curvature
-        PONCA_MULTIARCH inline Scalar GaussianCurvature() const { return m_k1 * m_k2;}
+        PONCA_MULTIARCH inline Scalar GaussianCurvature() const { return m_kmin * m_kmax;}
 
     protected:
         /// \brief Set curvature values. To be called in finalize() by child classes
         ///
-        /// Principal curvatures are re-ordered depending on their magnitude,
-        /// such that \f$ |k_1| > |k_2| \f$
-        PONCA_MULTIARCH inline void setCurvatureValues(Scalar k1, Scalar k2, const VectorType& v1, const VectorType& v2);
+        /// \warning Require \f$ k_{\min} <= k_{\max} \f$ and \f$ v_{\min} . v_{\max} = 0 \f$
+        ///
+        PONCA_MULTIARCH inline void setCurvatureValues(Scalar kmin, Scalar kmax, const VectorType& vmin, const VectorType& vmax);
     };
 
 } //namespace Ponca

--- a/Ponca/src/Fitting/curvature.hpp
+++ b/Ponca/src/Fitting/curvature.hpp
@@ -1,4 +1,3 @@
-#include PONCA_MULTIARCH_INCLUDE_STD(cmath)   //abs
 
 namespace Ponca {
     template<class DataPoint, class _WFunctor, int DiffType, typename T>
@@ -17,13 +16,17 @@ namespace Ponca {
     void
     CurvatureEstimatorBase<DataPoint, _WFunctor, DiffType, T>::setCurvatureValues(
             Scalar kmin, Scalar kmax, const VectorType &vmin, const VectorType &vmax) {
-        PONCA_MULTIARCH_STD_MATH(abs)
-        PONCA_DEBUG_ASSERT(kmin <= kmax);
-        PONCA_DEBUG_ASSERT(abs(vmin.dot(vmax)) < 0.001);
-        m_kmin = kmin;
-        m_kmax = kmax;
-        m_vmin = vmin;
-        m_vmax = vmax;
+        if(kmin <= kmax) {
+            m_kmin = kmin;
+            m_kmax = kmax;
+            m_vmin = vmin;
+            m_vmax = vmax;
+        } else {
+            m_kmin = kmax;
+            m_kmax = kmin;
+            m_vmin = vmax;
+            m_vmax = vmin;
+        }
         m_isValid = true;
     }
 }

--- a/Ponca/src/Fitting/curvature.hpp
+++ b/Ponca/src/Fitting/curvature.hpp
@@ -5,10 +5,10 @@ namespace Ponca {
     void
     CurvatureEstimatorBase<DataPoint, _WFunctor, DiffType, T>::init(const VectorType &_evalPos) {
         Base::init(_evalPos);
-        m_k1 = 0;
-        m_k2 = 0;
-        m_v1 = VectorType::Zero();
-        m_v2 = VectorType::Zero();
+        m_kmin = 0;
+        m_kmax = 0;
+        m_vmin = VectorType::Zero();
+        m_vmax = VectorType::Zero();
         m_isValid = false;
     }
 
@@ -16,21 +16,14 @@ namespace Ponca {
     template<class DataPoint, class _WFunctor, int DiffType, typename T>
     void
     CurvatureEstimatorBase<DataPoint, _WFunctor, DiffType, T>::setCurvatureValues(
-            Scalar k1, Scalar k2, const VectorType &v1, const VectorType &v2) {
+            Scalar kmin, Scalar kmax, const VectorType &vmin, const VectorType &vmax) {
         PONCA_MULTIARCH_STD_MATH(abs)
-
-        if (abs(k1) < abs(k2)) {
-            m_k1 = k2;
-            m_k2 = k1;
-            m_v1 = v2;
-            m_v2 = v1;
-        } else {
-            m_k1 = k1;
-            m_k2 = k2;
-            m_v1 = v1;
-            m_v2 = v2;
-        }
-
+        PONCA_DEBUG_ASSERT(kmin <= kmax);
+        PONCA_DEBUG_ASSERT(abs(vmin.dot(vmax)) < 0.001);
+        m_kmin = kmin;
+        m_kmax = kmax;
+        m_vmin = vmin;
+        m_vmax = vmax;
         m_isValid = true;
     }
 }

--- a/Ponca/src/Fitting/curvatureEstimation.hpp
+++ b/Ponca/src/Fitting/curvatureEstimation.hpp
@@ -148,19 +148,19 @@ NormalCovarianceCurvatureEstimator<DataPoint, _WFunctor, DiffType, T>::finalize 
 
         m_solver.computeDirect(m_cov);
 
-        Scalar k1 = m_solver.eigenvalues()(1);
-        Scalar k2 = m_solver.eigenvalues()(2);
+        Scalar kmin = m_solver.eigenvalues()(1);
+        Scalar kmax = m_solver.eigenvalues()(2);
 
-        VectorType v1 = m_solver.eigenvectors().col(1);
-        VectorType v2 = m_solver.eigenvectors().col(2);
+        VectorType vmin = m_solver.eigenvectors().col(1);
+        VectorType vmax = m_solver.eigenvectors().col(2);
 
         // fallback
         // TODO(thib) which epsilon value should be chosen ?
         Scalar epsilon = Scalar(1e-3);
-        if(k1<epsilon && k2<epsilon)
+        if(kmin<epsilon && kmax<epsilon)
         {
-            k1 = Scalar(0);
-            k2 = Scalar(0);
+            kmin = Scalar(0);
+            kmax = Scalar(0);
 
             // set principal directions from normals center of gravity
             VectorType n = m_cog.normalized();
@@ -168,15 +168,15 @@ NormalCovarianceCurvatureEstimator<DataPoint, _WFunctor, DiffType, T>::finalize 
             n.rowwise().squaredNorm().minCoeff(&i0);
             i1 = (i0+1)%3;
             i2 = (i0+2)%3;
-            v1[i0] = 0;
-            v1[i1] = n[i2];
-            v1[i2] = -n[i1];
-            v2[i0] = n[i1]*n[i1] + n[i2]*n[i2];
-            v2[i1] = -n[i1]*n[i0];
-            v2[i2] = -n[i2]*n[i0];
+            vmin[i0] = 0;
+            vmin[i1] = n[i2];
+            vmin[i2] = -n[i1];
+            vmax[i0] = n[i1]*n[i1] + n[i2]*n[i2];
+            vmax[i1] = -n[i1]*n[i0];
+            vmax[i2] = -n[i2]*n[i0];
         }
 
-        Base::setCurvatureValues(k1, k2, v1, v2);
+        Base::setCurvatureValues(kmin, kmax, vmin, vmax);
     }
     return res;
 }
@@ -259,8 +259,8 @@ ProjectedNormalCovarianceCurvatureEstimator<DataPoint, _WFunctor, DiffType, T>::
 
         m_solver.computeDirect(m_cov);
 
-        Base::m_k1 = m_solver.eigenvalues()(0);
-        Base::m_k2 = m_solver.eigenvalues()(1);
+        Base::m_kmin = m_solver.eigenvalues()(0);
+        Base::m_kmax = m_solver.eigenvalues()(1);
 
         // transform from local plane coordinates to world coordinates
         Base::m_v1 = m_tframe * m_solver.eigenvectors().col(0);
@@ -269,10 +269,10 @@ ProjectedNormalCovarianceCurvatureEstimator<DataPoint, _WFunctor, DiffType, T>::
         //TODO(thib) which epsilon value should be chosen ?
 //        Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision();
         Scalar epsilon = Scalar(1e-3);
-        if(Base::m_k1<epsilon && Base::m_k2<epsilon)
+        if(Base::m_kmin<epsilon && Base::m_kmax<epsilon)
         {
-            Base::m_k1 = Scalar(0);
-            Base::m_k2 = Scalar(0);
+            Base::m_kmin = Scalar(0);
+            Base::m_kmax = Scalar(0);
 
             // set principal directions from fitted plane
             Base::m_v2 = m_tframe.col(0);

--- a/doc/src/ponca_module_fitting.mdoc
+++ b/doc/src/ponca_module_fitting.mdoc
@@ -252,7 +252,7 @@ namespace Ponca
   \note There is currently no formal description of the API provided by each capability. This will be fixed in upcoming releases.
   These relations are currently implicitly defined (and used), but not documented.
   For instance, a tool with the capability `PROVIDES_PRINCIPAL_CURVATURES` provides the following methods:
-  `k1()`, `k2()`, `k1Direction()`, `k2Direction()`, `kMean()`, `GaussianCurvature()`, see CurvatureEstimatorBase.
+  `kmin()`, `kmax()`, `kminDirection()`, `kmaxDirection()`, `kMean()`, `GaussianCurvature()`, see CurvatureEstimatorBase.
 
   In order to ease tools combinations, each class declare a set of *required* and *provided* capabilities, as listed in the two following table:
 

--- a/examples/cpp/ponca_basic_cpu.cpp
+++ b/examples/cpp/ponca_basic_cpu.cpp
@@ -152,10 +152,10 @@ int main()
   if(fit3.isStable())
   {
     cout << "eigen values: "<< endl;
-    cout << fit3.k1() << endl;
-    cout << fit3.k2() << endl;
+    cout << fit3.kmin() << endl;
+    cout << fit3.kmax() << endl;
     cout << "eigen vectors: "<< endl;
-    cout << fit3.k1Direction() << endl << endl;
-    cout << fit3.k2Direction() << endl;
+    cout << fit3.kminDirection() << endl << endl;
+    cout << fit3.kmaxDirection() << endl;
   }
 }

--- a/tests/src/curvature_plane.cpp
+++ b/tests/src/curvature_plane.cpp
@@ -64,12 +64,12 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
         if( fit.isStable() ){
 
             // Check if principal curvature values are null
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k1()), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k2()), Scalar(1.), epsilon) );
+            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmin()), Scalar(1.), epsilon) );
+            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmax()), Scalar(1.), epsilon) );
 
             // Check if principal curvature directions lie on the plane
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k1Direction().dot(direction)), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k2Direction().dot(direction)), Scalar(1.), epsilon) );
+            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(direction)), Scalar(1.), epsilon) );
+            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(direction)), Scalar(1.), epsilon) );
         }
         else {
             VERIFY(FITTING_FAILED);

--- a/tests/src/curvature_sphere.cpp
+++ b/tests/src/curvature_sphere.cpp
@@ -60,23 +60,23 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
         if( fit.isStable() )
         {
             // Check if principal curvature values are equal to the inverse radius
-//            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k1()-curvature), Scalar(1.), epsilon) );
-//            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k2()-curvature), Scalar(1.), epsilon) );
+//            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmin()-curvature), Scalar(1.), epsilon) );
+//            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmax()-curvature), Scalar(1.), epsilon) );
 
             // Check if principal curvature directions are tangent to the sphere
             VectorType normal = (vectorPoints[i].pos()-center).normalized();
 
-            if(!Eigen::internal::isMuchSmallerThan(std::abs(fit.k1Direction().dot(normal)), Scalar(1.), epsilon) ||
-               !Eigen::internal::isMuchSmallerThan(std::abs(fit.k2Direction().dot(normal)), Scalar(1.), epsilon))
+            if(!Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(normal)), Scalar(1.), epsilon) ||
+               !Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(normal)), Scalar(1.), epsilon))
             {
-                Scalar dot1 = std::abs(fit.k1Direction().dot(normal));
-                Scalar dot2 = std::abs(fit.k2Direction().dot(normal));
+                Scalar dot1 = std::abs(fit.kminDirection().dot(normal));
+                Scalar dot2 = std::abs(fit.kmaxDirection().dot(normal));
                 cout << "dot1 = " << dot1 << endl;
                 cout << "dot2 = " << dot2 << endl;
             }
 
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k1Direction().dot(normal)), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.k2Direction().dot(normal)), Scalar(1.), epsilon) );
+            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(normal)), Scalar(1.), epsilon) );
+            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(normal)), Scalar(1.), epsilon) );
         }
         else {
             VERIFY(FITTING_FAILED);

--- a/tests/src/fit_radius_curvature_center.cpp
+++ b/tests/src/fit_radius_curvature_center.cpp
@@ -51,9 +51,9 @@ subTestSpatial<true, 3>::eval(const Fit& _fit,
                            Scalar /*_fitRadiusKappa*/,
                            Scalar /*_fitRadiusAlgebraic*/){
 
-    Scalar k1      = _fit.k1();
-    Scalar k2      = _fit.k2();
-    Scalar kmean   = (k1 + k2) / Scalar (2.);
+    Scalar kmin      = _fit.kmin();
+    Scalar kmax      = _fit.kmax();
+    Scalar kmean   = (kmin + kmax) / Scalar (2.);
     Scalar radius  = Scalar(1.) / kmean;
 
     //Test value

--- a/tests/src/gls_paraboloid_der.cpp
+++ b/tests/src/gls_paraboloid_der.cpp
@@ -204,8 +204,11 @@ void testFunction(bool isSigned = true)
       VectorType normal = flip_fit * fit.primitiveGradient().template cast<Scalar>();
 //       Scalar kmean = fit.kappa();
 
-      Scalar kappa1 = flip_fit * fit.k1();
-      Scalar kappa2 = flip_fit * fit.k2();
+      // principal curvatures k1,k2 are used here such that |k1| > |k2| (instead of kmin < kmax)
+      Scalar kmin = fit.kmin();
+      Scalar kmax = fit.kmax();
+      Scalar kappa1 = flip_fit * (std::abs(kmin)<std::abs(kmax) ? kmax : kmin);
+      Scalar kappa2 = flip_fit * (std::abs(kmin)<std::abs(kmax) ? kmin : kmax);
       Scalar kmeanFromK1K2 = (kappa1 + kappa2) * Scalar(.5);
       Scalar gaussian = fit.GaussianCurvature();
 


### PR DESCRIPTION
This PR changes the convention used to store principal curvatures in the `CurvatureEstimatorBase` class.
Before, `k1` and `k2` where stored such that `|k1| > |k2|`, which was the sources of issues such as discontinuities appearing in visualization.
Now, principal curvatures are renamed in `kmin` and `kmax` and verify `kmin < kmax`.

**Questions** 
Is it the responsability of the caller of `CurvatureEstimatorBase::setCurvatureValues` to ensure that `kmin <= kmax` ? 
Or should the class always check and swap the curvature values and direction if necessary ? 
Right now the first solution is implemented since `Eigen` often compute eigenvalues in this "natural" order, but that can be changed. 

Note that encapsulation is already private. There is still one unused class that try to access them directly using `Base::m_kmin = ...` (`ProjectedNormalCovarianceCurvatureEstimator`), but I think this class will be subject to some cleaning soon (I will investigate what `ProjectedNormalCovarianceCurvatureEstimator` and `NormalCovarianceCurvatureEstimator` are doing exactly).