### PR TITLE
[SpatialPartioning] Fix compilation error: wrong initializers ordering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Current head (v.1.4 RC)
 
 - Bug-fixes and code improvements
    - [spatialPartitioning] Fix compilation error with `MAX_NODE_COUNT` when compiled with MSVC (#152)
+   - [spatialPartitioning] Fix compilation error with AppleClang: wrong initializers ordering (#154)
 
 --------------------------------------------------------------------------------
 v.1.3

--- a/Ponca/src/SpatialPartitioning/query.h
+++ b/Ponca/src/SpatialPartitioning/query.h
@@ -197,7 +197,7 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>, \
 
         inline Query(const typename QueryOutType::OutputParameter &outParam,
                      const typename QueryInType::InputType &in)
-                : QueryOutType(outParam), QueryInType(in) {}
+                : QueryInType(in), QueryOutType(outParam) {}
     };
 
 DECLARE_INDEX_QUERY_CLASS(KNearest) //KNearestIndexQuery


### PR DESCRIPTION
Compilation error observed with appleclang