### PR TITLE
[fitting] Streamlining compute functions declaration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Current head (v.1.4 RC)
    - [spatialPartitioning] Fix issues with KdTreeCustomizableNode copy and move constructors(#192)
    - [fitting] Fix typo in code (#182)
    - [fitting] Fix unsafe use of m_ul in OrientedSphereFit for degenerated cases (#202)
+   - [fitting] Streamlining compute functions declaration (#194)
 
 - Tests
    - [fitting] Split Basket test in subtests (#96)

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -156,6 +156,8 @@ namespace internal
     using Scalar = typename DataPoint::Scalar;
 
     using ComputeObject<Self>::compute; // Make the default compute accessible
+    using BasketType::compute;
+    using BasketType::computeWithIds;
 
     /// \copydoc Basket::addNeighbor
     PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -113,45 +113,6 @@ namespace internal
         PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/) { return UNDEFINED; };
     }; // struct ComputeObject
 
-#define WRITE_COMPUTE_FUNCTIONS                                                                       \
-    /*! \brief Convenience function for STL-like iterators                                         */ \
-    /*! Add neighbors stored in a container using STL-like iterators, and call finalize at the end.*/ \
-    /*! The fit is evaluated multiple time if needed (see #NEED_OTHER_PASS)*/                         \
-    /*! \see addNeighbor() */                                                                         \
-    template <typename IteratorBegin, typename IteratorEnd>                                           \
-    PONCA_MULTIARCH inline                                                                            \
-    FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end){                           \
-        Base::init();                                                                                 \
-        FIT_RESULT res = UNDEFINED;                                                                   \
-        do {                                                                                          \
-            Self::startNewPass();                                                                     \
-            for (auto it = begin; it != end; ++it){                                                   \
-                Self::addNeighbor(*it);                                                               \
-            }                                                                                         \
-            res = Base::finalize();                                                                   \
-        } while ( res == NEED_OTHER_PASS );                                                           \
-        return res;                                                                                   \
-    }                                                                                                 \
-    /*! \brief Convenience function to iterate over a subset of samples in a PointContainer  */       \
-    /*! Add neighbors stored in a PointContainer and sampled using indices stored in ids.*/           \
-    /*! \tparam IndexRange STL-Like range storing indices of the neighbors */                         \
-    /*! \tparam PointContainer STL-like container storing the points */                               \
-    /*! \see #compute(const IteratorBegin& begin, const IteratorEnd& end)    */                       \
-    template <typename IndexRange, typename PointContainer>                                           \
-    PONCA_MULTIARCH inline                                                                            \
-    FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){                          \
-        this->init();                                                                                 \
-        FIT_RESULT res = UNDEFINED;                                                                   \
-        do {                                                                                          \
-            Self::startNewPass();                                                                     \
-            for (const auto& i : ids){                                                                \
-                this->addNeighbor(points[i]);                                                         \
-            }                                                                                         \
-            res = this->finalize();                                                                   \
-        } while ( res == NEED_OTHER_PASS );                                                           \
-        return res;                                                                                   \
-    }
-
     /*!
          \brief Aggregator class used to declare specialized structures with derivatives computations, using CRTP
 
@@ -195,7 +156,6 @@ namespace internal
     using Scalar = typename DataPoint::Scalar;
 
     using ComputeObject<Self>::compute; // Make the default compute accessible
-    WRITE_COMPUTE_FUNCTIONS
 
     /// \copydoc Basket::addNeighbor
     PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {
@@ -255,7 +215,46 @@ namespace internal
         using WeightFunction = W;
 
         using ComputeObject<Self>::compute; // Make the default compute accessible
-        WRITE_COMPUTE_FUNCTIONS;
+
+        /*! \brief Convenience function for STL-like iterators*/
+        /*! Add neighbors stored in a container using STL-like iterators, and call finalize at the end.*/
+        /*! The fit is evaluated multiple time if needed (see #NEED_OTHER_PASS)*/
+        /*! \see addNeighbor() */
+        template <typename IteratorBegin, typename IteratorEnd>
+        PONCA_MULTIARCH inline
+        FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end){
+            Base::init();
+            FIT_RESULT res = UNDEFINED;
+            do {
+                Self::startNewPass();
+                for (auto it = begin; it != end; ++it){
+                    Self::addNeighbor(*it);
+                }
+                res = Base::finalize();
+            } while ( res == NEED_OTHER_PASS );
+            return res;
+        }
+
+        /*! \brief Convenience function to iterate over a subset of samples in a PointContainer  */
+        /*! Add neighbors stored in a PointContainer and sampled using indices stored in ids.*/
+        /*! \tparam IndexRange STL-Like range storing indices of the neighbors */
+        /*! \tparam PointContainer STL-like container storing the points */
+        /*! \see #compute(const IteratorBegin& begin, const IteratorEnd& end)    */
+        template <typename IndexRange, typename PointContainer>
+        PONCA_MULTIARCH inline
+        FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){
+            this->init();
+            FIT_RESULT res = UNDEFINED;
+            do {
+                Self::startNewPass();
+                for (const auto& i : ids){
+                    this->addNeighbor(points[i]);
+                }
+                res = this->finalize();
+            } while ( res == NEED_OTHER_PASS );
+            return res;
+        }
+
 
         /// \brief Add a neighbor to perform the fit
         ///

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -73,9 +73,10 @@ namespace internal
 }
 #endif
 
