### PR TITLE
[SpatialPartitioning] Clean up kdtree API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Current head (v.1.2 RC)
 
 - API
     - [spatialPartitioning] Optimize memory use in knngraph queries (#104)
+    - [spatialPartitioning] Clean KdTree API (#122)
     - [fitting] Mark `Base` type as protected instead of private in CRTP classes (#119)
     - [fitting] Improve KdTreeNodes API by hiding internal memory layout, improve methods naming (#120)
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -185,11 +185,6 @@ public:
                                   IndexUserContainer sampling,
                                   Converter c);
 
-
-    /// Update sampling of an existing tree
-    template<typename IndexUserContainer>
-    inline void rebuild(IndexUserContainer sampling); // IndexUserContainer => Given by user, transformed to IndexContainer
-
     inline bool valid() const;
     inline std::string to_string() const;
 
@@ -230,17 +225,7 @@ public:
         return m_nodes;
     }
 
-    inline NodeContainer& node_data()
-    {
-        return m_nodes;
-    }
-
     inline const IndexContainer& index_data() const
-    {
-        return m_indices;
-    }
-
-    inline IndexContainer& index_data()
     {
         return m_indices;
     }


### PR DESCRIPTION
This PR removes some unused functions from the kd-tree API, as well as functions that should not be exposed (e.g. non const accessors to internal data).

This PR also fixes the `valid` function of the kd-tree that used to crash immediately upon entry in debug.