### PR TITLE
[ci] Do not configure examples (and fetch deps.) for testing

### DIFF
--- a/.github/workflows/ContinuousTest.yml
+++ b/.github/workflows/ContinuousTest.yml
@@ -27,15 +27,12 @@ jobs:
       - name: Add msbuild to PATH
         uses: seanmiddleditch/gha-setup-vsdevenv@master
         if: runner.os == 'Windows'
-      - name: Install PCL
-        run: sudo apt-get update && sudo apt-get install libpcl-dev
-        if: runner.os == 'Linux'
       - name: Checkout remote head
         uses: actions/checkout@master
         with:
           path: src
       - name: cmake
-        run: mkdir build && cd build && cmake ../src  -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DPONCA_CONFIGURE_EXAMPLES=ON -DPONCA_CONFIGURE_DOC=ON -DPONCA_CONFIGURE_TESTS=ON
+        run: mkdir build && cd build && cmake ../src  -GNinja -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DPONCA_CONFIGURE_EXAMPLES=OFF -DPONCA_CONFIGURE_DOC=ON -DPONCA_CONFIGURE_TESTS=ON
       - name: make buildtests
         run: cd build && cmake --build . --target buildtests
       - name: make ContinuousTest
@@ -43,6 +40,12 @@ jobs:
       - name: Display test failure logs
         if: ${{ failure() }}
         run : cat ./build/Testing/Temporary/LastTest.log
+      - name: Install PCL
+        run: |
+          sudo apt-get update && sudo apt-get install libpcl-dev
+        if: runner.os == 'Linux'
+      - name: reconfigure cmake with ponca-examples
+        run: cd build && cmake ../src -DPONCA_CONFIGURE_EXAMPLES=ON
       - name: make ponca-examples
         run: cd build && cmake --build . --target ponca-examples
       - name: make install

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ Current head (v.1.4 RC)
 - CI/Actions
     - Fix automatic doc deployment (#158,#176)
     - Print error log on tests failure (#162)
+		- save time by installing PCL and configurong examples only if tests are ok (#208)
 
 - Docs
     - [fitting] Updated the Fit user manual to account for the change of use of the curvature estimator (#172)


### PR DESCRIPTION
The goal is to reduce ci times when tests fails.
In this version, the project is configured without the examples first, then the tests are compiled.
If it goes fine, PCL is fetched, the project is re-configured with examples enables.