-
-    template<typename Derived, typename Base>
-    struct BasketComputeObject : public ComputeObject<Derived> {
+    template<typename _Derived, typename _Base>
+    struct BasketComputeObject : public ComputeObject<_Derived>, public virtual _Base {
+        using Base    = _Base;    /// <\brief Alias to the Base type
+        using Derived = _Derived; /// \brief Alias to the Derived type
     protected:
         using ComputeObject<Derived>::derived;
         Base& base() { return static_cast<Base&>(static_cast<Derived&>(*this)); }
@@ -155,8 +156,9 @@ namespace internal
     template <typename BasketType, int Type,
         template <class, class, int, typename> class Ext0,
         template <class, class, int, typename> class... Exts>
-    class BasketDiff : public BasketComputeObject<BasketDiff<BasketType, Type, Ext0, Exts...>, typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type>,
-                       public virtual internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type {
+    class BasketDiff : public BasketComputeObject<BasketDiff<BasketType, Type, Ext0, Exts...>,
+                                                  typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type>
+    {
     private:
         using Self   = BasketDiff;
     public:
@@ -214,8 +216,8 @@ namespace internal
     template <class P, class W,
         template <class, class, typename> class Ext0,
         template <class, class, typename> class... Exts>
-    class Basket : public BasketComputeObject<Basket<P, W, Ext0, Exts...>, typename internal::BasketAggregate<P, W, Ext0, Exts...>::type>,
-                   public internal::BasketAggregate<P, W, Ext0, Exts...>::type
+    class Basket : public BasketComputeObject<Basket<P, W, Ext0, Exts...>,
+                                              typename internal::BasketAggregate<P, W, Ext0, Exts...>::type>
     {
     private:
         using Self   = Basket;

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -155,8 +155,17 @@ namespace internal
     /// Scalar type used for computation, as defined from Basket
     using Scalar = typename DataPoint::Scalar;
 
-    using BasketType::compute; // Makes compute(container) and compute(begin, end) accessible
+
+    using ComputeObject<Self>::compute; // Make the default compute(container) accessible when not PONCA_CPU_ARCH
     using BasketType::computeWithIds;
+
+    // Resolves the ambiguity of the compute functions
+    /// \copydoc Basket::compute
+    template <typename IteratorBegin, typename IteratorEnd>
+    PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end) {
+        // This overwrite points to the function defined in Basket class
+        BasketType::compute(begin, end);
+    }
 
     /// \copydoc Basket::addNeighbor
     PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -200,7 +200,7 @@ namespace internal
         template <class, class, int, typename> class Ext0,
         template <class, class, int, typename> class... Exts>
     class BasketDiff : public BasketComputeObject<BasketDiff<BasketType, Type, Ext0, Exts...>, typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type>,
-                       public internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type {
+                       public virtual internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type {
     private:
         using Self   = BasketDiff;
     public:

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -9,6 +9,7 @@
 #include "defines.h"
 #include "enums.h"
 #include "primitive.h"
+#include "compute.h"
 
 #include PONCA_MULTIARCH_INCLUDE_STD(iterator)
 
@@ -72,51 +73,6 @@ namespace internal
 }
 #endif
 
-    /*!
-         \brief ComputeObject is a virtual object that represents an algorithm which can be used with the compute functions.
-         The compute(begin, end) and computeWithIds(ids, points) methods must be implemented by the inheriting class.
-         \note The compute(container) that is defined in this structure can be reused in the inheriting class by adding
-         "using ComputeObject<Self>::compute;" to make it accessible
-    */
-    template <typename Derived>
-    struct ComputeObject {
-    protected:
-        /// \brief Retrieve the top layer object
-        /// Returns a reference to the derived class so that we can use its overwritten methods
-        Derived& derived() { return static_cast<Derived&>(*this); }
-    public:
-
-#ifdef PONCA_CPU_ARCH
-        /*! \brief Convenience function for STL-like container                                                        */
-        /*! Uses the compute(IteratorBegin, IteratorEnd) function                                                     */
-        /*! \note This method is only accessible when using a CPU architecture (PONCA_CPU_ARCH = true)                */
-        /*! \tparam Container And STL-Like container                                                                  */
-        /*! \see #compute(const IteratorBegin& begin, const IteratorEnd& end)                                         */
-        template <typename Container>
-        FIT_RESULT compute(const Container& c) {
-            return derived().compute(std::begin(c), std::end(c));
-        }
-#endif
-
-        /*! \brief Convenience function for STL-like iterators
-            \tparam IteratorBegin The beginning of the iterator (std::begin(iterator)
-            \tparam IteratorEnd   The end of the iterator (std::end(iterator)
-        */
-        template <typename IteratorBegin, typename IteratorEnd>
-        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& /*begin*/, const IteratorEnd& /*end*/) {
-            return UNDEFINED;
-        };
-
-        /*! \brief Convenience function to iterate over a subset of samples in a PointContainer
-            \tparam IndexRange STL-Like range storing indices of the neighbors
-            \tparam PointContainer STL-like container storing the points
-            \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
-        */
-        template <typename IndexRange, typename PointContainer>
-        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/) {
-            return UNDEFINED;
-        };
-    }; // struct ComputeObject
 
     template<typename Derived, typename Base>
     struct BasketComputeObject : public ComputeObject<Derived> {

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -164,7 +164,7 @@ namespace internal
     template <typename IteratorBegin, typename IteratorEnd>
     PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end) {
         // This overwrite points to the function defined in Basket class
-        BasketType::compute(begin, end);
+        Self::compute(begin, end);
     }
 
     /// \copydoc Basket::addNeighbor

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -216,15 +216,17 @@ namespace internal
 
         using ComputeObject<Self>::compute; // Make the default compute accessible
 
-        /*! \brief Convenience function for STL-like iterators*/
-        /*! Add neighbors stored in a container using STL-like iterators, and call finalize at the end.*/
-        /*! The fit is evaluated multiple time if needed (see #NEED_OTHER_PASS)*/
-        /*! \see addNeighbor() */
+        /*!
+         * \brief Convenience function for STL-like iterators
+         * Add neighbors stored in a container using STL-like iterators, and call finalize at the end.
+         * The fit is evaluated multiple time if needed (see #NEED_OTHER_PASS)
+         * \see addNeighbor()
+         */
         template <typename IteratorBegin, typename IteratorEnd>
-        PONCA_MULTIARCH inline
-        FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end){
+        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end){
             Base::init();
             FIT_RESULT res = UNDEFINED;
+
             do {
                 Self::startNewPass();
                 for (auto it = begin; it != end; ++it){
@@ -232,19 +234,22 @@ namespace internal
                 }
                 res = Base::finalize();
             } while ( res == NEED_OTHER_PASS );
+
             return res;
         }
 
-        /*! \brief Convenience function to iterate over a subset of samples in a PointContainer  */
-        /*! Add neighbors stored in a PointContainer and sampled using indices stored in ids.*/
-        /*! \tparam IndexRange STL-Like range storing indices of the neighbors */
-        /*! \tparam PointContainer STL-like container storing the points */
-        /*! \see #compute(const IteratorBegin& begin, const IteratorEnd& end)    */
+        /*!
+         * \brief Convenience function to iterate over a subset of samples in a PointContainer
+         * Add neighbors stored in a PointContainer and sampled using indices stored in ids.
+         * \tparam IndexRange STL-Like range storing indices of the neighbors
+         * \tparam PointContainer STL-like container storing the points
+         * \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
+         */
         template <typename IndexRange, typename PointContainer>
-        PONCA_MULTIARCH inline
-        FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){
+        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){
             this->init();
             FIT_RESULT res = UNDEFINED;
+
             do {
                 Self::startNewPass();
                 for (const auto& i : ids){
@@ -252,6 +257,7 @@ namespace internal
                 }
                 res = this->finalize();
             } while ( res == NEED_OTHER_PASS );
+
             return res;
         }
 

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -163,8 +163,18 @@ namespace internal
     /// \copydoc Basket::compute
     template <typename IteratorBegin, typename IteratorEnd>
     PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end) {
-        // This overwrite points to the function defined in Basket class
-        Self::compute(begin, end);
+        Base::init();
+        FIT_RESULT res = UNDEFINED;
+
+        do {
+            Self::startNewPass();
+            for (auto it = begin; it != end; ++it){
+                Self::addNeighbor(*it);
+            }
+            res = Base::finalize();
+        } while ( res == NEED_OTHER_PASS );
+
+        return res;
     }
 
     /// \copydoc Basket::addNeighbor

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -47,27 +47,27 @@ namespace internal
     {
     };
 
