### PR TITLE
Fix max node count enum

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ Ponca changelog
 --------------------------------------------------------------------------------
 Current head (v.1.4 RC)
 
+- Cmake
+    - [build] Enable exportation of projects linking to Ponca targets (#150)
+    - [install] Change output directory to `lib/cmake/Ponca` (#150)
+
 --------------------------------------------------------------------------------
 v.1.3
 This release introduces several improvements around the KdTre API, as well as bug fixes, new features and doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endmacro()
 ################################################################################
 set(Ponca_EXPORT_TARGET_DIR \${CMAKE_CURRENT_LIST_DIR})
 
-set(config_install_dir "${CMAKE_INSTALL_PREFIX}/lib/cmake/")
+set(config_install_dir "${CMAKE_INSTALL_PREFIX}/lib/cmake/Ponca")
 set(include_install_dir "${CMAKE_INSTALL_PREFIX}/include")
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
@@ -114,7 +114,7 @@ private:
     using LeafType  = _LeafNodeType;
 
 public:
-    enum
+    enum : std::size_t
     {
         /*!
          * \brief The maximum number of nodes that a kd-tree can have when using

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -16,6 +16,7 @@ find_dependency(Eigen3 REQUIRED)
 
 include("@Ponca_EXPORT_TARGET_DIR@/PoncaTargets-Fitting.cmake")
 include("@Ponca_EXPORT_TARGET_DIR@/PoncaTargets-Common.cmake")
+include("@Ponca_EXPORT_TARGET_DIR@/PoncaTargets-SpatialPartitioning.cmake")
 
 
 # Compute paths

--- a/cmake/PoncaConfigureCommon.cmake
+++ b/cmake/PoncaConfigureCommon.cmake
@@ -36,7 +36,7 @@ install(EXPORT CommonTargets
 
 add_library(Ponca::Common ALIAS Common)
 export(EXPORT CommonTargets
-  FILE ${CMAKE_BINARY_DIR}/PoncaTargets-Common.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/PoncaTargets-Common.cmake
   NAMESPACE Ponca::
 )
 

--- a/cmake/PoncaConfigureCommon.cmake
+++ b/cmake/PoncaConfigureCommon.cmake
@@ -35,6 +35,10 @@ install(EXPORT CommonTargets
 )
 
 add_library(Ponca::Common ALIAS Common)
+export(EXPORT CommonTargets
+  FILE ${CMAKE_BINARY_DIR}/PoncaTargets-Common.cmake
+  NAMESPACE Ponca::
+)
 
 #############################################
 # HACK: have the files showing in the IDE, under the name 'ponca-src'

--- a/cmake/PoncaConfigureCommon.cmake
+++ b/cmake/PoncaConfigureCommon.cmake
@@ -31,7 +31,7 @@ install(TARGETS Common
 install(EXPORT CommonTargets
   FILE PoncaTargets-Common.cmake
   NAMESPACE Ponca::
-  DESTINATION lib/cmake
+  DESTINATION lib/cmake/Ponca
 )
 
 add_library(Ponca::Common ALIAS Common)

--- a/cmake/PoncaConfigureFitting.cmake
+++ b/cmake/PoncaConfigureFitting.cmake
@@ -74,7 +74,7 @@ install(EXPORT FittingTargets
 
 add_library(Ponca::Fitting ALIAS Fitting)
 export(EXPORT FittingTargets
-  FILE ${CMAKE_BINARY_DIR}/PoncaTargets-Fitting.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/PoncaTargets-Fitting.cmake
   NAMESPACE Ponca::
 )
 

--- a/cmake/PoncaConfigureFitting.cmake
+++ b/cmake/PoncaConfigureFitting.cmake
@@ -73,6 +73,10 @@ install(EXPORT FittingTargets
 )
 
 add_library(Ponca::Fitting ALIAS Fitting)
+export(EXPORT FittingTargets
+  FILE ${CMAKE_BINARY_DIR}/PoncaTargets-Fitting.cmake
+  NAMESPACE Ponca::
+)
 
 #############################################
 # HACK: have the files showing in the IDE, under the name 'ponca-src'

--- a/cmake/PoncaConfigureFitting.cmake
+++ b/cmake/PoncaConfigureFitting.cmake
@@ -68,7 +68,7 @@ install(TARGETS Fitting
 install(EXPORT FittingTargets
   FILE PoncaTargets-Fitting.cmake
   NAMESPACE Ponca::
-  DESTINATION lib/cmake
+  DESTINATION lib/cmake/Ponca
   COMPONENT Common
 )
 

--- a/cmake/PoncaConfigureSpatialPartitioning.cmake
+++ b/cmake/PoncaConfigureSpatialPartitioning.cmake
@@ -46,7 +46,7 @@ install(TARGETS SpatialPartitioning
 install(EXPORT SpatialPartitioningTargets
   FILE PoncaTargets-SpatialPartitioning.cmake
   NAMESPACE Ponca::
-  DESTINATION lib/cmake
+  DESTINATION lib/cmake/Ponca
   COMPONENT Common
 )
 

--- a/cmake/PoncaConfigureSpatialPartitioning.cmake
+++ b/cmake/PoncaConfigureSpatialPartitioning.cmake
@@ -52,7 +52,7 @@ install(EXPORT SpatialPartitioningTargets
 
 add_library(Ponca::SpatialPartitioning ALIAS SpatialPartitioning)
 export(EXPORT SpatialPartitioningTargets
-  FILE ${CMAKE_BINARY_DIR}/PoncaTargets-SpatialPartitioning.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/PoncaTargets-SpatialPartitioning.cmake
   NAMESPACE Ponca::
 )
 

--- a/cmake/PoncaConfigureSpatialPartitioning.cmake
+++ b/cmake/PoncaConfigureSpatialPartitioning.cmake
@@ -51,6 +51,10 @@ install(EXPORT SpatialPartitioningTargets
 )
 
 add_library(Ponca::SpatialPartitioning ALIAS SpatialPartitioning)
+export(EXPORT SpatialPartitioningTargets
+  FILE ${CMAKE_BINARY_DIR}/PoncaTargets-SpatialPartitioning.cmake
+  NAMESPACE Ponca::
+)
 
 #############################################
 # HACK: have the files showing in the IDE, under the name 'ponca-src'


### PR DESCRIPTION
On my MSVC install, the max node count enum does not automatically get promoted to `std::size_t`, which causes an error as it causes the `MAX_NODE_COUNT` value to be truncated. This PR makes the enum type explicit to avoid this.