### PR TITLE
[Fitting] Make base typedef of fitting types protected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ Current head (v.1.2 RC)
 
 - API
     - [spatialPartitioning] Optimize memory use in knngraph queries (#104)
+    - [fitting] Mark `Base` type as protected instead of private in CRTP classes (#119)
+
 - Examples
     - Fix example cuda/ponca_ssgls (#109)
 

--- a/Ponca/src/Fitting/defines.h
+++ b/Ponca/src/Fitting/defines.h
@@ -44,7 +44,7 @@ const CLASSNAME<DataPoint, _WFunctor, DiffType, T>& CONVERTER() const           
 
 /// Declare the following defaults types: Base, Scalar, VectorType, WFunctor
 #define PONCA_FITTING_DECLARE_DEFAULT_TYPES                                                                         \
-private:                                                                                                            \
+protected:                                                                                                          \
 using Base = T;  /*!< \brief Base class of the procedure*/                                                          \
 public:                                                                                                             \
 using Scalar     = typename DataPoint::Scalar; /*!< \brief Alias to scalar type*/                                   \


### PR DESCRIPTION
In some use cases, having recursive access to the `Base` typedef of fitting types throughout a basket (i.e. going up the hierarchy tree of the CRTP) can be useful. This PR makes this typedef protected instead of private to allow for such recursive access.