-    template <typename BasketType, int Type,
-        typename Aggregate,
+    template <int Type,
+        typename BasketType,
         template <class, class, int, typename> class Ext,
         template <class, class, int, typename> class... Exts>
     struct BasketDiffAggregateImpl
     {
-        using type = typename BasketDiffAggregateImpl<BasketType, Type, Ext<BSKP, BSKW, Type, Aggregate>, Exts...>::type;
+        using type = typename BasketDiffAggregateImpl<Type, Ext<BSKP, BSKW, Type, BasketType>, Exts...>::type;
     };
 
-    template <typename BasketType, int Type,
-        typename Aggregate,
+    template <int Type,
+        typename BasketType,
         template <class, class, int, typename> class Ext>
-    struct BasketDiffAggregateImpl<BasketType, Type, Aggregate, Ext>
+    struct BasketDiffAggregateImpl<Type, BasketType, Ext>
     {
-        using type = Ext<BSKP, BSKW, Type, Aggregate>;
+        using type = Ext<BSKP, BSKW, Type, BasketType>;
     };
 
     /*! \brief Internal class used to build the BasketDiff structure */
     template <typename BasketType, int Type,
         template <class, class, int, typename> class... Exts>
-    struct BasketDiffAggregate : BasketDiffAggregateImpl<BasketType, Type, BasketType, PrimitiveDer, Exts...>
+    struct BasketDiffAggregate : BasketDiffAggregateImpl<Type, BasketType, PrimitiveDer, Exts...>
     {
     };
 }

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -89,6 +89,7 @@ namespace internal
 #ifdef PONCA_CPU_ARCH
         /*! \brief Convenience function for STL-like container                                                        */
         /*! Uses the compute(IteratorBegin, IteratorEnd) function                                                     */
