### PR TITLE
KnnGraph: replace flag table by set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ Ponca changelog
 --------------------------------------------------------------------------------
 Current head (v.1.2 RC)
 
+- API
+    - [spatialPartitioning] Optimize memory use in knngraph queries (#104)
 - Examples
     - Fix example cuda/ponca_ssgls (#109)
 


### PR DESCRIPTION
Change internal implementation of the visited flag table: all points visited by the knn graphs are stored in a set, instead a fixed-size flag table.
This avoids to allocate tables of the size of the point cloud for each query.