### PR TITLE
Fix current status (issue #100)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,10 @@ Current head (v.1.2 RC)
 
 - Bug-fixes and code improvements
     - [fitting] Use variadic template for basket extensions (#85)
+    - [fitting] Fix current status issue (#108)
+
+-Docs
+    - [fitting] Clarify documentation on FIT_RESULT (#108)
 
 --------------------------------------------------------------------------------
 v.1.1 RC

--- a/Ponca/src/Fitting/covarianceFit.hpp
+++ b/Ponca/src/Fitting/covarianceFit.hpp
@@ -35,11 +35,11 @@ FIT_RESULT
 CovarianceFitBase<DataPoint, _WFunctor, T>::finalize ()
 {
     // handle specific configurations
+    if(Base::finalize() != STABLE) 
+        return Base::m_eCurrentState;
     // With less than 3 neighbors the fitting is undefined
-    if(Base::finalize() != STABLE || Base::getNumNeighbors() < 3)
-    {
+    if(Base::getNumNeighbors() < 3)
         return Base::m_eCurrentState = UNDEFINED;
-    }
 
     // Center the covariance on the centroid
     auto centroid = Base::barycenter();

--- a/Ponca/src/Fitting/covarianceFit.hpp
+++ b/Ponca/src/Fitting/covarianceFit.hpp
@@ -37,8 +37,8 @@ CovarianceFitBase<DataPoint, _WFunctor, T>::finalize ()
     // handle specific configurations
     if(Base::finalize() != STABLE) 
         return Base::m_eCurrentState;
-    // With less than 3 neighbors the fitting is undefined
-    if(Base::getNumNeighbors() < 3)
+    // With less than Dim neighbors the fitting is undefined
+    if(Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
 
     // Center the covariance on the centroid

--- a/Ponca/src/Fitting/covarianceLineFit.h
+++ b/Ponca/src/Fitting/covarianceLineFit.h
@@ -50,8 +50,10 @@ public:
     PONCA_MULTIARCH inline FIT_RESULT finalize()
     {
         static const int smallestEigenValue = DataPoint::Dim - 1;
-        if (Base::finalize() == STABLE)
+        if (Base::finalize() == STABLE) {
+            if (Base::line().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
             Base::setLine(Base::barycenter(), Base::m_solver.eigenvectors().col(smallestEigenValue).normalized());
+        }
         return Base::m_eCurrentState;
     }
 };

--- a/Ponca/src/Fitting/enums.h
+++ b/Ponca/src/Fitting/enums.h
@@ -9,18 +9,16 @@
 namespace Ponca
 {
    /*!
-      Enum corresponding to the state of a fitting method (and what the finalize function can return
+      Enum corresponding to the state of a fitting method (and what the finalize function returns)
     */
     enum FIT_RESULT : unsigned char
     {
-        /*! \brief The fitting is stable an ready to use (and having more than 6
-          neighbours)*/
+        /*! \brief The fitting is stable and ready to use*/
         STABLE    = 0,
-        /*! \brief The fitting is ready to use but it can be unstable (and
-          having between 3 and 6 neighbors)*/
+        /*! \brief The fitting is ready to use but it is considered 
+        as unstable (if the number of neighbors is low for example)*/
         UNSTABLE  = 1,
-        /*! \brief The fitting is undefined, you can't use it for valid results
-          (and having less than 3 neighbors)*/
+        /*! \brief The fitting is undefined, you can't use it for valid results*/
         UNDEFINED = 2,
         /*! \brief The fitting procedure needs to analyse the neighborhood
           another time*/

--- a/Ponca/src/Fitting/orientedSphereFit.hpp
+++ b/Ponca/src/Fitting/orientedSphereFit.hpp
@@ -41,8 +41,10 @@ OrientedSphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     PONCA_MULTIARCH_STD_MATH(abs);
 
     // Compute status
-    if(Base::finalize() != STABLE  || Base::getNumNeighbors() < 3)
+    if(Base::finalize() != STABLE)
         return Base::m_eCurrentState;
+    if(Base::getNumNeighbors() < 3)
+        return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else

--- a/Ponca/src/Fitting/orientedSphereFit.hpp
+++ b/Ponca/src/Fitting/orientedSphereFit.hpp
@@ -43,12 +43,12 @@ OrientedSphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     // Compute status
     if(Base::finalize() != STABLE)
         return Base::m_eCurrentState;
-    if(Base::getNumNeighbors() < 3)
+    if(Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::getNumNeighbors() < 6 ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 2*DataPoint::Dim ? UNSTABLE : STABLE;
 
     // 1. finalize sphere fitting
     Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision();

--- a/Ponca/src/Fitting/primitive.h
+++ b/Ponca/src/Fitting/primitive.h
@@ -120,9 +120,7 @@ public:
     PONCA_FITTING_APIDOC_FINALIZE
     PONCA_MULTIARCH inline FIT_RESULT finalize(){
         // handle specific configurations
-        // We need to have at least one neighbor to compute the mean
         if (m_sumW == Scalar(0.) || m_nbNeighbors < 1) {
-            init( m_w.basisCenter() );
             return m_eCurrentState = UNDEFINED;
         }
         return m_eCurrentState = STABLE;

--- a/Ponca/src/Fitting/sphereFit.hpp
+++ b/Ponca/src/Fitting/sphereFit.hpp
@@ -43,12 +43,12 @@ SphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     // Compute status
     if(Base::finalize() != STABLE)
         return Base::m_eCurrentState;
-    if(Base::getNumNeighbors() < 3)
+    if(Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::getNumNeighbors() < 6 ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 2*DataPoint::Dim ? UNSTABLE : STABLE;
 
     MatrixA matC;
     matC.setIdentity();

--- a/Ponca/src/Fitting/sphereFit.hpp
+++ b/Ponca/src/Fitting/sphereFit.hpp
@@ -41,7 +41,9 @@ FIT_RESULT
 SphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
 {
     // Compute status
-    if(Base::finalize() != STABLE || Base::getNumNeighbors() < 3)
+    if(Base::finalize() != STABLE)
+        return Base::m_eCurrentState;
+    if(Base::getNumNeighbors() < 3)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;

--- a/Ponca/src/Fitting/unorientedSphereFit.hpp
+++ b/Ponca/src/Fitting/unorientedSphereFit.hpp
@@ -90,8 +90,10 @@ UnorientedSphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     constexpr int Dim = DataPoint::Dim;
 
     // Compute status
-    if(Base::finalize() != STABLE || Base::getNumNeighbors() < 3)
+    if(Base::finalize() != STABLE)
         return Base::m_eCurrentState;
+    if(Base::getNumNeighbors() < 3)
+        return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else

--- a/Ponca/src/Fitting/unorientedSphereFit.hpp
+++ b/Ponca/src/Fitting/unorientedSphereFit.hpp
@@ -92,12 +92,12 @@ UnorientedSphereFitImpl<DataPoint, _WFunctor, T>::finalize ()
     // Compute status
     if(Base::finalize() != STABLE)
         return Base::m_eCurrentState;
-    if(Base::getNumNeighbors() < 3)
+    if(Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::getNumNeighbors() < 6 ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 2*DataPoint::Dim ? UNSTABLE : STABLE;
 
     // 1. finalize sphere fitting
     Scalar invSumW = Scalar(1.) / Base::getWeightSum();


### PR DESCRIPTION
This PR mainly fixes issue #100
It also improves
- the doc on `FIT_RESULT`
- the primitive base finalize
- the check on conflict

I have just a few questions or remarks
- the number of neighbors used to determine if a fit is stable or not should depends on the dimension right? For example, a PCA in 2D is stable with 2 neighbors, in 3D with 3 neighbors, etc... I wanted to be sure if it is correct for every fitting procedure and if it is pertinent to add this
- note that fitting an oriented sphere to 1 point and 1 normal vector in any dimension is always stable as it simply returns the plane that passes by this point with a normal equal to the normal of the input point. For 2 points in 2D I believe it is also quite stable in general. That being said, I am not sure for 2 points in 3D, the sphere fit may be good but the derivatives, the GLS, etc, may not be as good, and the stability may depends on the weighting function that is used, so it is safe to keep these thresholds in the end
- the file `linePrimitive.h` has the `Primive` kew-work in its title, whereas other primitives do not have it. For consistency, should we add it to the plane and algebraic sphere file name, or should we remove it from the line file name?