+        /*! \note This method is only accessible when using a CPU architecture (PONCA_CPU_ARCH = true)                */
         /*! \tparam Container And STL-Like container                                                                  */
         /*! \see #compute(const IteratorBegin& begin, const IteratorEnd& end)                                         */
         template <typename Container>
@@ -123,13 +124,11 @@ namespace internal
     template<typename Derived, typename Base>
     struct BasketComputeObject : public ComputeObject<Derived> {
     protected:
-        /// \brief Retrieve the top layer object
-        /// Returns a reference to the derived class so that we can use its overwritten methods
-        Derived& derived() { return static_cast<Derived&>(*this); }
-        // Base& base() { return static_cast<Base&>(*this); }
+        using ComputeObject<Derived>::derived;
         Base& base() { return static_cast<Base&>(static_cast<Derived&>(*this)); }
     public:
-        using ComputeObject<Derived>::compute;
+        using ComputeObject<Derived>::compute; // Makes the default compute(container) accessible when using a CPU architecture
+
         /*!
          * \brief Convenience function for STL-like iterators
          * Add neighbors stored in a container using STL-like iterators, and call finalize at the end.
@@ -217,7 +216,7 @@ namespace internal
     /// Scalar type used for computation, as defined from Basket
     using Scalar = typename DataPoint::Scalar;
 
-    using BasketComputeObject<Self, Base>::compute; // Make the default compute(container) accessible when not PONCA_CPU_ARCH
+    using BasketComputeObject<Self, Base>::compute;
     using BasketComputeObject<Self, Base>::computeWithIds;
 
     /// \copydoc Basket::addNeighbor
@@ -277,7 +276,7 @@ namespace internal
         /// Weighting function
         using WeightFunction = W;
 
-        using BasketComputeObject<Self, Base>::compute; // Make the default compute(container) accessible when not PONCA_CPU_ARCH
+        using BasketComputeObject<Self, Base>::compute;
         using BasketComputeObject<Self, Base>::computeWithIds;
 
         /// \brief Add a neighbor to perform the fit

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -155,8 +155,7 @@ namespace internal
     /// Scalar type used for computation, as defined from Basket
     using Scalar = typename DataPoint::Scalar;
 
-    using ComputeObject<Self>::compute; // Make the default compute accessible
-    using BasketType::compute;
+    using BasketType::compute; // Makes compute(container) and compute(begin, end) accessible
     using BasketType::computeWithIds;
 
     /// \copydoc Basket::addNeighbor

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -103,9 +103,7 @@ namespace internal
             \tparam IteratorEnd   The end of the iterator (std::end(iterator)
         */
         template <typename IteratorBegin, typename IteratorEnd>
-        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end)
-        {
-            std::cerr << "ERROR" << std::endl;
+        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& /*begin*/, const IteratorEnd& /*end*/) {
             return UNDEFINED;
         };
 
