### PR TITLE
Adding the missing base from the curvature estimator in the Fitting user manual

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,9 @@ Current head (v.1.4 RC)
 - CI/Actions
     - Fix automatic doc deployment (#158)
 
+- Docs
+    - [Fitting] Updated the Fit user manual to account for the change of use of the curvature estimator
+
 --------------------------------------------------------------------------------
 v.1.3
 This release introduces several improvements around the KdTre API, as well as bug fixes, new features and doc

--- a/doc/src/ponca_module_fitting.mdoc
+++ b/doc/src/ponca_module_fitting.mdoc
@@ -308,9 +308,9 @@ namespace Ponca
   Distance to PCA plane \cite Digne:2011:scalespacemeshing       | Mean curvature           | `Basket<P,W,CovariancePlaneFit> // method potential()`                                                    |  +++   | -           |
   Surface Variation \cite Pauly:2002:PSSimplification            | Mean curvature           | `Basket<P,W,CovariancePlaneFit> // method surfaceVariation()`                                             |  +++   | -           |
   Growing Least Squares \cite Mellado:2012:GLS                   | Mean curvature           | `Basket<P,W,OrientedSphereFit,GLSParam> // method kappa()`                                                |  ++    | + +         |
-  Point Set Surfaces (PSS) \cite Alexa:2001:Pss                  | Curvature Tensor         | `Basket<P,W,CovariancePlaneFit,CovariancePlaneSpaceDer,NormalDerivativesCurvatureEstimator>`              |  +++   | +           |
-  Algebraic Point Set Surfaces (APSS) \cite Guennebaud:2007:APSS | Curvature Tensor         | `Basket<P,W,OrientedSphereFit,OrientedSphereSpaceDer,NormalDerivativesCurvatureEstimator>`                |  ++    | + +         |
-  Algebraic Shape Operator (ASO) \cite Lejemble:2021:stable      | Curvature Tensor         | `Basket<P,W,OrientedSphereFit,OrientedSphereSpaceDer,MlsSphereFitDer,NormalDerivativesCurvatureEstimator>`|  +     | + + +       |
+  Point Set Surfaces (PSS) \cite Alexa:2001:Pss                  | Curvature Tensor         | `Basket<P,W,CovariancePlaneFit,CovariancePlaneSpaceDer,CurvatureEstimatorBase,NormalDerivativesCurvatureEstimator>`              |  +++   | +           |
+  Algebraic Point Set Surfaces (APSS) \cite Guennebaud:2007:APSS | Curvature Tensor         | `Basket<P,W,OrientedSphereFit,OrientedSphereSpaceDer,CurvatureEstimatorBase,NormalDerivativesCurvatureEstimator>`                |  ++    | + +         |
+  Algebraic Shape Operator (ASO) \cite Lejemble:2021:stable      | Curvature Tensor         | `Basket<P,W,OrientedSphereFit,OrientedSphereSpaceDer,MlsSphereFitDer,CurvatureEstimatorBase,NormalDerivativesCurvatureEstimator>`|  +     | + + +       |
 
 
   \image html buste.png "Figure 3. Example of mean curvature (GLSParam::kappa) computed at a fine (left) and a coarse (right) scale, and rendered with a simple color map (orange for concavities, blue for convexities)."


### PR DESCRIPTION
Fix issue in the doc #138