### PR TITLE
[Fitting] Expose barycenter and add barycenterLocal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ Ponca changelog
 --------------------------------------------------------------------------------
 Current head (v.1.3 RC)
 
+- Breaking Changes
+    - [fitting] Fix bad design where public barycenter() function was expressed in local coordinate (#141)
+
 - API
     - [SpatialPartitioning] Change part of the kdtree API (#123)
     - [spatialPartitioning] Refactor KdTree into KdTreeDense + KdTreeSparse (#129)

--- a/Ponca/src/Fitting/algebraicSphere.h
+++ b/Ponca/src/Fitting/algebraicSphere.h
@@ -214,7 +214,7 @@ public:
         }
 
         Scalar b = Scalar(1.)/m_uq;
-        return (Scalar(-0.5)*b)*m_ul + Base::m_w.basisCenter();
+        return Base::m_w.convertToGlobalBasis((Scalar(-0.5)*b)*m_ul);
     }
 
     //! \brief State indicating when the sphere has been normalized

--- a/Ponca/src/Fitting/algebraicSphere.hpp
+++ b/Ponca/src/Fitting/algebraicSphere.hpp
@@ -26,7 +26,7 @@ AlgebraicSphere<DataPoint, _WFunctor, T>::project(const VectorType& _q) const
     {
         t = - (norm - sqrt(norm*norm - Scalar(4) * m_uq * potential)) / (Scalar(2) * m_uq * norm);
     }
-    return Base::m_w.basisCenter() + lq + t * grad;
+    return Base::m_w.convertToGlobalBasis( lq + t * grad );
 }
 
 template < class DataPoint, class _WFunctor, typename T>
@@ -53,7 +53,7 @@ AlgebraicSphere<DataPoint, _WFunctor, T>::projectDescent( const VectorType& _q, 
         delta = -(m_uc + proj.dot(m_ul) + m_uq * proj.squaredNorm())*min(ilg,Scalar(1.));
         proj += dir*delta;
     }
-    return proj + Base::m_w.basisCenter();
+    return Base::m_w.convertToGlobalBasis( proj );
 }
 
 template < class DataPoint, class _WFunctor, typename T>

--- a/Ponca/src/Fitting/covarianceFit.hpp
+++ b/Ponca/src/Fitting/covarianceFit.hpp
@@ -42,7 +42,7 @@ CovarianceFitBase<DataPoint, _WFunctor, T>::finalize ()
         return Base::m_eCurrentState = UNDEFINED;
 
     // Center the covariance on the centroid
-    auto centroid = Base::barycenter();
+    auto centroid = Base::barycenterLocal();
     m_cov = m_cov/Base::getWeightSum() - centroid * centroid.transpose();
 
 #ifdef __CUDACC__