@@ -116,7 +114,6 @@ namespace internal
         */
         template <typename IndexRange, typename PointContainer>
         PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/) {
-            std::cerr << "ERROR" << std::endl;
             return UNDEFINED;
         };
     }; // struct ComputeObject

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -23,6 +23,15 @@ namespace Ponca
 /*! \brief Namespace used for structure or classes used internally by the lib */
 namespace internal
 {
+    /*!
+     * \brief This class unrolls the extension (from left to right) from the CRTP variadic list
+     *
+     * \tparam P Implements \ref ponca_concepts "PointConcept"
+     * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+     * \tparam Aggregate The base CRTP class
+     * \tparam Ext First (left-side) extension in the CTRP variadic list
+     * \tparam Exts Remaining elements (excluding Ext) of the CRTP variadic list
+     */
     template <class P, class W,
         typename Aggregate,
         template <class, class, typename> class Ext,
@@ -32,6 +41,14 @@ namespace internal
         using type = typename BasketAggregateImpl<P, W, Ext<P, W, Aggregate>, Exts...>::type;
     };
 
+    /*!
+     * \brief Specialized version of BasketAggregateImpl when the variadic list is empty
+     *
+     * \tparam P Implements \ref ponca_concepts "PointConcept"
+     * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+     * \tparam Aggregate The base CRTP class
+     * \tparam Ext Unique (or last) extension of the CTRP variadic list
+     */
     template <class P, class W,
         typename Aggregate,
         template <class, class, typename> class Ext>
