### PR TITLE
Fix MlsSphereFitDer weight derivatives (issue #95)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,8 @@ improved doc.
     - [fitting] Fix a potential bug when using multi-pass fitting (#89)
     - [fitting] Fix a bug in CovarianceFit (#93)
     - [fitting] Remove deadcode in Basket (#86)
+    - [fitting] Fix a bug in dtau computation for scale-only derivation (#98)
+    - [fitting] Fix a bug in MlsSphereFitDer weight derivatives (#97)
     - [ci] Fix Compiler is out of heap space error on Github (MSVC), by splitting tests (#87)
 
 - Tests

--- a/Ponca/src/Fitting/mlsSphereFitDer.hpp
+++ b/Ponca/src/Fitting/mlsSphereFitDer.hpp
@@ -35,14 +35,14 @@ MlsSphereFitDer<DataPoint, _WFunctor, DiffType, T>::addLocalNeighbor(Scalar w,
         Matrix d2w = Matrix::Zero();
 
         if (Base::isScaleDer())
-            d2w(0,0) = Base::m_w.scaled2w(localQ, attributes);
+            d2w(0,0) = Base::m_w.scaled2w(attributes.pos(), attributes);
 
         if (Base::isSpaceDer())
-            d2w.template bottomRightCorner<Dim,Dim>() = Base::m_w.spaced2w(localQ, attributes);
+            d2w.template bottomRightCorner<Dim,Dim>() = Base::m_w.spaced2w(attributes.pos(), attributes);
 
         if (Base::isScaleDer() && Base::isSpaceDer())
         {
-            d2w.template bottomLeftCorner<Dim,1>() = Base::m_w.scaleSpaced2w(localQ,attributes);
+            d2w.template bottomLeftCorner<Dim,1>() = Base::m_w.scaleSpaced2w(attributes.pos(),attributes);
             d2w.template topRightCorner<1,Dim>() = d2w.template bottomLeftCorner<Dim,1>().transpose();
         }
 

--- a/Ponca/src/Fitting/weightFunc.h
+++ b/Ponca/src/Fitting/weightFunc.h
@@ -71,6 +71,8 @@ public:
     /*!
         \brief Compute the weight of the given query with respect to its coordinates.
 
+        \param _q Query in global coordinate
+
         As the query \f$\mathbf{q}\f$ is expressed in global coordinate, it is
         first converted to the centered basis. Then, the WeightKernel is directly
         applied to the norm of its coordinates with respect to the current scale  \f$ t \f$ :
@@ -86,6 +88,8 @@ public:
 
     /*!
         \brief First order derivative in space (for each spatial dimension \f$\mathsf{x})\f$
+
+        \param _q Query in global coordinate
 
         \f$ \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}
         \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t})
@@ -103,6 +107,8 @@ public:
 
     /*!
         \brief Second order derivative in space (for each spatial dimension \f$\mathsf{x})\f$
+
+        \param _q Query in global coordinate
 
         \f$ \frac{\delta^2 \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}^2}
         \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
@@ -125,6 +131,8 @@ public:
     /*!
         \brief First order derivative in scale  \f$t\f$
 
+        \param _q Query in global coordinate
+
         \f$ \frac{\delta \frac{\left|\mathbf{q}\right|}{t}}{\delta t}
         \nabla w(\frac{\left|\mathbf{q}\right|}{t})
         = - \frac{\left|\mathbf{q}\right|}{t^2} \nabla{w(\frac{\left|\mathbf{q}\right|}{t})} \f$
@@ -139,6 +147,8 @@ public:
 
     /*!
         \brief Second order derivative in scale  \f$t\f$
+
+        \param _q Query in global coordinate
 
         \f$ \frac{\delta^2 \frac{\left|\mathbf{q}\right|}{t}}{\delta t^2}
         \nabla w(\frac{\left|\mathbf{q}\right|}{t}) +
@@ -158,6 +168,8 @@ public:
 
     /*!
         \brief Cross derivative in scale \f$t\f$ and in space (for each spatial dimension \f$\mathsf{x})\f$
+
+        \param _q Query in global coordinate
 
         \f$ \frac{\delta^2 \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta t\ \delta \mathsf{x}}
         \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +


### PR DESCRIPTION
Here is a quick fix to the issue  #95.
The basis center is added to the local point to get back the point in global coordinates, and then call weight derivatives functions. 

Small disadvantage: the basis center is added here, but then subtracted in the weight function, so it is not the most efficient solution (except if the compiler is good enough to avoid these successive additions and substractions).

 