@@ -103,7 +103,7 @@ CovarianceFitDer<DataPoint, _WFunctor, DiffType, T>::finalize()
     // Test if base finalize end on a viable case (stable / unstable)
     if (this->isReady())
     {
-        VectorType cog = Base::barycenter();
+        VectorType cog = Base::barycenterLocal();
         MatrixType cogSq = cog * cog.transpose();
         // \fixme Better use eigen here
         for(int k=0; k<Base::NbDerivatives; ++k)

--- a/Ponca/src/Fitting/covarianceLineFit.h
+++ b/Ponca/src/Fitting/covarianceLineFit.h
@@ -52,7 +52,7 @@ public:
         static const int smallestEigenValue = DataPoint::Dim - 1;
         if (Base::finalize() == STABLE) {
             if (Base::line().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-            Base::setLine(Base::barycenter(), Base::m_solver.eigenvectors().col(smallestEigenValue).normalized());
+            Base::setLine(Base::barycenterLocal(), Base::m_solver.eigenvectors().col(smallestEigenValue).normalized());
         }
         return Base::m_eCurrentState;
     }

--- a/Ponca/src/Fitting/covariancePlaneFit.hpp
+++ b/Ponca/src/Fitting/covariancePlaneFit.hpp
@@ -40,7 +40,7 @@ CovariancePlaneFitImpl<DataPoint, _WFunctor, T>::tangentPlaneToWorld (const Vect
   if (ignoreTranslation)
     return Base::m_solver.eigenvectors().transpose().inverse() * _lq;
   else {
-    return Base::m_solver.eigenvectors().transpose().inverse() * _lq + Base::m_w.basisCenter();
+    return Base::m_w.convertToGlobalBasis(Base::m_solver.eigenvectors().transpose().inverse() * _lq);
   }
 }
 

--- a/Ponca/src/Fitting/covariancePlaneFit.hpp
+++ b/Ponca/src/Fitting/covariancePlaneFit.hpp
@@ -13,7 +13,7 @@ CovariancePlaneFitImpl<DataPoint, _WFunctor, T>::finalize ()
 {
     if (Base::finalize() == STABLE) {
         if (Base::plane().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-        Base::setPlane(Base::m_solver.eigenvectors().col(0), Base::barycenter());
+        Base::setPlane(Base::m_solver.eigenvectors().col(0), Base::barycenterLocal());
     }
 
     return Base::m_eCurrentState;
@@ -56,7 +56,7 @@ CovariancePlaneDerImpl<DataPoint, _WFunctor, DiffType, T>::finalize()
     // Test if base finalize end on a viable case (stable / unstable)
     if (this->isReady())
     {
-      VectorType   barycenter = Base::barycenter();
+      VectorType   barycenter = Base::barycenterLocal();
       VectorArray dBarycenter = Base::barycenterDerivatives();
 
       // pre-compute shifted eigenvalues to apply the pseudo inverse of C - lambda_0 I

--- a/Ponca/src/Fitting/linePrimitive.h
+++ b/Ponca/src/Fitting/linePrimitive.h
@@ -112,7 +112,7 @@ public:
     PONCA_MULTIARCH inline VectorType project (const VectorType& _q) const
     {
         // Project on the normal vector and add the offset value
-        return EigenBase::projection(Base::m_w.convertToLocalBasis(_q)) + Base::m_w.basisCenter();
+        return Base::m_w.convertToGlobalBasis(EigenBase::projection(Base::m_w.convertToLocalBasis(_q)));
     }
 }; //class Line
 

--- a/Ponca/src/Fitting/mean.h
+++ b/Ponca/src/Fitting/mean.h
@@ -38,7 +38,7 @@ namespace Ponca {
         /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
         ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in \f$\mathbf{x}\f$'s neighborhood
         PONCA_MULTIARCH inline VectorType barycenter() const {
-            return barycenterLocal() + Base::m_w.basisCenter();
+            return Base::m_w.convertToGlobalBasis( barycenterLocal() );
         }
 
     protected:

--- a/Ponca/src/Fitting/mean.h
+++ b/Ponca/src/Fitting/mean.h
@@ -33,11 +33,25 @@ namespace Ponca {
         PONCA_FITTING_DECLARE_INIT
         PONCA_FITTING_DECLARE_ADDNEIGHBOR
 
-        /// \brief Barycenter of the input points
+        /// \brief Barycenter of the input points expressed in the global frame
         ///
         /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
         ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in \f$\mathbf{x}\f$'s neighborhood
         PONCA_MULTIARCH inline VectorType barycenter() const {
+            return barycenterLocal() + Base::m_w.basisCenter();
+        }
+
+    protected:
+        /// \brief Barycenter of the input points expressed in the local frame
+        /// \see barycenter()
+        ///
+        /// \warning Provided for internal use only: any access to the barycenter in other computing classes must be
+        /// done using this function and not #barycenter()
+        ///
+        /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
+        ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in
+        /// \f$\mathbf{x}\f$'s neighborhood
+        PONCA_MULTIARCH inline VectorType barycenterLocal() const {
             return (m_sumP / Base::getWeightSum());
         }
 
@@ -104,8 +118,8 @@ namespace Ponca {
         PONCA_FITTING_DECLARE_INIT
         PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER
 
-        /// \brief Compute derivatives of the barycenter.
-        /// \see MeanPosition::barycenter()
+        /// \brief Compute derivatives of the barycenter (in local frame).
+        /// \see MeanPosition::barycenterLocal()
         ///
         /// ### Step-by-step derivation from the barycenter definition
         /// Given the definition of the barycenter \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
@@ -126,7 +140,7 @@ namespace Ponca {
         /// \note This code is not directly tested, but rather indirectly by testing CovariancePlaneDer::dNormal()
         PONCA_MULTIARCH VectorArray barycenterDerivatives() const
         {
-            return ( m_dSumP - Base::barycenter() * Base::m_dSumW ) / Base::getWeightSum();
+            return ( m_dSumP - Base::barycenterLocal() * Base::m_dSumW ) / Base::getWeightSum();
         }
 
     }; //class MeanPositionDer

--- a/Ponca/src/Fitting/meanPlaneFit.h
+++ b/Ponca/src/Fitting/meanPlaneFit.h
@@ -43,7 +43,7 @@ public:
         if(Base::finalize() == STABLE)
         {
             if (Base::plane().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-            Base::setPlane(Base::m_sumN / Base::getWeightSum(), Base::barycenter());
+            Base::setPlane(Base::m_sumN / Base::getWeightSum(), Base::barycenterLocal());
         }
         return Base::m_eCurrentState;
     }

--- a/Ponca/src/Fitting/plane.h
+++ b/Ponca/src/Fitting/plane.h
@@ -105,7 +105,7 @@ public:
     PONCA_MULTIARCH inline VectorType project (const VectorType& _q) const
     {
         // Project on the normal vector and add the offset value
-        return EigenBase::projection(Base::m_w.convertToLocalBasis(_q)) + Base::m_w.basisCenter();
+        return Base::m_w.convertToGlobalBasis(EigenBase::projection(Base::m_w.convertToLocalBasis(_q)));
     }
 
     //! \brief Scalar field gradient direction at the evaluation point

--- a/Ponca/src/Fitting/weightFunc.h
+++ b/Ponca/src/Fitting/weightFunc.h
@@ -58,11 +58,18 @@ public:
         m_p = _evalPos;
     }
 
-    /// \todo add convertToGlobalBasis, and remove this function
+    /// \brief Get access to basis center location in global coordinate system
     PONCA_MULTIARCH inline const VectorType& basisCenter() const { return m_p; }
 
     /*!
-     * \brief Convert query from global to local coordinate system
+     * \brief Convert position from local to global coordinate system
+     * @param _q Position in local coordinate
+     * @return Position expressed independently of the local basis center
+     */
+    PONCA_MULTIARCH inline VectorType convertToGlobalBasis(const VectorType& _q) const;
+
+    /*!
+     * \brief Convert query from global to local coordinate system (used internally(
      * @param _q Query in global coordinate
      * @return Query expressed relatively to the basis center
      */

--- a/Ponca/src/Fitting/weightFunc.hpp
+++ b/Ponca/src/Fitting/weightFunc.hpp
@@ -7,6 +7,13 @@
 
 template <class DataPoint, class WeightKernel>
 typename DistWeightFunc<DataPoint, WeightKernel>::VectorType
+DistWeightFunc<DataPoint, WeightKernel>::convertToGlobalBasis(const VectorType& _q) const
+{
+    return _q + m_p;
+}
+
+template <class DataPoint, class WeightKernel>
+typename DistWeightFunc<DataPoint, WeightKernel>::VectorType
 DistWeightFunc<DataPoint, WeightKernel>::convertToLocalBasis(const VectorType& _q) const
 {
     return _q - m_p;

--- a/tests/src/fit_cov.cpp
+++ b/tests/src/fit_cov.cpp
@@ -101,7 +101,7 @@ CovarianceFitTwoPassesBase<DataPoint, _WFunctor, T>::finalize ()
         auto ret = Base::finalize();
         if(ret == STABLE) {
             m_barycenterReady = true;
-            m_barycenter = Base::barycenter();
+            m_barycenter = Base::barycenterLocal();
             return NEED_OTHER_PASS;
         }
         // handle specific configurations


### PR DESCRIPTION
In the current version it is not clear that the barycenter is given in local coordinate system.

### Todo
- [x] changelog
- [x] double-check documentation
- [x] methods visibility (local should be for internal use only)