@@ -40,13 +57,29 @@ namespace internal
         using type = Ext<P, W, Aggregate>;
     };
 
-    /*! \brief Internal class used to build the Basket structure */
+    /*!
+     * \brief Internal class used to build the Basket structure
+     * Uses BasketAggregateImpl to unroll the CRTP variadic list
+     *
+     * \tparam P Implements \ref ponca_concepts "PointConcept"
+     * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+     * \tparam Exts CRTP variadic list
+     */
     template <class P, class W,
         template <class, class, typename> class... Exts>
     struct BasketAggregate : BasketAggregateImpl<P, W, PrimitiveBase<P, W>, Exts...>
     {
     };
 
+    /*!
+     * \brief This class unrolls the extension (from left to right) from the CRTP variadic list
+     * \see BasketDiffAggregateImpl
+     *
+     * \tparam Type Differentiation type
+     * \tparam BasketType Input Basket Type
+     * \tparam Ext First (left-side) extension in the CTRP variadic list
+     * \tparam Exts Remaining elements (excluding Ext) of the CRTP variadic list
+     */
     template <int Type,
         typename BasketType,
         template <class, class, int, typename> class Ext,
@@ -56,6 +89,13 @@ namespace internal
         using type = typename BasketDiffAggregateImpl<Type, Ext<BSKP, BSKW, Type, BasketType>, Exts...>::type;
     };
 
+    /*!
+     * \brief Specialized version of BasketDiffAggregateImpl when the variadic list is empty
+     *
+     * \tparam Type Differentiation type
+     * \tparam BasketType Input Basket Type
+     * \tparam Ext Unique (or last) extension of the CTRP variadic list
+     */
     template <int Type,
         typename BasketType,
         template <class, class, int, typename> class Ext>
@@ -64,7 +104,14 @@ namespace internal
         using type = Ext<BSKP, BSKW, Type, BasketType>;
     };
 
-    /*! \brief Internal class used to build the BasketDiff structure */
+    /*!
+     * \brief Internal class used to build the BasketDiff structure
+     * Uses BasketDiffAggregateImpl to unroll the CRTP variadic list
+     *
+     * \tparam BasketType BasketType Input Basket Type
+     * \tparam Type Differentiation type
+     * \tparam Exts CRTP variadic list
+     */
     template <typename BasketType, int Type,
         template <class, class, int, typename> class... Exts>
     struct BasketDiffAggregate : BasketDiffAggregateImpl<Type, BasketType, PrimitiveDer, Exts...>
@@ -73,6 +120,14 @@ namespace internal
 }
 #endif
 
