### PR TITLE
[SpatialPartitioning] Change part of the kdtree API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ Ponca changelog
 --------------------------------------------------------------------------------
 Current head (v.1.3 RC)
 
+- API
+    - [SpatialPartitioning] Change part of the kdtree API (#123)
 
 --------------------------------------------------------------------------------
 v.1.2
@@ -16,7 +18,6 @@ This release introduces several bug fixes and minor improvements.
     - [spatialPartitioning] Simplify node customization (#128)
     - [fitting] Mark `Base` type as protected instead of private in CRTP classes (#119)
     - [fitting] Improve KdTreeNodes API by hiding internal memory layout, improve methods naming (#120)
-    - [SpatialPartitioning] Change part of the kdtree API (#123)
 
 - Examples
     - Fix example cuda/ponca_ssgls (#109)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ This release introduces several bug fixes and minor improvements.
     - [spatialPartitioning] Simplify node customization (#128)
     - [fitting] Mark `Base` type as protected instead of private in CRTP classes (#119)
     - [fitting] Improve KdTreeNodes API by hiding internal memory layout, improve methods naming (#120)
+    - [SpatialPartitioning] Change part of the kdtree API (#123)
 
 - Examples
     - Fix example cuda/ponca_ssgls (#109)

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestQueries.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestQueries.h
@@ -41,7 +41,7 @@ public:
 
 protected:
     inline void search(){
-        KdTreeQuery<Traits>::search_internal(QueryType::getInputPosition(QueryAccelType::m_kdtree->point_data()),
+        KdTreeQuery<Traits>::search_internal(QueryType::getInputPosition(QueryAccelType::m_kdtree->points()),
                                              [](IndexType, IndexType){},
                                              [this](){return QueryType::descentDistanceThreshold();},
                                              [this](IndexType idx){return QueryType::skipIndexFunctor(idx);},

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestQueries.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestQueries.h
@@ -41,7 +41,7 @@ public:
 
 protected:
     inline void search(){
-        KdTreeQuery<Traits>::search_internal(QueryType::getInputPosition(QueryAccelType::m_kdtree->point_data()),
+        KdTreeQuery<Traits>::search_internal(QueryType::getInputPosition(QueryAccelType::m_kdtree->points()),
                                              [](IndexType, IndexType){},
                                              [this](){return QueryType::descentDistanceThreshold();},
                                              [this](IndexType idx){return QueryType::skipIndexFunctor(idx);},

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeQuery.h
@@ -44,9 +44,9 @@ protected:
                          ProcessNeighborFunctor processNeighborFunctor
                          )
     {
-        const auto& nodes   = m_kdtree->node_data();
-        const auto& points  = m_kdtree->point_data();
-        const auto& indices = m_kdtree->index_data();
+        const auto& nodes   = m_kdtree->nodes();
+        const auto& points  = m_kdtree->points();
+        const auto& indices = m_kdtree->samples();
 
         if (nodes.empty() || points.empty() || indices.empty())
             throw std::invalid_argument("Empty KdTree");

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeQueries.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeQueries.h
@@ -47,8 +47,8 @@ public:
 
 protected:
     inline void advance(Iterator& it){
-        const auto& points  = QueryAccelType::m_kdtree->point_data();
-        const auto& indices = QueryAccelType::m_kdtree->index_data();
+        const auto& points  = QueryAccelType::m_kdtree->points();
+        const auto& indices = QueryAccelType::m_kdtree->samples();
         const auto& point   = QueryType::getInputPosition(points);
 
         auto descentDistanceThreshold = [this](){return QueryType::descentDistanceThreshold();};

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -8,6 +8,7 @@
 
 #include "./kdTreeTraits.h"
 
+#include <iostream>
 #include <memory>
 #include <numeric>
 #include <type_traits>
@@ -186,7 +187,7 @@ public:
                                   Converter c);
 
     inline bool valid() const;
-    inline std::string to_string(bool verbose = false) const;
+    inline void print(std::ostream& os, bool verbose = false) const;
 
     // Accessors ---------------------------------------------------------------
 public:
@@ -195,7 +196,7 @@ public:
         return m_nodes.size();
     }
 
-    inline IndexType index_count() const
+    inline IndexType sample_count() const
     {
         return (IndexType)m_indices.size();
     }
@@ -210,22 +211,22 @@ public:
         return m_leaf_count;
     }
 
-    inline PointContainer& point_data()
+    inline PointContainer& points()
     {
         return m_points;
     };
 
-    inline const PointContainer& point_data() const
+    inline const PointContainer& points() const
     {
         return m_points;
     };
 
-    inline const NodeContainer& node_data() const
+    inline const NodeContainer& nodes() const
     {
         return m_nodes;
     }
 
-    inline const IndexContainer& index_data() const
+    inline const IndexContainer& samples() const
     {
         return m_indices;
     }
@@ -295,3 +296,10 @@ protected:
 
 #include "./kdTree.hpp"
 } // namespace Ponca
+
+template <typename Traits>
+std::ostream& operator<<(std::ostream& os, Ponca::KdTreeBase<Traits>& kdtree)
+{
+    kdtree.print(os);
+    return os;
+}

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -298,7 +298,7 @@ protected:
 } // namespace Ponca
 
 template <typename Traits>
-std::ostream& operator<<(std::ostream& os, Ponca::KdTreeBase<Traits>& kdtree)
+std::ostream& operator<<(std::ostream& os, const Ponca::KdTreeBase<Traits>& kdtree)
 {
     kdtree.print(os);
     return os;

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -42,7 +42,7 @@ inline void KdTreeBase<Traits>::buildWithSampling(PointUserContainer&& points,
 
     m_indices = std::move(sampling);
 
-    this->build_rec(0, 0, index_count(), 1);
+    this->build_rec(0, 0, sample_count(), 1);
 
     PONCA_DEBUG_ASSERT(this->valid());
 }
@@ -73,7 +73,7 @@ bool KdTreeBase<Traits>::valid() const
         const NodeType& node = m_nodes[n];
         if(node.is_leaf())
         {
-            if(index_count() <= node.leaf_start() || node.leaf_start()+node.leaf_size() > index_count())
+            if(sample_count() <= node.leaf_start() || node.leaf_start()+node.leaf_size() > sample_count())
             {
                 return false;
             }
@@ -95,52 +95,48 @@ bool KdTreeBase<Traits>::valid() const
 }
 
 template<typename Traits>
-std::string KdTreeBase<Traits>::to_string(bool verbose) const
+void KdTreeBase<Traits>::print(std::ostream& os, bool verbose) const
 {
-    std::stringstream str;
-
-    str << "KdTree:";
-    str << "\n  MaxNodes: " << MAX_NODE_COUNT;
-    str << "\n  MaxPoints: " << MAX_POINT_COUNT;
-    str << "\n  MaxDepth: " << Traits::MAX_DEPTH;
-    str << "\n  PointCount: " << point_count();
-    str << "\n  SampleCount: " << index_count();
-    str << "\n  NodeCount: " << node_count();
+    os << "KdTree:";
+    os << "\n  MaxNodes: " << MAX_NODE_COUNT;
+    os << "\n  MaxPoints: " << MAX_POINT_COUNT;
+    os << "\n  MaxDepth: " << Traits::MAX_DEPTH;
+    os << "\n  PointCount: " << point_count();
+    os << "\n  SampleCount: " << index_count();
+    os << "\n  NodeCount: " << node_count();
 
     if (!verbose)
     {
-        return str.str();
+        return;
     }
 
-    str << "\n  Samples: [";
+    os << "\n  Samples: [";
     static constexpr IndexType SAMPLES_PER_LINE = 10;
     for (IndexType i = 0; i < index_count(); ++i)
     {
-        str << (i == 0 ? "" : ",");
-        str << (i % SAMPLES_PER_LINE == 0 ? "\n    " : " ");
-        str << m_indices[i];
+        os << (i == 0 ? "" : ",");
+        os << (i % SAMPLES_PER_LINE == 0 ? "\n    " : " ");
+        os << m_indices[i];
     }
 
-    str << "]\n  Nodes:";
+    os << "]\n  Nodes:";
     for (NodeIndexType n = 0; n < node_count(); ++n)
     {
         const NodeType& node = m_nodes[n];
         if (node.is_leaf())
         {
-            str << "\n    - Type: Leaf";
-            str << "\n      Start: " << node.leaf_start();
-            str << "\n      Size: " << node.leaf_size();
+            os << "\n    - Type: Leaf";
+            os << "\n      Start: " << node.leaf_start();
+            os << "\n      Size: " << node.leaf_size();
         }
         else
         {
-            str << "\n    - Type: Inner";
-            str << "\n      SplitDim: " << node.inner_split_dim();
-            str << "\n      SplitValue: " << node.inner_split_value();
-            str << "\n      FirstChild: " << node.inner_first_child_id();
+            os << "\n    - Type: Inner";
+            os << "\n      SplitDim: " << node.inner_split_dim();
+            os << "\n      SplitValue: " << node.inner_split_value();
+            os << "\n      FirstChild: " << node.inner_first_child_id();
         }
     }
-
-    return str.str();
 }
 
 template<typename Traits>

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -102,7 +102,7 @@ void KdTreeBase<Traits>::print(std::ostream& os, bool verbose) const
     os << "\n  MaxPoints: " << MAX_POINT_COUNT;
     os << "\n  MaxDepth: " << Traits::MAX_DEPTH;
     os << "\n  PointCount: " << point_count();
-    os << "\n  SampleCount: " << index_count();
+    os << "\n  SampleCount: " << sample_count();
     os << "\n  NodeCount: " << node_count();
 
     if (!verbose)
@@ -112,7 +112,7 @@ void KdTreeBase<Traits>::print(std::ostream& os, bool verbose) const
 
     os << "\n  Samples: [";
     static constexpr IndexType SAMPLES_PER_LINE = 10;
-    for (IndexType i = 0; i < index_count(); ++i)
+    for (IndexType i = 0; i < sample_count(); ++i)
     {
         os << (i == 0 ? "" : ",");
         os << (i % SAMPLES_PER_LINE == 0 ? "\n    " : " ");

--- a/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
@@ -70,8 +70,8 @@ public:
     /// \warning KdTreeTraits compatibility is checked with static assertion
     template<typename KdTreeTraits>
     inline KnnGraphBase(const KdTreeBase<KdTreeTraits>& kdtree, int k = 6)
-            : m_k(std::min(k,kdtree.index_count()-1)),
-              m_kdTreePoints(kdtree.point_data())
+            : m_k(std::min(k,kdtree.sample_count()-1)),
+              m_kdTreePoints(kdtree.points())
     {
         static_assert( std::is_same<typename Traits::DataPoint, typename KdTreeTraits::DataPoint>::value,
                        "KdTreeTraits::DataPoint is not equal to Traits::DataPoint" );
@@ -85,7 +85,7 @@ public:
         // \fixme Update API to properly handle kdtree subsampling
         const int cloudSize   = kdtree.point_count();
         {
-            const int samplesSize = kdtree.index_count();
+            const int samplesSize = kdtree.sample_count();
             eigen_assert(cloudSize == samplesSize);
         }
 

--- a/examples/cpp/ponca_basic_cpu.cpp
+++ b/examples/cpp/ponca_basic_cpu.cpp
@@ -89,7 +89,7 @@ void test_fit(Fit& _fit, const KdTree<MyPoint>& tree, const VectorType& _p)
   // Iterate over samples and _fit the primitive
   for(int i : tree.range_neighbors(_p, tmax) )
   {
-      _fit.addNeighbor( tree.point_data()[i] );
+      _fit.addNeighbor( tree.points()[i] );
   }
 
   //finalize fitting

--- a/examples/cpp/ponca_customize_kdtree.cpp
+++ b/examples/cpp/ponca_customize_kdtree.cpp
@@ -80,7 +80,7 @@ int main()
               << *kdtree.nearest_neighbor(query_pt).begin() << std::endl;
 
     //! [ReadCustomProperties]
-    auto bbox = kdtree.node_data()[0].getAabb();
+    auto bbox = kdtree.nodes()[0].getAabb();
     if (bbox) {
         std::cout << "Root bounding box is as follows: \n"
                   << "  Center:   " << bbox->center()

--- a/tests/src/basket.cpp
+++ b/tests/src/basket.cpp
@@ -70,7 +70,7 @@ void testBasicFunctionalities(const KdTree<typename Fit::DataPoint>& tree, typen
     typedef typename DataPoint::VectorType VectorType;
     typedef typename Fit::WFunctor WeightFunc;
 
-    const auto& vectorPoints = tree.point_data();
+    const auto& vectorPoints = tree.points();
 
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG
@@ -135,7 +135,7 @@ void testIsSame(const KdTree<typename Fit1::DataPoint>& tree,
     typedef typename Fit1::Scalar     Scalar;
     typedef typename Fit1::VectorType VectorType;
     typedef typename Fit1::WFunctor   WeightFunc;
-    const auto& vectorPoints = tree.point_data();
+    const auto& vectorPoints = tree.points();
 
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG


### PR DESCRIPTION
This PR renames some of the KdTree accessors and changes its `to_string` method to a `print` method taking an `std::ostream` as argument. This PR also adds an `operator<<` overload for the KdTree.

Most notably, the `index_data` method was renamed to `samples` to work on solving the confusion raised by how the KdTree handles sampling (see #114).