### PR TITLE
[fitting] Extending basket compute

### DIFF
--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -18,6 +18,17 @@ namespace Ponca
 #define BSKW typename BasketType::WeightFunction
 #define BSKP typename BasketType::DataPoint
 
+template <class P, class W>
+struct BasketBase {
+    template <typename Container>
+    PONCA_MULTIARCH inline
+    FIT_RESULT compute(const Container& /*c*/) {};
+
+    template <typename IndexRange, typename PointContainer>
+    PONCA_MULTIARCH inline
+    FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/) {};
+};
+
 #ifndef PARSED_WITH_DOXYGEN
 /*! \brief Namespace used for structure or classes used internally by the lib */
 namespace internal
@@ -150,7 +161,8 @@ namespace internal
     template <typename BasketType, int Type,
         template <class, class, int, typename> class Ext0,
         template <class, class, int, typename> class... Exts>
-    class BasketDiff : public internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type {
+    class BasketDiff : public BasketBase<typename BasketType::P, typename BasketType::W>,
+                       public internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type {
     private:
         using Self   = BasketDiff;
     public:
@@ -207,7 +219,7 @@ namespace internal
     template <class P, class W,
         template <class, class, typename> class Ext0,
         template <class, class, typename> class... Exts>
-    class Basket : public internal::BasketAggregate<P, W, Ext0, Exts...>::type
+    class Basket : public BasketBase<P, W>, public internal::BasketAggregate<P, W, Ext0, Exts...>::type
     {
     private:
         using Self   = Basket;

--- a/Ponca/src/Fitting/cnc.h
+++ b/Ponca/src/Fitting/cnc.h
@@ -1,0 +1,53 @@
+/*
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include "defines.h"
+#include "defines.h"
+
+#include PONCA_MULTIARCH_INCLUDE_STD(iterator)
+
+namespace Ponca
+{
+
+template <class P, class W>
+struct CNC : BasketBase {
+    using random = Eigen::internal::random<int>;
+
+    int nbTry = 1;
+
+    template <typename IndexRange, typename PointContainer>
+    FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){
+        float curvature = 0;
+        int lengthIds = ids.size();
+
+        for (int i = 0; i < nbTry; i++) {
+            int t1 = points[ids[random(0, lengthIds)]];
+            int t2 = points[ids[random(0, lengthIds)]];
+            int t3 = points[ids[random(0, lengthIds)]];
+            curvature += estimate(t1, t2, t3);
+        }
+
+        curvature /= nbTry;
+    }
+
+    template <typename PointContainer>
+    PONCA_MULTIARCH inline
+    FIT_RESULT compute(const PointContainer& points) {
+        float curvature = 0;
+        int lengthPoints = points.size();
+
+        for (int i = 0; i < nbTry; i++) {
+            int t1 = points[random(0, lengthPoints)];
+            int t2 = points[random(0, lengthPoints)];
+            int t2 = points[random(0, lengthPoints)];
+            curvature += estimate(t1, t2, t3);
+        }
+
+        curvature /= nbTry;
+    };
+};


### PR DESCRIPTION
Include other fitting types that can't utilize the addNeighbor based compute methods (like CNC for instance) : They need to define their own compute methods.