### PR TITLE
Fix sphere gradient (#118)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Current head (v.1.2 RC)
     - [spatialPartitioning] Fix potential compilation issues in KnnGraph (#111) 
     - [spatialPartitioning] Fix debug macros in KnnGraphRangeQuery (#121)
     - [fitting] Fix sphere fit eigen solver (#112)
+    - [fitting] Fix a bug in AlgebraicSphere::primtiveGradient (#127)
     - [spatialPartitioning] Improve kdtree to_string to output data in YAML format (#125)
 
 -Docs

--- a/Ponca/src/Fitting/algebraicSphere.h
+++ b/Ponca/src/Fitting/algebraicSphere.h
@@ -249,7 +249,7 @@ public:
     PONCA_MULTIARCH inline VectorType primitiveGradient (const VectorType& _q) const;
 
     /*! \brief Approximation of the scalar field gradient at the evaluation point */
-    PONCA_MULTIARCH inline VectorType primitiveGradient () const { return m_ul.normalized(); }
+    PONCA_MULTIARCH inline VectorType primitiveGradient () const { return m_ul; }
 
     /*!
         \brief Used to know if the fitting result to a plane

--- a/Ponca/src/Fitting/algebraicSphere.h
+++ b/Ponca/src/Fitting/algebraicSphere.h
@@ -249,7 +249,7 @@ public:
     PONCA_MULTIARCH inline VectorType primitiveGradient (const VectorType& _q) const;
 
     /*! \brief Approximation of the scalar field gradient at the evaluation point */
-    PONCA_MULTIARCH inline VectorType primitiveGradient () const { return m_ul; }
+    PONCA_MULTIARCH inline const VectorType& primitiveGradient () const { return m_ul; }
 
     /*!
         \brief Used to know if the fitting result to a plane

--- a/Ponca/src/Fitting/algebraicSphere.h
+++ b/Ponca/src/Fitting/algebraicSphere.h
@@ -245,10 +245,12 @@ public:
      */
     PONCA_MULTIARCH inline VectorType projectDescent (const VectorType& _q, int nbIter = 16) const;
 
-    //! \brief Approximation of the scalar field gradient at \f$ \mathbf{q} (not normalized) \f$
+    /*! \brief Approximation of the scalar field gradient at \f$ \mathbf{q}\f$
+        \warning The gradient is not normalized by default */
     PONCA_MULTIARCH inline VectorType primitiveGradient (const VectorType& _q) const;
 
-    /*! \brief Approximation of the scalar field gradient at the evaluation point */
+    /*! \brief Approximation of the scalar field gradient at the evaluation point
+        \warning The gradient is not normalized by default */
     PONCA_MULTIARCH inline const VectorType& primitiveGradient () const { return m_ul; }
 
     /*!

--- a/tests/src/gls_paraboloid_der.cpp
+++ b/tests/src/gls_paraboloid_der.cpp
@@ -159,7 +159,7 @@ void testFunction(bool isSigned = true)
 //         dTau(k)    = ( f.tau()   - ref_fit.tau()   ) / h;
 
         dPotential(k) = ( flip_f*f.potential() - flip_ref * ref_fit.potential()   ) / h;
-        dN.col(k)     = ( flip_f*f.primitiveGradient()    - flip_ref * ref_fit.primitiveGradient()      ) / h;
+        dN.col(k)     = ( flip_f*f.primitiveGradient().normalized() - flip_ref * ref_fit.primitiveGradient().normalized() ) / h;
 //         dKappa(k)     = ( f.kappa() - ref_fit.kappa() ) / h;
       }
 


### PR DESCRIPTION
Fix #118 
- remove normalization of the gradient of the algebraic sphere in `primitveGradient()`
- the test `gls_paraboloid_der` estimates the derivative of the normal using finite difference on the gradient, so a call to `normalized()` on the gradient is added in this test

