### PR TITLE
[SpatialPartitioning] Force max node count type to 'std::size_t'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@ Current head (v.1.4 RC)
     - [build] Enable exportation of projects linking to Ponca targets (#150)
     - [install] Change output directory to `lib/cmake/Ponca` (#150)
 
+- Bug-fixes and code improvements
+   - [spatialPartitioning] Fix compilation error with `MAX_NODE_COUNT` when compiled with MSVC (#152)
+
 --------------------------------------------------------------------------------
 v.1.3
 This release introduces several improvements around the KdTre API, as well as bug fixes, new features and doc

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
@@ -114,7 +114,7 @@ private:
     using LeafType  = _LeafNodeType;
 
 public:
-    enum
+    enum : std::size_t
     {
         /*!
          * \brief The maximum number of nodes that a kd-tree can have when using


### PR DESCRIPTION
On MSVC, the `MAX_NODE_COUNT` enum value does not automatically get promoted to `std::size_t` when it is too big which generates an error ([C4309](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4309?view=msvc-170)). This PR simply forces the enum to have `std::size_t` as the underlying type.