+    /*!
+     * Base ComputeObject for the Basket classes
+     *
+     * Implements the compute methods for fitting: #compute, #computeWithIds, ...
+     *
+     * @tparam Derived Derived class that provides the addNeighbor method (either Basket or BasketDiff)
+     * @tparam Base Base class that provides, through the CRTP the init, startNewPass, addNeighbor and finalize methods
+     */
     template<typename _Derived, typename _Base>
     struct BasketComputeObject : public ComputeObject<_Derived>, public virtual _Base {
         using Base    = _Base;    /// <\brief Alias to the Base type

--- a/Ponca/src/Fitting/compute.h
+++ b/Ponca/src/Fitting/compute.h
@@ -1,0 +1,61 @@
+/*
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include "defines.h"
+
+namespace Ponca{
+    /*!
+      \brief ComputeObject is a virtual object that represents an algorithm which can be used with the compute functions.
+
+      The compute(begin, end) and computeWithIds(ids, points) methods must be implemented by the inheriting class.
+      \note The compute(container) that is defined in this structure can be reused in the inheriting class by adding
+      "using ComputeObject<Self>::compute;" to make it accessible
+ */
+    template <typename Derived>
+    struct ComputeObject {
+    protected:
+        /// \brief Retrieve the top layer object
+        /// Returns a reference to the derived class so that we can use its overwritten methods
+        Derived& derived() { return static_cast<Derived&>(*this); }
+    public:
+
+#ifdef PONCA_CPU_ARCH
+        /*! \brief Convenience function for STL-like container
+         *
+         * \note This method is only accessible when using a CPU architecture (PONCA_CPU_ARCH = true)
+         * \tparam Container And STL-Like container
+         * \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
+         */
+        template <typename Container>
+        FIT_RESULT compute(const Container& c) {
+            return derived().compute(std::begin(c), std::end(c));
+        }
+#endif
+
+        /*! \brief Convenience function for STL-like iterators
+            \tparam IteratorBegin The beginning of the iterator (std::begin(iterator)
+            \tparam IteratorEnd   The end of the iterator (std::end(iterator)
+        */
+        template <typename IteratorBegin, typename IteratorEnd>
+        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& /*begin*/, const IteratorEnd& /*end*/) {
+            return UNDEFINED;
+        };
+
+        /*! \brief Convenience function to iterate over a subset of samples in a PointContainer
+            \tparam IndexRange STL-Like range storing indices of the neighbors
+            \tparam PointContainer STL-like container storing the points
+            \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
+        */
+        template <typename IndexRange, typename PointContainer>
+        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/) {
+            return UNDEFINED;
+        };
+    }; // struct ComputeObject
+
+}
+

--- a/Ponca/src/Fitting/primitive.h
+++ b/Ponca/src/Fitting/primitive.h
@@ -146,6 +146,10 @@ public:
     contains at least FitScaleDer. The size of these arrays can be known using
     derDimension(), and the differentiation type by isScaleDer() and
     isSpaceDer().
+
+    Thanks to the BasketDiff definition, we know that PrimitiveDer has Primitive
+    as base class (through the Basket). As a result, this class first asks to
+    compute the Fit, and if it works properly, compute the weight derivatives.
  */
 template < class DataPoint, class _WFunctor, int Type, typename T>
 class PrimitiveDer : public T
@@ -198,7 +202,7 @@ public:
                                                  const DataPoint &attributes,
                                                  ScalarArray &dw)
     {
-        if( Base::addLocalNeighbor(w, localQ, attributes) ) {
+        if( Base::addLocalNeighbor(w, localQ, attributes) ) { // call the Primitive Fit (without dw)
             int spaceId = (Type & FitScaleDer) ? 1 : 0;
             // compute weight
             if (Type & FitScaleDer)

--- a/cmake/PoncaConfigureFitting.cmake
+++ b/cmake/PoncaConfigureFitting.cmake
@@ -9,6 +9,7 @@ set(ponca_Fitting_INCLUDE
     "${PONCA_src_ROOT}/Ponca/src/Fitting/covarianceLineFit.h"
     "${PONCA_src_ROOT}/Ponca/src/Fitting/covariancePlaneFit.h"
     "${PONCA_src_ROOT}/Ponca/src/Fitting/covariancePlaneFit.hpp"
+    "${PONCA_src_ROOT}/Ponca/src/Fitting/compute.h"
     "${PONCA_src_ROOT}/Ponca/src/Fitting/curvatureEstimation.h"
     "${PONCA_src_ROOT}/Ponca/src/Fitting/curvatureEstimation.hpp"
     "${PONCA_src_ROOT}/Ponca/src/Fitting/curvature.h"


### PR DESCRIPTION
Removes the uses of `WRITE_COMPUTE_FUNCTIONS` macro in `src/Fitting/basket.h` by defining the compute functions directly in the Basket` class.