### PR TITLE
[common] Clang format for Ponca

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+﻿---
+BasedOnStyle: Microsoft
+ColumnLimit: '120'
+TabWidth: '4'
+IndentWidth: '4'
+NamespaceIndentation: All
+AccessModifierOffset: -4
+InsertNewlineAtEOF: true
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtEOF: true
+KeepEmptyLines:
+  AtEndOfFile: true
+AlignConsecutiveAssignments: true
+AlignEscapedNewlines: Left
+AllowShortFunctionsOnASingleLine: All
+AlwaysBreakTemplateDeclarations: 'Yes'
+IncludeBlocks: Preserve
+IndentPPDirectives: AfterHash
+Language: Cpp
+PointerAlignment: Left
+SortIncludes: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+
+...

--- a/.github/workflows/CheckFormatting.yml
+++ b/.github/workflows/CheckFormatting.yml
@@ -1,0 +1,24 @@
+name: Check formatting
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: RafikFarhad/clang-format-github-action@v6
+        with:
+          sources: "**/*.h,**/*.hpp,**/*.cpp"
+          style: "file"
+ 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ introduces several bug fixes and minors improvements.
     - [fitting] Fix issues when converting vectors between local and global frames (#201)
     - [fitting] Fix bug in MongePatch::primitiveGradient (#269)
     - [fitting] Fix warnings on windows (#278)
+    - [commin] Applied clang-formatting (#274)
 
 - Tests
     - [utils] Improve point cloud generation functions (#201)
@@ -31,6 +32,7 @@ introduces several bug fixes and minors improvements.
 
 - CI/Actions
     - [ci] Fix CNC coverage test (crash + slow execution) (#272)
+    - [ci] New github action for checking formatting (#274)
 
 - Examples
     - [all] Update according to API changes (#201)

--- a/Ponca/src/Common/Assert.h
+++ b/Ponca/src/Common/Assert.h
@@ -2,40 +2,42 @@
 
 #include "./Macro.h"
 
-#define PONCA_ERROR                                                             \
-    PONCA_MACRO_START                                                           \
-    PONCA_PRINT_ERROR("");                                                      \
-    PONCA_CRASH;                                                                \
+#define PONCA_ERROR        \
+    PONCA_MACRO_START      \
+    PONCA_PRINT_ERROR(""); \
+    PONCA_CRASH;           \
     PONCA_MACRO_END
 
-#define PONCA_ERROR_MSG(MSG)                                                    \
-    PONCA_MACRO_START                                                           \
-    PONCA_PRINT_ERROR(MSG);                                                     \
-    PONCA_CRASH;                                                                \
+#define PONCA_ERROR_MSG(MSG) \
+    PONCA_MACRO_START        \
+    PONCA_PRINT_ERROR(MSG);  \
+    PONCA_CRASH;             \
     PONCA_MACRO_END
 
-#define PONCA_ASSERT(EXPR)                                                      \
-    PONCA_MACRO_START                                                           \
-    if(!(EXPR)) {                                                              \
-        PONCA_ERROR_MSG(PONCA_STR(EXPR));                                        \
-    }                                                                          \
+#define PONCA_ASSERT(EXPR)                \
+    PONCA_MACRO_START                     \
+    if (!(EXPR))                          \
+    {                                     \
+        PONCA_ERROR_MSG(PONCA_STR(EXPR)); \
+    }                                     \
     PONCA_MACRO_END
 
-#define PONCA_ASSERT_MSG(EXPR,MSG)                                              \
-    PONCA_MACRO_START                                                           \
-    if(!(EXPR)) {                                                              \
-        PONCA_ERROR_MSG(MSG);                                                   \
-    }                                                                          \
+#define PONCA_ASSERT_MSG(EXPR, MSG) \
+    PONCA_MACRO_START               \
+    if (!(EXPR))                    \
+    {                               \
+        PONCA_ERROR_MSG(MSG);       \
+    }                               \
     PONCA_MACRO_END
 
 #ifdef PONCA_DEBUG
-    #define PONCA_DEBUG_ASSERT(EXPR)          PONCA_ASSERT(EXPR)
-    #define PONCA_DEBUG_ASSERT_MSG(EXPR,MSG)  PONCA_ASSERT_MSG(EXPR,MSG)
-    #define PONCA_DEBUG_ERROR_MSG(MSG)        PONCA_ERROR_MSG(MSG)
-    #define PONCA_DEBUG_ERROR                 PONCA_ERROR
+#    define PONCA_DEBUG_ASSERT(EXPR) PONCA_ASSERT(EXPR)
+#    define PONCA_DEBUG_ASSERT_MSG(EXPR, MSG) PONCA_ASSERT_MSG(EXPR, MSG)
+#    define PONCA_DEBUG_ERROR_MSG(MSG) PONCA_ERROR_MSG(MSG)
+#    define PONCA_DEBUG_ERROR PONCA_ERROR
 #else
-    #define PONCA_DEBUG_ASSERT(EXPR)
-    #define PONCA_DEBUG_ASSERT_MSG(EXPR,MSG)
-    #define PONCA_DEBUG_ERROR_MSG(MSG)
-    #define PONCA_DEBUG_ERROR
+#    define PONCA_DEBUG_ASSERT(EXPR)
+#    define PONCA_DEBUG_ASSERT_MSG(EXPR, MSG)
+#    define PONCA_DEBUG_ERROR_MSG(MSG)
+#    define PONCA_DEBUG_ERROR
 #endif

--- a/Ponca/src/Common/Containers/limitedPriorityQueue.h
+++ b/Ponca/src/Common/Containers/limitedPriorityQueue.h
@@ -12,401 +12,390 @@
 #include <functional>
 #include "../defines.h"
 
-namespace Ponca {
-
-//!
-//! \brief The limited_priority_queue class is similar to std::priority_queue
-//! but has a limited capacity and handles the comparison differently.
-//!
-//! In case the capacity is reached, the container is full and push() do not
-//! insert a new element if its priority is lower than the current minimal one.
-//!
-//! The comparison predicate must return true is the first argument has
-//! priority on the second one.
-//!
-//! The element with the highest priority is the last one that is pop out, but
-//! is the first one that is iterated through.
-//!
-//! Example 1:
-//! Using std::less as comparison predicate, we have the following situation:
-//!
-//!     full()      = false
-//!     empty()     = false
-//!     capacity()  = 6
-//!     size()      = 4
-//!     top()       = 1
-//!     bottom()    = 9
-//!
-//!     pop() removes the value 9
-//!     push(4) adds the value 4
-//!
-//!     begin            end
-//!       v               v
-//!     +---+---+---+---+---+---+
-//!     | 1 | 3 | 8 | 9 |   |   |
-//!     +---+---+---+---+---+---+
-//!       ^           ^
-//!      top        bottom
-//!
-//!
-//!
-//! Example 2:
-//! Using std::greater as comparison predicate, we have the following situation:
-//!
-//!     full()      = true
-//!     empty()     = false
-//!     capacity()  = 6
-//!     size()      = 6
-//!     top()       = 9
-//!     bottom()    = 2
-//!
-//!     begin                    end
-//!       v                       v
-//!     +---+---+---+---+---+---+
-//!     | 9 | 8 | 6 | 4 | 3 | 2 |
-//!     +---+---+---+---+---+---+
-//!       ^                   ^
-//!      top                bottom
-//!
-//!     pop() removes the value 2
-//!     push(5) adds the value 5 and remove the value 2
-//!     push(0) do nothing
-//!
-template<class T,
-         class CompareT = std::less<T>>
-class limited_priority_queue
+namespace Ponca
 {
-public:
-    using value_type      = T;
-    using container_type  = std::vector<T>;
-    using compare         = CompareT;
-    using iterator        = typename container_type::iterator;
-    using const_iterator  = typename container_type::const_iterator;
-    using this_type       = limited_priority_queue<T,CompareT>;
 
-    // limited_priority_queue --------------------------------------------------
-public:
-    PONCA_MULTIARCH inline limited_priority_queue();
-    PONCA_MULTIARCH inline limited_priority_queue(const this_type& other);
-    PONCA_MULTIARCH inline explicit limited_priority_queue(int capacity);
-    template<class InputIt>
-    PONCA_MULTIARCH inline limited_priority_queue(int capacity, InputIt first, InputIt last);
-
-    PONCA_MULTIARCH inline ~limited_priority_queue();
-
-    PONCA_MULTIARCH inline limited_priority_queue& operator=(const this_type& other);
-
-    // Iterator ----------------------------------------------------------------
-public:
-    PONCA_MULTIARCH inline iterator       begin();
-    PONCA_MULTIARCH inline const_iterator begin() const;
-    PONCA_MULTIARCH inline const_iterator cbegin() const;
-
-    PONCA_MULTIARCH inline iterator       end();
-    PONCA_MULTIARCH inline const_iterator end() const;
-    PONCA_MULTIARCH inline const_iterator cend() const;
-
-    // Element access ----------------------------------------------------------
-public:
-    PONCA_MULTIARCH inline const T& top() const;
-    PONCA_MULTIARCH inline const T& bottom() const;
-
-    PONCA_MULTIARCH inline T& top();
-    PONCA_MULTIARCH inline T& bottom();
-
-    // Capacity ----------------------------------------------------------------
-public:
-    PONCA_MULTIARCH inline bool empty() const;
-    PONCA_MULTIARCH inline bool full() const;
-    PONCA_MULTIARCH inline size_t  size() const;
-    PONCA_MULTIARCH inline size_t  capacity() const;
-
-    // Modifiers ---------------------------------------------------------------
-public:
-    PONCA_MULTIARCH inline bool push(const T& value);
-    PONCA_MULTIARCH inline bool push(T&& value);
-
-    PONCA_MULTIARCH inline void pop();
-
-    PONCA_MULTIARCH inline void reserve(int capacity);
-
-    PONCA_MULTIARCH inline void clear();
-
-    // Data --------------------------------------------------------------------
-public:
-    PONCA_MULTIARCH inline const container_type& container() const;
-
-protected:
-    container_type  m_c;
-    compare         m_comp;
-    size_t          m_size {0};
-};
-
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-
-// limited_priority_queue ------------------------------------------------------
-
-template<class T, class Cmp>
-limited_priority_queue<T,Cmp>::limited_priority_queue() :
-    m_c(),
-    m_comp(),
-    m_size(0)
-{
-}
-
-
-template<class T, class Cmp>
-limited_priority_queue<T,Cmp>::limited_priority_queue(const this_type& other) :
-    m_c(other.m_c),
-    m_comp(other.m_comp),
-    m_size(other.m_size)
-{
-}
-
-template<class T, class Cmp>
-limited_priority_queue<T,Cmp>::limited_priority_queue(int capacity) :
-    m_c(capacity),
-    m_comp(),
-    m_size(0)
-{
-}
-
-template<class T, class Cmp>
-template<class InputIt>
-limited_priority_queue<T,Cmp>::limited_priority_queue(int capacity, InputIt first, InputIt last) :
-    m_c(capacity),
-    m_comp(),
-    m_size(0)
-{
-    for(InputIt it=first; it<last; ++it)
+    //!
+    //! \brief The limited_priority_queue class is similar to std::priority_queue
+    //! but has a limited capacity and handles the comparison differently.
+    //!
+    //! In case the capacity is reached, the container is full and push() do not
+    //! insert a new element if its priority is lower than the current minimal one.
+    //!
+    //! The comparison predicate must return true is the first argument has
+    //! priority on the second one.
+    //!
+    //! The element with the highest priority is the last one that is pop out, but
+    //! is the first one that is iterated through.
+    //!
+    //! Example 1:
+    //! Using std::less as comparison predicate, we have the following situation:
+    //!
+    //!     full()      = false
+    //!     empty()     = false
+    //!     capacity()  = 6
+    //!     size()      = 4
+    //!     top()       = 1
+    //!     bottom()    = 9
+    //!
+    //!     pop() removes the value 9
+    //!     push(4) adds the value 4
+    //!
+    //!     begin            end
+    //!       v               v
+    //!     +---+---+---+---+---+---+
+    //!     | 1 | 3 | 8 | 9 |   |   |
+    //!     +---+---+---+---+---+---+
+    //!       ^           ^
+    //!      top        bottom
+    //!
+    //!
+    //!
+    //! Example 2:
+    //! Using std::greater as comparison predicate, we have the following situation:
+    //!
+    //!     full()      = true
+    //!     empty()     = false
+    //!     capacity()  = 6
+    //!     size()      = 6
+    //!     top()       = 9
+    //!     bottom()    = 2
+    //!
+    //!     begin                    end
+    //!       v                       v
+    //!     +---+---+---+---+---+---+
+    //!     | 9 | 8 | 6 | 4 | 3 | 2 |
+    //!     +---+---+---+---+---+---+
+    //!       ^                   ^
+    //!      top                bottom
+    //!
+    //!     pop() removes the value 2
+    //!     push(5) adds the value 5 and remove the value 2
+    //!     push(0) do nothing
+    //!
+    template <class T, class CompareT = std::less<T>>
+    class limited_priority_queue
     {
-        push(*it);
+    public:
+        using value_type     = T;
+        using container_type = std::vector<T>;
+        using compare        = CompareT;
+        using iterator       = typename container_type::iterator;
+        using const_iterator = typename container_type::const_iterator;
+        using this_type      = limited_priority_queue<T, CompareT>;
+
+        // limited_priority_queue --------------------------------------------------
+    public:
+        PONCA_MULTIARCH inline limited_priority_queue();
+        PONCA_MULTIARCH inline limited_priority_queue(const this_type& other);
+        PONCA_MULTIARCH inline explicit limited_priority_queue(int capacity);
+        template <class InputIt>
+        PONCA_MULTIARCH inline limited_priority_queue(int capacity, InputIt first, InputIt last);
+
+        PONCA_MULTIARCH inline ~limited_priority_queue();
+
+        PONCA_MULTIARCH inline limited_priority_queue& operator=(const this_type& other);
+
+        // Iterator ----------------------------------------------------------------
+    public:
+        PONCA_MULTIARCH inline iterator begin();
+        PONCA_MULTIARCH inline const_iterator begin() const;
+        PONCA_MULTIARCH inline const_iterator cbegin() const;
+
+        PONCA_MULTIARCH inline iterator end();
+        PONCA_MULTIARCH inline const_iterator end() const;
+        PONCA_MULTIARCH inline const_iterator cend() const;
+
+        // Element access ----------------------------------------------------------
+    public:
+        PONCA_MULTIARCH inline const T& top() const;
+        PONCA_MULTIARCH inline const T& bottom() const;
+
+        PONCA_MULTIARCH inline T& top();
+        PONCA_MULTIARCH inline T& bottom();
+
+        // Capacity ----------------------------------------------------------------
+    public:
+        PONCA_MULTIARCH inline bool empty() const;
+        PONCA_MULTIARCH inline bool full() const;
+        PONCA_MULTIARCH inline size_t size() const;
+        PONCA_MULTIARCH inline size_t capacity() const;
+
+        // Modifiers ---------------------------------------------------------------
+    public:
+        PONCA_MULTIARCH inline bool push(const T& value);
+        PONCA_MULTIARCH inline bool push(T&& value);
+
+        PONCA_MULTIARCH inline void pop();
+
+        PONCA_MULTIARCH inline void reserve(int capacity);
+
+        PONCA_MULTIARCH inline void clear();
+
+        // Data --------------------------------------------------------------------
+    public:
+        PONCA_MULTIARCH inline const container_type& container() const;
+
+    protected:
+        container_type m_c;
+        compare m_comp;
+        size_t m_size{0};
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // limited_priority_queue ------------------------------------------------------
+
+    template <class T, class Cmp>
+    limited_priority_queue<T, Cmp>::limited_priority_queue() : m_c(), m_comp(), m_size(0)
+    {
     }
-}
 
-template<class T, class Cmp>
-limited_priority_queue<T,Cmp>::~limited_priority_queue()
-{
-}
-
-template<class T, class Cmp>
-limited_priority_queue<T,Cmp>& limited_priority_queue<T,Cmp>::operator=(const this_type& other)
-{
-    m_c    = other.m_c;
-    m_comp = other.m_comp;
-    m_size = other.m_size;
-    return *this;
-}
-
-// Iterator --------------------------------------------------------------------
-
-template<class T, class Cmp>
-typename limited_priority_queue<T,Cmp>::iterator limited_priority_queue<T,Cmp>::begin()
-{
-    return m_c.begin();
-}
-
-template<class T, class Cmp>
-typename limited_priority_queue<T,Cmp>::const_iterator limited_priority_queue<T,Cmp>::begin() const
-{
-    return m_c.begin();
-}
-
-template<class T, class Cmp>
-typename limited_priority_queue<T,Cmp>::const_iterator limited_priority_queue<T,Cmp>::cbegin() const
-{
-    return m_c.cbegin();
-}
-
-template<class T, class Cmp>
-typename limited_priority_queue<T,Cmp>::iterator limited_priority_queue<T,Cmp>::end()
-{
-    return m_c.begin() + m_size;
-}
-
-template<class T, class Cmp>
-typename limited_priority_queue<T,Cmp>::const_iterator limited_priority_queue<T,Cmp>::end() const
-{
-    return m_c.begin() + m_size;
-}
-
-template<class T, class Cmp>
-typename limited_priority_queue<T,Cmp>::const_iterator limited_priority_queue<T,Cmp>::cend() const
-{
-    return m_c.cbegin() + m_size;
-}
-
-// Element access --------------------------------------------------------------
-
-template<class T, class Cmp>
-const T& limited_priority_queue<T,Cmp>::top() const
-{
-    return m_c[0];
-}
-
-template<class T, class Cmp>
-const T& limited_priority_queue<T,Cmp>::bottom() const
-{
-    return m_c[m_size-1];
-}
-
-template<class T, class Cmp>
-T& limited_priority_queue<T,Cmp>::top()
-{
-    return m_c[0];
-}
-
-template<class T, class Cmp>
-T& limited_priority_queue<T,Cmp>::bottom()
-{
-    return m_c[m_size-1];
-}
-
-// Capacity --------------------------------------------------------------------
-
-template<class T, class Cmp>
-bool limited_priority_queue<T,Cmp>::empty() const
-{
-    return m_size == 0;
-}
-
-template<class T, class Cmp>
-bool limited_priority_queue<T,Cmp>::full() const
-{
-    return m_size == capacity();
-}
-
-template<class T, class Cmp>
-size_t limited_priority_queue<T,Cmp>::size() const
-{
-    return m_size;
-}
-
-template<class T, class Cmp>
-size_t limited_priority_queue<T,Cmp>::capacity() const
-{
-    return m_c.size();
-}
-
-// Modifiers -------------------------------------------------------------------
-
-template<class T, class Cmp>
-bool limited_priority_queue<T,Cmp>::push(const T& value)
-{
-    if(empty())
+    template <class T, class Cmp>
+    limited_priority_queue<T, Cmp>::limited_priority_queue(const this_type& other)
+        : m_c(other.m_c), m_comp(other.m_comp), m_size(other.m_size)
     {
-        if(capacity()>0)
+    }
+
+    template <class T, class Cmp>
+    limited_priority_queue<T, Cmp>::limited_priority_queue(int capacity) : m_c(capacity), m_comp(), m_size(0)
+    {
+    }
+
+    template <class T, class Cmp>
+    template <class InputIt>
+    limited_priority_queue<T, Cmp>::limited_priority_queue(int capacity, InputIt first, InputIt last)
+        : m_c(capacity), m_comp(), m_size(0)
+    {
+        for (InputIt it = first; it < last; ++it)
         {
-            m_c.front() = value;
-            ++m_size;
-            return true;
+            push(*it);
         }
     }
-    else
+
+    template <class T, class Cmp>
+    limited_priority_queue<T, Cmp>::~limited_priority_queue()
     {
-        iterator it = std::upper_bound(begin(), end(), value, m_comp);
-        if(it==end())
+    }
+
+    template <class T, class Cmp>
+    limited_priority_queue<T, Cmp>& limited_priority_queue<T, Cmp>::operator=(const this_type& other)
+    {
+        m_c    = other.m_c;
+        m_comp = other.m_comp;
+        m_size = other.m_size;
+        return *this;
+    }
+
+    // Iterator --------------------------------------------------------------------
+
+    template <class T, class Cmp>
+    typename limited_priority_queue<T, Cmp>::iterator limited_priority_queue<T, Cmp>::begin()
+    {
+        return m_c.begin();
+    }
+
+    template <class T, class Cmp>
+    typename limited_priority_queue<T, Cmp>::const_iterator limited_priority_queue<T, Cmp>::begin() const
+    {
+        return m_c.begin();
+    }
+
+    template <class T, class Cmp>
+    typename limited_priority_queue<T, Cmp>::const_iterator limited_priority_queue<T, Cmp>::cbegin() const
+    {
+        return m_c.cbegin();
+    }
+
+    template <class T, class Cmp>
+    typename limited_priority_queue<T, Cmp>::iterator limited_priority_queue<T, Cmp>::end()
+    {
+        return m_c.begin() + m_size;
+    }
+
+    template <class T, class Cmp>
+    typename limited_priority_queue<T, Cmp>::const_iterator limited_priority_queue<T, Cmp>::end() const
+    {
+        return m_c.begin() + m_size;
+    }
+
+    template <class T, class Cmp>
+    typename limited_priority_queue<T, Cmp>::const_iterator limited_priority_queue<T, Cmp>::cend() const
+    {
+        return m_c.cbegin() + m_size;
+    }
+
+    // Element access --------------------------------------------------------------
+
+    template <class T, class Cmp>
+    const T& limited_priority_queue<T, Cmp>::top() const
+    {
+        return m_c[0];
+    }
+
+    template <class T, class Cmp>
+    const T& limited_priority_queue<T, Cmp>::bottom() const
+    {
+        return m_c[m_size - 1];
+    }
+
+    template <class T, class Cmp>
+    T& limited_priority_queue<T, Cmp>::top()
+    {
+        return m_c[0];
+    }
+
+    template <class T, class Cmp>
+    T& limited_priority_queue<T, Cmp>::bottom()
+    {
+        return m_c[m_size - 1];
+    }
+
+    // Capacity --------------------------------------------------------------------
+
+    template <class T, class Cmp>
+    bool limited_priority_queue<T, Cmp>::empty() const
+    {
+        return m_size == 0;
+    }
+
+    template <class T, class Cmp>
+    bool limited_priority_queue<T, Cmp>::full() const
+    {
+        return m_size == capacity();
+    }
+
+    template <class T, class Cmp>
+    size_t limited_priority_queue<T, Cmp>::size() const
+    {
+        return m_size;
+    }
+
+    template <class T, class Cmp>
+    size_t limited_priority_queue<T, Cmp>::capacity() const
+    {
+        return m_c.size();
+    }
+
+    // Modifiers -------------------------------------------------------------------
+
+    template <class T, class Cmp>
+    bool limited_priority_queue<T, Cmp>::push(const T& value)
+    {
+        if (empty())
         {
-            if(!full())
+            if (capacity() > 0)
             {
-                *it = value;
+                m_c.front() = value;
                 ++m_size;
                 return true;
             }
         }
         else
         {
-            if(full())
+            iterator it = std::upper_bound(begin(), end(), value, m_comp);
+            if (it == end())
             {
-                std::copy_backward(it, end()-1, end());
-                *it = value;
+                if (!full())
+                {
+                    *it = value;
+                    ++m_size;
+                    return true;
+                }
             }
             else
             {
-                std::copy_backward(it, end(), end()+1);
-                *it = value;
-                ++m_size;
+                if (full())
+                {
+                    std::copy_backward(it, end() - 1, end());
+                    *it = value;
+                }
+                else
+                {
+                    std::copy_backward(it, end(), end() + 1);
+                    *it = value;
+                    ++m_size;
+                }
+                return true;
             }
-            return true;
         }
+        return false;
     }
-    return false;
-}
 
-template<class T, class Cmp>
-bool limited_priority_queue<T,Cmp>::push(T&& value)
-{
-    if(empty())
+    template <class T, class Cmp>
+    bool limited_priority_queue<T, Cmp>::push(T&& value)
     {
-        if(capacity()>0)
+        if (empty())
         {
-            m_c.front() = std::move(value);
-            ++m_size;
-            return true;
-        }
-    }
-    else
-    {
-        iterator it = std::upper_bound(begin(), end(), std::move(value), m_comp);
-        if(it==end())
-        {
-            if(!full())
+            if (capacity() > 0)
             {
-                *it = std::move(value);
+                m_c.front() = std::move(value);
                 ++m_size;
                 return true;
             }
         }
         else
         {
-            if(full())
+            iterator it = std::upper_bound(begin(), end(), std::move(value), m_comp);
+            if (it == end())
             {
-                std::copy_backward(it, end()-1, end());
-                *it = std::move(value);
+                if (!full())
+                {
+                    *it = std::move(value);
+                    ++m_size;
+                    return true;
+                }
             }
             else
             {
-                std::copy_backward(it, end(), end()+1);
-                *it = std::move(value);
-                ++m_size;
+                if (full())
+                {
+                    std::copy_backward(it, end() - 1, end());
+                    *it = std::move(value);
+                }
+                else
+                {
+                    std::copy_backward(it, end(), end() + 1);
+                    *it = std::move(value);
+                    ++m_size;
+                }
+                return true;
             }
-            return true;
         }
+        return false;
     }
-    return false;
-}
 
-template<class T, class Cmp>
-void limited_priority_queue<T,Cmp>::pop()
-{
-    --m_size;
-}
-
-template<class T, class Cmp>
-void limited_priority_queue<T,Cmp>::reserve(int capacity)
-{
-    if(m_size>capacity)
+    template <class T, class Cmp>
+    void limited_priority_queue<T, Cmp>::pop()
     {
-        m_size = capacity;
+        --m_size;
     }
-    m_c.resize(capacity);
-}
 
-template<class T, class Cmp>
-void limited_priority_queue<T,Cmp>::clear()
-{
-    m_size = 0;
-}
+    template <class T, class Cmp>
+    void limited_priority_queue<T, Cmp>::reserve(int capacity)
+    {
+        if (m_size > capacity)
+        {
+            m_size = capacity;
+        }
+        m_c.resize(capacity);
+    }
 
-// Data ------------------------------------------------------------------------
+    template <class T, class Cmp>
+    void limited_priority_queue<T, Cmp>::clear()
+    {
+        m_size = 0;
+    }
 
-template<class T, class Cmp>
-const typename limited_priority_queue<T,Cmp>::container_type& limited_priority_queue<T,Cmp>::container() const
-{
-    return m_c;
-}
+    // Data ------------------------------------------------------------------------
 
-}   
+    template <class T, class Cmp>
+    const typename limited_priority_queue<T, Cmp>::container_type& limited_priority_queue<T, Cmp>::container() const
+    {
+        return m_c;
+    }
+
+} // namespace Ponca

--- a/Ponca/src/Common/Containers/stack.h
+++ b/Ponca/src/Common/Containers/stack.h
@@ -12,113 +12,112 @@
 
 #include "../defines.h" //STD_SAFE_AT
 
-namespace Ponca {
-
-/// Stack with fixed-size storage
-///
-/// \warning This class does not destroy elements that are removed from the stack, but rather when
-/// they are overriden by another element (e.g. when running pop() and then push(). This makes it
-/// not appropriate to store smart pointers.
-///
-template<class T, int N>
-class Stack
+namespace Ponca
 {
-public:
-    /// Type of value stored in the Stack
-    using ValueType = T;
 
-    PONCA_MULTIARCH inline Stack();
+    /// Stack with fixed-size storage
+    ///
+    /// \warning This class does not destroy elements that are removed from the stack, but rather when
+    /// they are overriden by another element (e.g. when running pop() and then push(). This makes it
+    /// not appropriate to store smart pointers.
+    ///
+    template <class T, int N>
+    class Stack
+    {
+    public:
+        /// Type of value stored in the Stack
+        using ValueType = T;
 
-    /// Read access to the top element of the Stack
-    PONCA_MULTIARCH inline const T& top() const;
-    /// Write access to the top element of the Stack
-    PONCA_MULTIARCH inline       T& top();
+        PONCA_MULTIARCH inline Stack();
 
-    /// Is the stack empty
-    PONCA_MULTIARCH inline bool empty() const;
-    /// Get the number of elements in the Stack
-    PONCA_MULTIARCH inline int  size() const;
+        /// Read access to the top element of the Stack
+        PONCA_MULTIARCH inline const T& top() const;
+        /// Write access to the top element of the Stack
+        PONCA_MULTIARCH inline T& top();
 
-    /// Add an element on top of the stack.
-    /// \throw std::out_of_range when the Stack is full, only if compiled with PONCA_DEBUG
-    PONCA_MULTIARCH inline void push(const T& value);
+        /// Is the stack empty
+        PONCA_MULTIARCH inline bool empty() const;
+        /// Get the number of elements in the Stack
+        PONCA_MULTIARCH inline int size() const;
 
-    /// Add an element with default initialization
-    PONCA_MULTIARCH inline void push();
-    /// Pop the last element of the Stack
-    /// \note In practice the element is not destroyed, only the size of the Stack is reduced. This
-    /// makes the Stack not appropriate to store `shared_ptr`: counters will not be decremented.
-    PONCA_MULTIARCH inline void pop();
-    /// Clear the stack content.
-    /// \note Shares the same limitation than Stack::pop()
-    PONCA_MULTIARCH inline void clear();
+        /// Add an element on top of the stack.
+        /// \throw std::out_of_range when the Stack is full, only if compiled with PONCA_DEBUG
+        PONCA_MULTIARCH inline void push(const T& value);
 
-protected:
-    /// Number of elements in the Stack
-    int m_size;
-    /// Fixed-size data buffer
-    std::array<T,N> m_data;
-};
+        /// Add an element with default initialization
+        PONCA_MULTIARCH inline void push();
+        /// Pop the last element of the Stack
+        /// \note In practice the element is not destroyed, only the size of the Stack is reduced. This
+        /// makes the Stack not appropriate to store `shared_ptr`: counters will not be decremented.
+        PONCA_MULTIARCH inline void pop();
+        /// Clear the stack content.
+        /// \note Shares the same limitation than Stack::pop()
+        PONCA_MULTIARCH inline void clear();
 
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
+    protected:
+        /// Number of elements in the Stack
+        int m_size;
+        /// Fixed-size data buffer
+        std::array<T, N> m_data;
+    };
 
-template<class T, int N>
-Stack<T,N>::Stack() :
-    m_size(0),
-    m_data()
-{
-}
+    ////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////
 
-template<class T, int N>
-const T& Stack<T,N>::top() const
-{
-    return STD_SAFE_AT(m_data,m_size-1);
-}
+    template <class T, int N>
+    Stack<T, N>::Stack() : m_size(0), m_data()
+    {
+    }
 
-template<class T, int N>
-T& Stack<T,N>::top()
-{
-    return STD_SAFE_AT(m_data,m_size-1);
-}
+    template <class T, int N>
+    const T& Stack<T, N>::top() const
+    {
+        return STD_SAFE_AT(m_data, m_size - 1);
+    }
 
-template<class T, int N>
-bool Stack<T,N>::empty() const
-{
-    return m_size==0;
-}
+    template <class T, int N>
+    T& Stack<T, N>::top()
+    {
+        return STD_SAFE_AT(m_data, m_size - 1);
+    }
 
-template<class T, int N>
-int Stack<T,N>::size() const
-{
-    return m_size;
-}
+    template <class T, int N>
+    bool Stack<T, N>::empty() const
+    {
+        return m_size == 0;
+    }
 
-template<class T, int N>
-void Stack<T,N>::push(const T& value)
-{
-    STD_SAFE_AT(m_data,m_size) = value;
-    ++m_size;
-}
+    template <class T, int N>
+    int Stack<T, N>::size() const
+    {
+        return m_size;
+    }
 
-template<class T, int N>
-void Stack<T,N>::push()
-{
-    ++m_size;
-}
+    template <class T, int N>
+    void Stack<T, N>::push(const T& value)
+    {
+        STD_SAFE_AT(m_data, m_size) = value;
+        ++m_size;
+    }
 
-template<class T, int N>
-void Stack<T,N>::pop()
-{
-    --m_size;
-}
+    template <class T, int N>
+    void Stack<T, N>::push()
+    {
+        ++m_size;
+    }
 
-template<class T, int N>
-void Stack<T,N>::clear()
-{
-    m_size = 0;
-}
+    template <class T, int N>
+    void Stack<T, N>::pop()
+    {
+        --m_size;
+    }
+
+    template <class T, int N>
+    void Stack<T, N>::clear()
+    {
+        m_size = 0;
+    }
 
 } // namespace Ponca
 

--- a/Ponca/src/Common/Macro.h
+++ b/Ponca/src/Common/Macro.h
@@ -3,52 +3,51 @@
 #include <cstdio>
 
 // macro delimiters
-#define PONCA_MACRO_START do {
-#define PONCA_MACRO_END   } while(0)
+#define PONCA_MACRO_START \
+    do                    \
+    {
+#define PONCA_MACRO_END \
+    }                   \
+    while (0)
 
 // Stringification
 #define PONCA_XSTR(S) #S
 #define PONCA_STR(S) PONCA_XSTR(S)
 
-#define PONCA_CRASH                                                             \
-    PONCA_MACRO_START                                                           \
-    asm volatile ("int $3");                                                   \
+#define PONCA_CRASH         \
+    PONCA_MACRO_START       \
+    asm volatile("int $3"); \
     PONCA_MACRO_END
 
-#define PONCA_PRINT_ERROR(MSG)                                                  \
-    PONCA_MACRO_START                                                           \
-    fprintf(stderr,                                                            \
-            "%s:%i: [Error] %s\n",                                             \
-            __FILE__,__LINE__,MSG);                                            \
-    fflush(stderr);                                                            \
+#define PONCA_PRINT_ERROR(MSG)                                       \
+    PONCA_MACRO_START                                                \
+    fprintf(stderr, "%s:%i: [Error] %s\n", __FILE__, __LINE__, MSG); \
+    fflush(stderr);                                                  \
     PONCA_MACRO_END
 
-#define PONCA_PRINT_WARNING(MSG)                                                \
-    PONCA_MACRO_START                                                           \
-    fprintf(stderr,                                                            \
-            "%s:%i: [Warning] %s\n",                                           \
-            __FILE__,__LINE__,MSG);                                            \
-    fflush(stderr);                                                            \
+#define PONCA_PRINT_WARNING(MSG)                                       \
+    PONCA_MACRO_START                                                  \
+    fprintf(stderr, "%s:%i: [Warning] %s\n", __FILE__, __LINE__, MSG); \
+    fflush(stderr);                                                    \
     PONCA_MACRO_END
 
 // turnoff warning
-#define PONCA_UNUSED(VAR)                                                       \
-    PONCA_MACRO_START                                                           \
-    (void)(VAR);                                                               \
+#define PONCA_UNUSED(VAR)         \
+    PONCA_MACRO_START(void)(VAR); \
     PONCA_MACRO_END
 
-#define PONCA_TODO                                                              \
-    PONCA_MACRO_START                                                           \
-    PONCA_PRINT_ERROR("TODO");                                                  \
-    PONCA_CRASH;                                                                \
+#define PONCA_TODO             \
+    PONCA_MACRO_START          \
+    PONCA_PRINT_ERROR("TODO"); \
+    PONCA_CRASH;               \
     PONCA_MACRO_END
 
 #ifdef __has_builtin
-#if __has_builtin(__builtin_clz)
-#define PONCA_HAS_BUILTIN_CLZ 1
-#endif
+#    if __has_builtin(__builtin_clz)
+#        define PONCA_HAS_BUILTIN_CLZ 1
+#    endif
 #endif
 
 #ifndef PONCA_HAS_BUILTIN_CLZ
-#define PONCA_HAS_BUILTIN_CLZ 0
+#    define PONCA_HAS_BUILTIN_CLZ 0
 #endif

--- a/Ponca/src/Common/defines.h
+++ b/Ponca/src/Common/defines.h
@@ -74,7 +74,7 @@ namespace Ponca
      * hasNormal<MyPoint>::value will be true if MyPoint has a member function 'normal()'
      * \endcode
      *
-     * @tparam T The Point type
+     * \tparam T The Point type
      */
     template <typename T, typename = void>
     struct hasNormal : std::false_type {};

--- a/Ponca/src/Common/defines.h
+++ b/Ponca/src/Common/defines.h
@@ -4,64 +4,63 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 #pragma once
 
 /**
-  *
-  * \defgroup common Common module
-  * \brief This modules includes general purpose classes and methods.
-  *
-  */
+ *
+ * \defgroup common Common module
+ * \brief This modules includes general purpose classes and methods.
+ *
+ */
 
 ////////////////////////////////////////////////////////////////////////////////
 // Compatibility types, macros, functions
 //
 #ifdef __CUDACC__
-# include <cuda.h>
-# define PONCA_MULTIARCH __host__ __device__
-# define PONCA_MULTIARCH_HOST __host__
+#    include <cuda.h>
+#    define PONCA_MULTIARCH __host__ __device__
+#    define PONCA_MULTIARCH_HOST __host__
 #else
-# define PONCA_MULTIARCH
-# define PONCA_MULTIARCH_HOST
+#    define PONCA_MULTIARCH
+#    define PONCA_MULTIARCH_HOST
 
 // GCC: compile with -std=c++0x
-# if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ >= 5))
-#   if defined(nullptr_t) || (__cplusplus > 199711L) || defined(HACK_GCC_ITS_CPP0X)
-#     define __CPP0X__
-#   endif
-# endif
+#    if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ >= 5))
+#        if defined(nullptr_t) || (__cplusplus > 199711L) || defined(HACK_GCC_ITS_CPP0X)
+#            define __CPP0X__
+#        endif
+#    endif
 
 #endif // ifdef __CUDACC__
 
 #ifdef __CUDA_ARCH__
-  #define PONCA_MULTIARCH_INCLUDE_STD(FILENAME) "defines.h"
-  #define PONCA_MULTIARCH_STD_MATH(FUNC)
-  #define PONCA_MULTIARCH_STD_MATH_NAMESPACE(FUNC) FUNC
+#    define PONCA_MULTIARCH_INCLUDE_STD(FILENAME) "defines.h"
+#    define PONCA_MULTIARCH_STD_MATH(FUNC)
+#    define PONCA_MULTIARCH_STD_MATH_NAMESPACE(FUNC) FUNC
 
-  //see https://nvidia.github.io/libcudacxx/standard_api.html
-  #define PONCA_MULTIARCH_CU_STD_NAMESPACE(FUNC) cuda::std::FUNC
-  #define PONCA_MULTIARCH_INCLUDE_CU_STD(FILENAME) <cuda/std/FILENAME>
+// see https://nvidia.github.io/libcudacxx/standard_api.html
+#    define PONCA_MULTIARCH_CU_STD_NAMESPACE(FUNC) cuda::std::FUNC
+#    define PONCA_MULTIARCH_INCLUDE_CU_STD(FILENAME) <cuda/std/FILENAME>
 
-  #define PONCA_CUDA_ARCH
+#    define PONCA_CUDA_ARCH
 #else
-  #define PONCA_MULTIARCH_INCLUDE_STD(FILENAME) <FILENAME>
-  #define PONCA_MULTIARCH_STD_MATH(FUNC) using std::FUNC;
-  #define PONCA_MULTIARCH_STD_MATH_NAMESPACE(FUNC) std::FUNC
-  #define PONCA_MULTIARCH_CU_STD_NAMESPACE(FUNC) std::FUNC
-  #define PONCA_MULTIARCH_INCLUDE_CU_STD(FILENAME) <FILENAME>
-  #define PONCA_CPU_ARCH
+#    define PONCA_MULTIARCH_INCLUDE_STD(FILENAME) <FILENAME>
+#    define PONCA_MULTIARCH_STD_MATH(FUNC) using std::FUNC;
+#    define PONCA_MULTIARCH_STD_MATH_NAMESPACE(FUNC) std::FUNC
+#    define PONCA_MULTIARCH_CU_STD_NAMESPACE(FUNC) std::FUNC
+#    define PONCA_MULTIARCH_INCLUDE_CU_STD(FILENAME) <FILENAME>
+#    define PONCA_CPU_ARCH
 #endif
 
 #ifndef PONCA_DEBUG
-#define STD_SAFE_AT(C,i) C[i]
+#    define STD_SAFE_AT(C, i) C[i]
 #else
-#define STD_SAFE_AT(C,i) C.at(i)
+#    define STD_SAFE_AT(C, i) C.at(i)
 #endif
 
 #ifndef M_PI
 // Source: http://www.geom.uiuc.edu/~huberty/math5337/groupe/digits.html
-#define M_PI 3.141592653589793238462643383279502884197169399375105820974944592307816406
+#    define M_PI 3.141592653589793238462643383279502884197169399375105820974944592307816406
 #endif
 
 namespace Ponca
@@ -77,10 +76,14 @@ namespace Ponca
      * \tparam T The Point type
      */
     template <typename T, typename = void>
-    struct hasNormal : std::false_type {};
+    struct hasNormal : std::false_type
+    {
+    };
 
     /// \copydoc hasNormal<typename,typename>
     template <typename T>
-    struct hasNormal<T, std::void_t<decltype(std::declval<T>().normal())>> : std::true_type {};
+    struct hasNormal<T, std::void_t<decltype(std::declval<T>().normal())>> : std::true_type
+    {
+    };
 } // namespace Ponca
 

--- a/Ponca/src/Common/pointGeneration.h
+++ b/Ponca/src/Common/pointGeneration.h
@@ -16,40 +16,39 @@ This Source Code Form is subject to the terms of the Mozilla Public
 #define MIN_NOISE 0.99
 #define MAX_NOISE 1.01
 
-namespace Ponca {
+namespace Ponca
+{
 
     /*! \brief Generate points on a sphere */
-    template<typename DataPoint>
-    [[nodiscard]] DataPoint getPointOnSphere(
-        const typename DataPoint::Scalar _radius,
-        const typename DataPoint::VectorType _vCenter,
-        const bool _bAddPositionNoise = true,
-        const bool _bAddNormalNoise = true,
-        const bool _bReverseNormals = false
-    ) {
+    template <typename DataPoint>
+    [[nodiscard]] DataPoint getPointOnSphere(const typename DataPoint::Scalar _radius,
+                                             const typename DataPoint::VectorType _vCenter,
+                                             const bool _bAddPositionNoise = true, const bool _bAddNormalNoise = true,
+                                             const bool _bReverseNormals = false)
+    {
         typedef typename DataPoint::Scalar Scalar;
         typedef typename DataPoint::VectorType VectorType;
 
         VectorType vNormal   = VectorType::Random().normalized();
         VectorType vPosition = _vCenter + vNormal * _radius;
 
-        if(_bAddPositionNoise)
+        if (_bAddPositionNoise)
         {
             vPosition = vPosition + VectorType::Random().normalized() *
-                    Eigen::internal::random<Scalar>(Scalar(0.), Scalar(1. - MIN_NOISE));
+                                        Eigen::internal::random<Scalar>(Scalar(0.), Scalar(1. - MIN_NOISE));
             vNormal = (vPosition - _vCenter).normalized();
         }
 
-        if(_bAddNormalNoise)
+        if (_bAddNormalNoise)
         {
-            VectorType vTempPos =  vPosition + VectorType::Random().normalized() *
-                    Eigen::internal::random<Scalar>(Scalar(0.), Scalar(1. - MIN_NOISE));
+            VectorType vTempPos = vPosition + VectorType::Random().normalized() *
+                                                  Eigen::internal::random<Scalar>(Scalar(0.), Scalar(1. - MIN_NOISE));
             vNormal = (vTempPos - _vCenter).normalized();
         }
-        if(_bReverseNormals)
+        if (_bReverseNormals)
         {
             const float reverse = Eigen::internal::random<float>(0.f, 1.f);
-            if(reverse > 0.5f)
+            if (reverse > 0.5f)
                 vNormal = -vNormal;
         }
 
@@ -57,17 +56,15 @@ namespace Ponca {
     }
 
     /// \brief Sample points on a circle in the xy plane
-    template<typename VectorType>
-    [[nodiscard]] VectorType getPointOnCircle(
-        typename VectorType::Scalar _radius,
-        VectorType _vCenter
-    ) {
+    template <typename VectorType>
+    [[nodiscard]] VectorType getPointOnCircle(typename VectorType::Scalar _radius, VectorType _vCenter)
+    {
         using Scalar = typename VectorType::Scalar;
         // Generate random angle
-        const Scalar theta = Eigen::internal::random<Scalar>(0, Scalar(2.*EIGEN_PI));
+        const Scalar theta = Eigen::internal::random<Scalar>(0, Scalar(2. * EIGEN_PI));
 
         // Generate random radius (adjusted for uniform area distribution)
-        const Scalar r = _radius * std::sqrt(Eigen::internal::random<Scalar>(0,1));
+        const Scalar r = _radius * std::sqrt(Eigen::internal::random<Scalar>(0, 1));
 
         // Convert to Cartesian coordinates
         VectorType p = _vCenter;
@@ -78,191 +75,161 @@ namespace Ponca {
     }
 
     /*! \brief Generate points on a plane without normals */
-    template<typename DataPoint>
-    [[nodiscard]] DataPoint getPointOnRectangularPlane(
-        const typename DataPoint::VectorType& _vPosition,
-        const typename DataPoint::VectorType& /*_vNormal*/,
-        const typename DataPoint::Scalar& _width,
-        const typename DataPoint::Scalar& _height,
-        const typename DataPoint::VectorType& _localxAxis,
-        const typename DataPoint::VectorType& _localyAxis,
-        const bool _bAddPositionNoise = true
-    ) {
+    template <typename DataPoint>
+    [[nodiscard]] DataPoint getPointOnRectangularPlane(const typename DataPoint::VectorType& _vPosition,
+                                                       const typename DataPoint::VectorType& /*_vNormal*/,
+                                                       const typename DataPoint::Scalar& _width,
+                                                       const typename DataPoint::Scalar& _height,
+                                                       const typename DataPoint::VectorType& _localxAxis,
+                                                       const typename DataPoint::VectorType& _localyAxis,
+                                                       const bool _bAddPositionNoise = true)
+    {
         typedef typename DataPoint::Scalar Scalar;
         typedef typename DataPoint::VectorType VectorType;
 
-        const Scalar u = Eigen::internal::random<Scalar>(
-            -_width /Scalar(2), _width /Scalar(2) );
-        const Scalar v = Eigen::internal::random<Scalar>(
-            -_height/Scalar(2), _height/Scalar(2) );
+        const Scalar u = Eigen::internal::random<Scalar>(-_width / Scalar(2), _width / Scalar(2));
+        const Scalar v = Eigen::internal::random<Scalar>(-_height / Scalar(2), _height / Scalar(2));
 
-        VectorType vRandomPosition = _vPosition + u*_localxAxis + v*_localyAxis;
+        VectorType vRandomPosition = _vPosition + u * _localxAxis + v * _localyAxis;
 
-        if(_bAddPositionNoise)
+        if (_bAddPositionNoise)
         {
             vRandomPosition = vRandomPosition +
-                    VectorType::Random().normalized() *
-                    Eigen::internal::random<Scalar>(0., 1. - MIN_NOISE);
+                              VectorType::Random().normalized() * Eigen::internal::random<Scalar>(0., 1. - MIN_NOISE);
         }
 
         return DataPoint(vRandomPosition);
     }
 
     /*! \brief Generate points on a plane */
-    template<typename DataPoint>
-    [[nodiscard]] DataPoint getPointOnPlane(
-        const typename DataPoint::VectorType _vPosition,
-        const typename DataPoint::VectorType _vNormal,
-        const typename DataPoint::Scalar _radius,
-        const bool _bAddPositionNoise = true,
-        const bool _bAddNormalNoise = true,
-        const bool _bReverseNormals = false
-    ) {
+    template <typename DataPoint>
+    [[nodiscard]] DataPoint getPointOnPlane(const typename DataPoint::VectorType _vPosition,
+                                            const typename DataPoint::VectorType _vNormal,
+                                            const typename DataPoint::Scalar _radius,
+                                            const bool _bAddPositionNoise = true, const bool _bAddNormalNoise = true,
+                                            const bool _bReverseNormals = false)
+    {
         typedef typename DataPoint::Scalar Scalar;
         typedef typename DataPoint::VectorType VectorType;
         typedef Eigen::Quaternion<Scalar> QuaternionType;
 
         VectorType vRandom;
         VectorType vRandomDirection = VectorType::Zero();
-        VectorType vRandomPoint = VectorType::Zero();
-        VectorType vLocalUp     = _vNormal;
+        VectorType vRandomPoint     = VectorType::Zero();
+        VectorType vLocalUp         = _vNormal;
 
         do
         {
-            vRandom = VectorType::Random().normalized(); // Direction in the unit sphere
+            vRandom          = VectorType::Random().normalized(); // Direction in the unit sphere
             vRandomDirection = vRandom.cross(vLocalUp);
-        }
-        while(vRandomDirection == VectorType::Zero());
+        } while (vRandomDirection == VectorType::Zero());
 
         vRandomDirection = vRandomDirection.normalized();
-        vRandomPoint = vRandomDirection * _radius;
+        vRandomPoint     = vRandomDirection * _radius;
         vRandomPoint += _vPosition;
 
-        if(_bAddPositionNoise)
+        if (_bAddPositionNoise)
         {
             vRandomPoint = vRandomPoint + VectorType::Random().normalized() *
-                    Eigen::internal::random<Scalar>(Scalar(0), Scalar(1. - MIN_NOISE));
+                                              Eigen::internal::random<Scalar>(Scalar(0), Scalar(1. - MIN_NOISE));
         }
 
-        if(_bAddNormalNoise)
+        if (_bAddNormalNoise)
         {
-            VectorType vLocalLeft = vLocalUp.cross(vRandomDirection);
+            VectorType vLocalLeft  = vLocalUp.cross(vRandomDirection);
             VectorType vLocalFront = vLocalLeft.cross(vLocalUp);
 
             Scalar rotationAngle     = Eigen::internal::random<Scalar>(Scalar(-M_PI / 16.), Scalar(M_PI / 16.));
             VectorType vRotationAxis = vLocalLeft;
             QuaternionType qRotation = QuaternionType(Eigen::AngleAxis<Scalar>(rotationAngle, vRotationAxis));
-            qRotation = qRotation.normalized();
-            vLocalUp  = qRotation * vLocalUp;
+            qRotation                = qRotation.normalized();
+            vLocalUp                 = qRotation * vLocalUp;
 
             rotationAngle = Eigen::internal::random<Scalar>(Scalar(-M_PI / 16.), Scalar(M_PI / 16.));
             vRotationAxis = vLocalFront;
-            qRotation = QuaternionType(Eigen::AngleAxis<Scalar>(rotationAngle, vRotationAxis));
-            qRotation = qRotation.normalized();
-            vLocalUp = qRotation * vLocalUp;
+            qRotation     = QuaternionType(Eigen::AngleAxis<Scalar>(rotationAngle, vRotationAxis));
+            qRotation     = qRotation.normalized();
+            vLocalUp      = qRotation * vLocalUp;
         }
 
-        if(_bReverseNormals)
+        if (_bReverseNormals)
         {
             const float reverse = Eigen::internal::random<float>(0.f, 1.f);
-            if(reverse > 0.5f)
+            if (reverse > 0.5f)
                 vLocalUp = -vLocalUp;
-
         }
 
         return DataPoint(vRandomPoint, vLocalUp);
     }
 
-    namespace internal {
+    namespace internal
+    {
         /*! \brief Generate z value using the equation z = ax^2 + by^2 */
-        template<typename Scalar>
-        [[nodiscard]] inline Scalar getParaboloidZ(
-            const Scalar _x,
-            const Scalar _y,
-            const Scalar _a,
-            const Scalar _b
-        ) {
-            return _a*_x*_x + _b*_y*_y;
+        template <typename Scalar>
+        [[nodiscard]] inline Scalar getParaboloidZ(const Scalar _x, const Scalar _y, const Scalar _a, const Scalar _b)
+        {
+            return _a * _x * _x + _b * _y * _y;
         }
 
         /// Generate z value using the equation z = ax^2 + by^2 + cxy + dx + ey + f
-        template<typename Scalar>
-        [[nodiscard]] inline Scalar
-        getParaboloidZ(Scalar _x,
-                       Scalar _y,
-                       Scalar _a,
-                       Scalar _b,
-                       Scalar _c,
-                       Scalar _d,
-                       Scalar _e,
-                       Scalar _f)
+        template <typename Scalar>
+        [[nodiscard]] inline Scalar getParaboloidZ(Scalar _x, Scalar _y, Scalar _a, Scalar _b, Scalar _c, Scalar _d,
+                                                   Scalar _e, Scalar _f)
         {
-            return _a*_x*_x + _b*_y*_y + _c*_x*_y + _d*_x + _e*_y + _f;
+            return _a * _x * _x + _b * _y * _y + _c * _x * _y + _d * _x + _e * _y + _f;
         }
 
         /*! \brief Generate z value using the equation z = ax^2 + by^2 */
-        template<typename VectorType>
-        [[nodiscard]] inline VectorType getParaboloidNormal(
-            const VectorType& in,
-            const typename VectorType::Scalar _a,
-            const typename VectorType::Scalar _b
-        ) {
-            return VectorType((_a * in.x()), (_b * in.y()), -1.).normalized();;
-        }
-        template<typename DataPoint>
-        inline typename std::enable_if<Ponca::hasNormal<DataPoint>::value, void>::type
-        getParaboloidNormal(DataPoint& in,
-                    typename DataPoint::Scalar _a,
-                    typename DataPoint::Scalar _b,
-                    typename DataPoint::Scalar _c,
-                    typename DataPoint::Scalar _d,
-                    typename DataPoint::Scalar _e,
-                    typename DataPoint::Scalar _f)
+        template <typename VectorType>
+        [[nodiscard]] inline VectorType getParaboloidNormal(const VectorType& in, const typename VectorType::Scalar _a,
+                                                            const typename VectorType::Scalar _b)
         {
-            static constexpr typename DataPoint::Scalar two {2};
-            auto& pos = in.pos();
-            in.normal() = typename DataPoint::VectorType(two*_a * pos.x() + _c*pos.y() + _d,
-                                                         two*_b * pos.y() + _c*pos.x() + _d,
-                                                         -1.).normalized();
+            return VectorType((_a * in.x()), (_b * in.y()), -1.).normalized();
+            ;
+        }
+        template <typename DataPoint>
+        inline typename std::enable_if<Ponca::hasNormal<DataPoint>::value, void>::type getParaboloidNormal(
+            DataPoint& in, typename DataPoint::Scalar _a, typename DataPoint::Scalar _b, typename DataPoint::Scalar _c,
+            typename DataPoint::Scalar _d, typename DataPoint::Scalar _e, typename DataPoint::Scalar _f)
+        {
+            static constexpr typename DataPoint::Scalar two{2};
+            auto& pos   = in.pos();
+            in.normal() = typename DataPoint::VectorType(two * _a * pos.x() + _c * pos.y() + _d,
+                                                         two * _b * pos.y() + _c * pos.x() + _d, -1.)
+                              .normalized();
         }
 
-        template<typename DataPoint>
-        inline typename std::enable_if<! Ponca::hasNormal<DataPoint>::value, void>::type
-        getParaboloidNormal(DataPoint& in,
-                            typename DataPoint::Scalar _a,
-                            typename DataPoint::Scalar _b,
-                            typename DataPoint::Scalar _c,
-                            typename DataPoint::Scalar _d,
-                            typename DataPoint::Scalar _e,
-                            typename DataPoint::Scalar _f)
-        { }
-    }
+        template <typename DataPoint>
+        inline typename std::enable_if<!Ponca::hasNormal<DataPoint>::value, void>::type getParaboloidNormal(
+            DataPoint& in, typename DataPoint::Scalar _a, typename DataPoint::Scalar _b, typename DataPoint::Scalar _c,
+            typename DataPoint::Scalar _d, typename DataPoint::Scalar _e, typename DataPoint::Scalar _f)
+        {
+        }
+    } // namespace internal
 
     /*! \brief Generate point samples on the primitive z = ax^2 + by^2
      *
      * Points (x,y) are generated in the interval [-_s, -s]^2
      */
-    template<typename DataPoint>
-    [[nodiscard]] DataPoint getPointOnParaboloid(
-        const typename DataPoint::Scalar _a,
-        const typename DataPoint::Scalar _b,
-        const typename DataPoint::Scalar _s,
-        const bool _bAddNoise = true
-    ) {
+    template <typename DataPoint>
+    [[nodiscard]] DataPoint getPointOnParaboloid(const typename DataPoint::Scalar _a,
+                                                 const typename DataPoint::Scalar _b,
+                                                 const typename DataPoint::Scalar _s, const bool _bAddNoise = true)
+    {
         typedef typename DataPoint::Scalar Scalar;
         typedef typename DataPoint::VectorType VectorType;
 
         VectorType vNormal;
         VectorType vPosition;
 
-        const Scalar x = Eigen::internal::random<Scalar>(-_s, _s),
-                     y = Eigen::internal::random<Scalar>(-_s, _s);
+        const Scalar x = Eigen::internal::random<Scalar>(-_s, _s), y = Eigen::internal::random<Scalar>(-_s, _s);
 
-        vPosition = { x, y, internal::getParaboloidZ(x, y, _a, _b)};
+        vPosition = {x, y, internal::getParaboloidZ(x, y, _a, _b)};
         vNormal   = internal::getParaboloidNormal(vPosition, _a, _b);
 
-        if(_bAddNoise) // spherical noise
-            vPosition += VectorType::Random().normalized() * Eigen::internal::random<Scalar>(Scalar(0), Scalar(1. - MIN_NOISE));
+        if (_bAddNoise) // spherical noise
+            vPosition +=
+                VectorType::Random().normalized() * Eigen::internal::random<Scalar>(Scalar(0), Scalar(1. - MIN_NOISE));
 
         return DataPoint(vPosition, vNormal);
     }
@@ -270,16 +237,11 @@ namespace Ponca {
     /// Generate point samples on the primitive z = ax^2 + by^2
     /// Points (x,y) are generated in the interval [-_s, -s]^2
     /// See getParaboloidZ and getParaboloidNormal
-    template<typename DataPoint>
-    [[nodiscard]] DataPoint
-    getPointOnParaboloid(typename DataPoint::Scalar _a,
-                         typename DataPoint::Scalar _b,
-                         typename DataPoint::Scalar _c,
-                         typename DataPoint::Scalar _d,
-                         typename DataPoint::Scalar _e,
-                         typename DataPoint::Scalar _f,
-                         typename DataPoint::Scalar _s,
-                         bool _bAddNoise = true)
+    template <typename DataPoint>
+    [[nodiscard]] DataPoint getPointOnParaboloid(typename DataPoint::Scalar _a, typename DataPoint::Scalar _b,
+                                                 typename DataPoint::Scalar _c, typename DataPoint::Scalar _d,
+                                                 typename DataPoint::Scalar _e, typename DataPoint::Scalar _f,
+                                                 typename DataPoint::Scalar _s, bool _bAddNoise = true)
     {
         typedef typename DataPoint::Scalar Scalar;
         typedef typename DataPoint::VectorType VectorType;
@@ -287,38 +249,37 @@ namespace Ponca {
         DataPoint out;
 
         // generate random position in polar coordinates to get points on the circle
-        out.pos() = getPointOnCircle(_s, VectorType({0,0,0}));
+        out.pos()     = getPointOnCircle(_s, VectorType({0, 0, 0}));
         out.pos().z() = internal::getParaboloidZ(out.pos().x(), out.pos().y(), _a, _b, _c, _d, _e, _f);
 
         // does nothing if the point type does not have a normal field.
         internal::getParaboloidNormal(out, _a, _b, _c, _d, _e, _f);
 
-        if(_bAddNoise) //spherical noise
+        if (_bAddNoise) // spherical noise
         {
-            out.pos() += VectorType::Random().normalized() * Eigen::internal::random<Scalar>(Scalar(0), Scalar(1. - MIN_NOISE));
+            out.pos() +=
+                VectorType::Random().normalized() * Eigen::internal::random<Scalar>(Scalar(0), Scalar(1. - MIN_NOISE));
         }
 
         return out;
     }
 
-
-    template<typename DataPoint, typename Params>
-    [[nodiscard]] DataPoint
-    getPointOnParaboloid(const Params &_params,
-                         typename DataPoint::Scalar _s,
-                         bool _bAddNoise = true)
+    template <typename DataPoint, typename Params>
+    [[nodiscard]] DataPoint getPointOnParaboloid(const Params& _params, typename DataPoint::Scalar _s,
+                                                 bool _bAddNoise = true)
     {
-        return getPointOnParaboloid<DataPoint>(_params(0), _params(1), _params(2),
-                                               _params(3), _params(4), _params(5), _s, _bAddNoise);
+        return getPointOnParaboloid<DataPoint>(_params(0), _params(1), _params(2), _params(3), _params(4), _params(5),
+                                               _s, _bAddNoise);
     }
 
     /*! \brief Generate a random points */
-    template<typename DataPoint>
-    [[nodiscard]] DataPoint getRandomPoint() {
+    template <typename DataPoint>
+    [[nodiscard]] DataPoint getRandomPoint()
+    {
         typedef typename DataPoint::VectorType VectorType;
         typedef typename DataPoint::Scalar Scalar;
         const VectorType n = VectorType::Random().normalized();
         const VectorType p = n * Eigen::internal::random<Scalar>(MIN_NOISE, MAX_NOISE);
-        return {p, (n + VectorType::Random()*Scalar(0.1)).normalized()};
+        return {p, (n + VectorType::Random() * Scalar(0.1)).normalized()};
     }
-}
+} // namespace Ponca

--- a/Ponca/src/Common/pointTypes.h
+++ b/Ponca/src/Common/pointTypes.h
@@ -13,29 +13,34 @@ This Source Code Form is subject to the terms of the Mozilla Public
   \brief Useful user-end DataPoint types
 */
 
-namespace Ponca {
+namespace Ponca
+{
     // [PointPositionNormal]
     //! \brief Point data type containing the position and normal vectors.
-    template<typename _Scalar, int _Dim>
+    template <typename _Scalar, int _Dim>
     class PointPositionNormal
     {
     public:
-        enum {Dim = _Dim};
+        enum
+        {
+            Dim = _Dim
+        };
         typedef _Scalar Scalar;
-        typedef Eigen::Matrix<Scalar, Dim,   1>	VectorType;
-        typedef Eigen::Matrix<Scalar, Dim, Dim>	MatrixType;
+        typedef Eigen::Matrix<Scalar, Dim, 1> VectorType;
+        typedef Eigen::Matrix<Scalar, Dim, Dim> MatrixType;
 
-        PONCA_MULTIARCH inline PointPositionNormal(
-                const VectorType &pos    = VectorType::Zero(),
-                const VectorType& normal = VectorType::Zero()
-        ) : m_pos(pos), m_normal(normal) {}
+        PONCA_MULTIARCH inline PointPositionNormal(const VectorType& pos    = VectorType::Zero(),
+                                                   const VectorType& normal = VectorType::Zero())
+            : m_pos(pos), m_normal(normal)
+        {
+        }
 
         //! \brief Get the point position.
-        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& pos()    const { return m_pos; }
+        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& pos() const { return m_pos; }
         //! \brief Get the point normal.
         PONCA_MULTIARCH [[nodiscard]] inline const VectorType& normal() const { return m_normal; }
         //! \copybrief pos
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType& pos()    { return m_pos; }
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType& pos() { return m_pos; }
         //! \copybrief normal
         PONCA_MULTIARCH [[nodiscard]] inline VectorType& normal() { return m_normal; }
 
@@ -46,29 +51,29 @@ namespace Ponca {
 
     // [PointPosition]
     //! \brief Point data type containing only containing the position vector.
-    template<typename _Scalar, int _Dim>
+    template <typename _Scalar, int _Dim>
     class PointPosition
     {
     public:
-        enum {Dim = _Dim};
+        enum
+        {
+            Dim = _Dim
+        };
         typedef _Scalar Scalar;
-        typedef Eigen::Matrix<Scalar, Dim,   1>	VectorType;
-        typedef Eigen::Matrix<Scalar, Dim, Dim>	MatrixType;
+        typedef Eigen::Matrix<Scalar, Dim, 1> VectorType;
+        typedef Eigen::Matrix<Scalar, Dim, Dim> MatrixType;
 
-        PONCA_MULTIARCH inline PointPosition(
-            const VectorType &pos = VectorType::Zero()
-        ) : m_pos(pos) {}
+        PONCA_MULTIARCH inline PointPosition(const VectorType& pos = VectorType::Zero()) : m_pos(pos) {}
 
         //! \copybrief PointPositionNormal::pos
-        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& pos()    const { return m_pos; }
+        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& pos() const { return m_pos; }
         //! \copybrief PointPositionNormal::pos
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType& pos()    { return m_pos; }
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType& pos() { return m_pos; }
 
     private:
         VectorType m_pos;
     };
     // [PointPosition]
-
 
     // [PointPositionNormalBinding]
     /*! \brief Variant of the \ref PointPositionNormal data type that uses external raw data.
@@ -80,28 +85,31 @@ namespace Ponca {
      *
      * \see PointPositionNormal
      */
-    template<typename _Scalar, int _Dim>
+    template <typename _Scalar, int _Dim>
     class PointPositionNormalBinding
     {
     public:
-        enum {Dim = _Dim};
+        enum
+        {
+            Dim = _Dim
+        };
         typedef _Scalar Scalar;
-        typedef Eigen::Matrix<Scalar, Dim, 1>   VectorType;
+        typedef Eigen::Matrix<Scalar, Dim, 1> VectorType;
         typedef Eigen::Matrix<Scalar, Dim, Dim> MatrixType;
 
-        PONCA_MULTIARCH inline PointPositionNormalBinding(
-            const Scalar* _interlacedArray, const int _pId
-        ) : m_pos   (Eigen::Map< const VectorType >(_interlacedArray + Dim*2*_pId  )),
-            m_normal(Eigen::Map< const VectorType >(_interlacedArray + Dim*2*_pId+Dim))
-        {}
+        PONCA_MULTIARCH inline PointPositionNormalBinding(const Scalar* _interlacedArray, const int _pId)
+            : m_pos(Eigen::Map<const VectorType>(_interlacedArray + Dim * 2 * _pId)),
+              m_normal(Eigen::Map<const VectorType>(_interlacedArray + Dim * 2 * _pId + Dim))
+        {
+        }
 
         //! \copybrief PointPositionNormal::pos
-        PONCA_MULTIARCH [[nodiscard]] inline const Eigen::Map< const VectorType >& pos()    const { return m_pos; }
+        PONCA_MULTIARCH [[nodiscard]] inline const Eigen::Map<const VectorType>& pos() const { return m_pos; }
         //! \copybrief PointPositionNormal::normal
-        PONCA_MULTIARCH [[nodiscard]] inline const Eigen::Map< const VectorType >& normal() const { return m_normal; }
+        PONCA_MULTIARCH [[nodiscard]] inline const Eigen::Map<const VectorType>& normal() const { return m_normal; }
 
     private:
-        const Eigen::Map< const VectorType > m_pos, m_normal;
+        const Eigen::Map<const VectorType> m_pos, m_normal;
     };
     // [PointPositionNormalBinding]
 
@@ -116,33 +124,40 @@ namespace Ponca {
      *
      * \see PointPositionNormal
      */
-    template<typename _Scalar, int _Dim>
+    template <typename _Scalar, int _Dim>
     class PointPositionNormalLazyBinding
     {
     public:
-        enum {Dim = _Dim};
+        enum
+        {
+            Dim = _Dim
+        };
         typedef _Scalar Scalar;
-        typedef Eigen::Matrix<Scalar, Dim, 1>   VectorType;
+        typedef Eigen::Matrix<Scalar, Dim, 1> VectorType;
         typedef Eigen::Matrix<Scalar, Dim, Dim> MatrixType;
 
         PONCA_MULTIARCH inline PointPositionNormalLazyBinding(Scalar* _interlacedArray, const int _pId)
-            : m_interlacedArray (_interlacedArray),
-            m_id(_pId)
-        {}
-
-        //! \brief Allows change of reference
-        PONCA_MULTIARCH inline void bind(Scalar* _interlacedArray) {
-            m_interlacedArray = _interlacedArray;
+            : m_interlacedArray(_interlacedArray), m_id(_pId)
+        {
         }
 
+        //! \brief Allows change of reference
+        PONCA_MULTIARCH inline void bind(Scalar* _interlacedArray) { m_interlacedArray = _interlacedArray; }
+
         //! \copybrief PointPositionNormal::pos
-        PONCA_MULTIARCH [[nodiscard]] inline Eigen::Map< const VectorType > pos()    const { return Eigen::Map< const VectorType >(m_interlacedArray + Dim*2*m_id); }
+        PONCA_MULTIARCH [[nodiscard]] inline Eigen::Map<const VectorType> pos() const
+        {
+            return Eigen::Map<const VectorType>(m_interlacedArray + Dim * 2 * m_id);
+        }
         //! \copybrief PointPositionNormal::normal
-        PONCA_MULTIARCH [[nodiscard]] inline Eigen::Map< const VectorType > normal() const { return Eigen::Map< const VectorType >(m_interlacedArray + Dim*2*m_id+Dim); }
+        PONCA_MULTIARCH [[nodiscard]] inline Eigen::Map<const VectorType> normal() const
+        {
+            return Eigen::Map<const VectorType>(m_interlacedArray + Dim * 2 * m_id + Dim);
+        }
 
     private:
-        Scalar * m_interlacedArray;
+        Scalar* m_interlacedArray;
         const int m_id;
     };
     // [PointPositionNormalLazyBinding]
-}
+} // namespace Ponca

--- a/Ponca/src/Fitting/algebraicSphere.h
+++ b/Ponca/src/Fitting/algebraicSphere.h
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 #pragma once
 
 #include "./defines.h"
@@ -17,263 +16,267 @@
 namespace Ponca
 {
 
-/*!
-    \brief Algebraic Sphere primitive
-
-    Method published in \cite Guennebaud:2007:APSS
-
-    An algebraic hyper-sphere is defined as the \f$0\f$-isosurface of the scalar field
-
-    \f$ s_\mathbf{u}(\mathbf{x}) = \left[ 1 \; \mathbf{x}^T \; \mathbf{x}^T\mathbf{x}\right]^T \cdot \mathbf{u} \f$
-
-    with \f$ \mathbf{u} \left[ u_c \; \mathbf{u_l} \; u_q\right]^T \f$ is the
-    vector of the constant, linear and quadratic parameters.
-
-    \note If internally the scalar fields are stored in a local frame defined
-    by the evaluation position, the public methods involving a query (such as
-    project, potential, gradient) have to be defined in global
-    coordinates (e.g. you don't need to convert your query in the current locale
-    frame).
-
-    This primitive provides:
-    \verbatim PROVIDES_ALGEBRAIC_SPHERE \endverbatim
-
-    \todo Deal with planar case (_uq == 0) and what about _ul == 0 ?
-*/
-
-
-template < class DataPoint, class _NFilter, typename T >
-class AlgebraicSphere : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    static_assert(_NFilter::hasLocalFrame, "AlgebraicSphere requires local frame");
-
-protected:
-    enum
-    {
-        check = Base::PROVIDES_PRIMITIVE_BASE,  /*!< \brief Requires PrimitiveBase */
-        PROVIDES_ALGEBRAIC_SPHERE               /*!< \brief Provides Algebraic Sphere */
-    };
-
-protected:
-    //! \brief Is the implicit scalar field normalized using Pratt
-    bool m_isNormalized {false};
-
-// results
-public:
-    Scalar m_uc {0},       /*!< \brief Constant parameter of the Algebraic hyper-sphere */
-           m_uq {0};       /*!< \brief Quadratic parameter of the Algebraic hyper-sphere */
-    VectorType m_ul {VectorType::Zero()};   /*!< \brief Linear parameter of the Algebraic hyper-sphere */
-
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(AlgebraicSphere,algebraicSphere)
-
-    /*! \brief Set the scalar field values to 0 and reset the isNormalized() status
-
-        \warning Set m_ul to Zero(), which leads to nans in OrientedSphere::normal()
-    */
-    PONCA_MULTIARCH inline void init()
-    {
-        Base::init();
-
-        m_uc = Scalar(0);
-        m_ul = VectorType::Zero();
-        m_uq = Scalar(0);
-
-        m_isNormalized = false;
-    }
-
-    /// \brief Tell if the sphere as been correctly set.
-    /// Used to set CONFLICT_ERROR_FOUND during fitting
-    /// \return false when called straight after #init. Should be true after fitting
-    PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const{
-        return !( m_ul.isApprox(VectorType::Zero()) && m_uc == Scalar(0) && m_uq == Scalar(0) );
-    }
-
-    /// \brief Comparison operator \warning Assume that other shares the same basis \see changeBasis()
-    PONCA_MULTIARCH inline bool operator==(const AlgebraicSphere<DataPoint, NeighborFilter, T>& other) const{
-        PONCA_MULTIARCH_STD_MATH(pow);
-        const Scalar epsilon        = Eigen::NumTraits<Scalar>::dummy_precision();
-        const Scalar squaredEpsilon = epsilon*epsilon;
-        return  pow(m_uc - other.m_uc, Scalar(2)) < squaredEpsilon &&
-                pow(m_uq - other.m_uq, Scalar(2)) < squaredEpsilon &&
-                 m_ul.isApprox(other.m_ul);
-    }
-    /// \brief Approximate operator \warning Assume that other shares the same basis \see changeBasis()
-    template<typename Other>
-    PONCA_MULTIARCH [[nodiscard]] inline bool isApprox(const Other& other, const Scalar& epsilon = Eigen::NumTraits<Scalar>::dummy_precision()) const{
-        PONCA_MULTIARCH_STD_MATH(pow);
-        const Scalar squaredEpsilon = epsilon*epsilon;
-        return  pow(m_uc - other.m_uc, Scalar(2)) < squaredEpsilon &&
-                pow(m_uq - other.m_uq, Scalar(2)) < squaredEpsilon &&
-                 m_ul.isApprox(other.m_ul);
-    }
-
-
-    /*! \brief Comparison operator, convenience function */
-    PONCA_MULTIARCH inline bool operator!=(const AlgebraicSphere<DataPoint, NeighborFilter, T>& other) const{
-        return ! ((*this) == other);
-    }
-
-    /*! \brief Express the scalar field relatively to a new basis 
-    
-    The sphere in dimension \f$d\f$ is parametrized in the original basis by \f$\mathbf{u} = \left[u_c, \mathbf{u}_l^T, u_q\right]^T \in \mathbb{R}^{d+2}\f$.
-    The sphere equation is given in this basis by:
-
-    \begin{equation}
-    u_c + \mathbf{u}_l^T.\mathbf{x} + u_q \mathbf{x}^T.\mathbf{x}= 0 
-    \end{equation}
-
-    The same equation written in a different basis is:
-    \begin{equation}
-    u_c + \mathbf{u}_l^T.(\mathbf{x}-\mathbf{\Delta}) + u_q (\mathbf{x}-\mathbf{\Delta})^T.(\mathbf{x}-\mathbf{\Delta})= 0 
-    \end{equation}
-    where \f$\mathbf{\Delta}\f$ is the difference vector between the two basis: \f$\mathbf{\Delta} = \mathbf{b}_\mathrm{original}-\mathbf{b}_\mathrm{new}\f$.
-    It corresponds to a translation of \f$\Delta\f$ of the sphere.
-    This develops in:
-    \begin{equation}
-    \left[u_c - \mathbf{u}_l^T.\mathbf{\Delta} + u_q \mathbf{\Delta}^T.\mathbf{\Delta}\right] + \left[\mathbf{u}_l - 2 u_q \mathbf{\Delta}\right]^T.\mathbf{x} + u_q \mathbf{x}^T.\mathbf{x} = 0 
-    \end{equation}
-
-    By identification, the parametrization \f$\left[u_c', \mathbf{u}_l'^T, u_q'\right]^T\f$ of the sphere in the new basis is given by
-
-    \f$u_c' = u_c - \mathbf{u}_l^T.\mathbf{\Delta} + u_q \mathbf{\Delta}^T.\mathbf{\Delta}\f$
-
-    \f$\mathbf{u}_l' = \mathbf{u}_l - 2 u_q \mathbf{\Delta}\f$
-
-    \f$u_q'=u_q\f$
-
-    */
-    PONCA_MULTIARCH inline void changeBasis(const VectorType& newbasis)
-    {
-        VectorType diff = Base::getNeighborFilter().evalPos() - newbasis;
-        Base::m_nFilter.changeNeighborhoodFrame(newbasis);
-        Base::init();
-        m_uc = m_uc - m_ul.dot(diff) + m_uq * diff.dot(diff);
-        m_ul = m_ul - Scalar(2.)*m_uq*diff;
-        //m_uq is not changed
-        m_isNormalized = false;
-        applyPrattNorm();
-    }
-
-    /*! \brief compute the Pratt norm of the implicit scalar field. */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar prattNorm() const
-    {
-        PONCA_MULTIARCH_STD_MATH(sqrt);
-        return sqrt(prattNorm2());
-    }
-
-    /*! \brief compute the squared Pratt norm of the implicit scalar field. */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar prattNorm2() const
-    {
-        return m_ul.squaredNorm() - Scalar(4.) * m_uc * m_uq;
-    }
-
     /*!
-        \brief Normalize the scalar field by the Pratt norm
-        \return false when the normalization fails (sphere is already normalized)
+        \brief Algebraic Sphere primitive
+
+        Method published in \cite Guennebaud:2007:APSS
+
+        An algebraic hyper-sphere is defined as the \f$0\f$-isosurface of the scalar field
+
+        \f$ s_\mathbf{u}(\mathbf{x}) = \left[ 1 \; \mathbf{x}^T \; \mathbf{x}^T\mathbf{x}\right]^T \cdot \mathbf{u} \f$
+
+        with \f$ \mathbf{u} \left[ u_c \; \mathbf{u_l} \; u_q\right]^T \f$ is the
+        vector of the constant, linear and quadratic parameters.
+
+        \note If internally the scalar fields are stored in a local frame defined
+        by the evaluation position, the public methods involving a query (such as
+        project, potential, gradient) have to be defined in global
+        coordinates (e.g. you don't need to convert your query in the current locale
+        frame).
+
+        This primitive provides:
+        \verbatim PROVIDES_ALGEBRAIC_SPHERE \endverbatim
+
+        \todo Deal with planar case (_uq == 0) and what about _ul == 0 ?
     */
-    PONCA_MULTIARCH inline bool applyPrattNorm()
+
+    template <class DataPoint, class _NFilter, typename T>
+    class AlgebraicSphere : public T
     {
-        if (! m_isNormalized)
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        static_assert(_NFilter::hasLocalFrame, "AlgebraicSphere requires local frame");
+
+    protected:
+        enum
         {
-            Scalar pn = prattNorm();
-            m_uc /= pn;
-            m_ul *= Scalar(1.)/pn;
-            m_uq /= pn;
+            check = Base::PROVIDES_PRIMITIVE_BASE, /*!< \brief Requires PrimitiveBase */
+            PROVIDES_ALGEBRAIC_SPHERE              /*!< \brief Provides Algebraic Sphere */
+        };
 
-            m_isNormalized = true;
+    protected:
+        //! \brief Is the implicit scalar field normalized using Pratt
+        bool m_isNormalized{false};
+
+        // results
+    public:
+        Scalar m_uc{0},                      /*!< \brief Constant parameter of the Algebraic hyper-sphere */
+            m_uq{0};                         /*!< \brief Quadratic parameter of the Algebraic hyper-sphere */
+        VectorType m_ul{VectorType::Zero()}; /*!< \brief Linear parameter of the Algebraic hyper-sphere */
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(AlgebraicSphere, algebraicSphere)
+
+        /*! \brief Set the scalar field values to 0 and reset the isNormalized() status
+
+            \warning Set m_ul to Zero(), which leads to nans in OrientedSphere::normal()
+        */
+        PONCA_MULTIARCH inline void init()
+        {
+            Base::init();
+
+            m_uc = Scalar(0);
+            m_ul = VectorType::Zero();
+            m_uq = Scalar(0);
+
+            m_isNormalized = false;
         }
-        return true;
-    }
 
-    /*!
-        \brief return the estimated radius of the sphere
-        \warning return inf if the fitted surface is planar
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar radius() const
-    {
-        PONCA_MULTIARCH_STD_MATH(numeric_limits);
-        if(isPlane())
-            return numeric_limits<Scalar>::infinity(); // non-sense value
+        /// \brief Tell if the sphere as been correctly set.
+        /// Used to set CONFLICT_ERROR_FOUND during fitting
+        /// \return false when called straight after #init. Should be true after fitting
+        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const
+        {
+            return !(m_ul.isApprox(VectorType::Zero()) && m_uc == Scalar(0) && m_uq == Scalar(0));
+        }
 
-        PONCA_MULTIARCH_STD_MATH(sqrt);
-        Scalar b = Scalar(1.)/m_uq;
-        return Scalar(sqrt( ((Scalar(-0.5)*b)*m_ul).squaredNorm() - m_uc*b ));
-    }
+        /// \brief Comparison operator \warning Assume that other shares the same basis \see changeBasis()
+        PONCA_MULTIARCH inline bool operator==(const AlgebraicSphere<DataPoint, NeighborFilter, T>& other) const
+        {
+            PONCA_MULTIARCH_STD_MATH(pow);
+            const Scalar epsilon        = Eigen::NumTraits<Scalar>::dummy_precision();
+            const Scalar squaredEpsilon = epsilon * epsilon;
+            return pow(m_uc - other.m_uc, Scalar(2)) < squaredEpsilon &&
+                   pow(m_uq - other.m_uq, Scalar(2)) < squaredEpsilon && m_ul.isApprox(other.m_ul);
+        }
+        /// \brief Approximate operator \warning Assume that other shares the same basis \see changeBasis()
+        template <typename Other>
+        PONCA_MULTIARCH [[nodiscard]] inline bool isApprox(
+            const Other& other, const Scalar& epsilon = Eigen::NumTraits<Scalar>::dummy_precision()) const
+        {
+            PONCA_MULTIARCH_STD_MATH(pow);
+            const Scalar squaredEpsilon = epsilon * epsilon;
+            return pow(m_uc - other.m_uc, Scalar(2)) < squaredEpsilon &&
+                   pow(m_uq - other.m_uq, Scalar(2)) < squaredEpsilon && m_ul.isApprox(other.m_ul);
+        }
 
-    /*!
-        \brief return the estimated center of the sphere
-        \warning return Vector inf if the fitted surface is planar
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType center() const
-    {
-        PONCA_MULTIARCH_STD_MATH(numeric_limits);
-        if(isPlane())
-            return VectorType::Constant(numeric_limits<Scalar>::infinity()); // non-sense value
+        /*! \brief Comparison operator, convenience function */
+        PONCA_MULTIARCH inline bool operator!=(const AlgebraicSphere<DataPoint, NeighborFilter, T>& other) const
+        {
+            return !((*this) == other);
+        }
 
-        Scalar b = Scalar(1.)/m_uq;
-        return Base::getNeighborFilter().convertToGlobalBasis((Scalar(-0.5)*b)*m_ul);
-    }
+        /*! \brief Express the scalar field relatively to a new basis
 
-    //! \brief State indicating when the sphere has been normalized
-    PONCA_MULTIARCH [[nodiscard]] inline bool isNormalized() const { return m_isNormalized; }
+        The sphere in dimension \f$d\f$ is parametrized in the original basis by \f$\mathbf{u} = \left[u_c,
+        \mathbf{u}_l^T, u_q\right]^T \in \mathbb{R}^{d+2}\f$. The sphere equation is given in this basis by:
 
-    //! \brief Value of the scalar field at the location \f$ \mathbf{q}\f$.
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potential (const VectorType& _q) const
-    {
-        // Turn to centered basis
-        const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
-        return potentialLocal(lq);
-    }
+        \begin{equation}
+        u_c + \mathbf{u}_l^T.\mathbf{x} + u_q \mathbf{x}^T.\mathbf{x}= 0
+        \end{equation}
 
-    //! \brief Value of the scalar field at the evaluation point
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potential() const { return m_uc; }
+        The same equation written in a different basis is:
+        \begin{equation}
+        u_c + \mathbf{u}_l^T.(\mathbf{x}-\mathbf{\Delta}) + u_q
+        (\mathbf{x}-\mathbf{\Delta})^T.(\mathbf{x}-\mathbf{\Delta})= 0
+        \end{equation}
+        where \f$\mathbf{\Delta}\f$ is the difference vector between the two basis: \f$\mathbf{\Delta} =
+        \mathbf{b}_\mathrm{original}-\mathbf{b}_\mathrm{new}\f$. It corresponds to a translation of \f$\Delta\f$ of the
+        sphere. This develops in:
+        \begin{equation}
+        \left[u_c - \mathbf{u}_l^T.\mathbf{\Delta} + u_q \mathbf{\Delta}^T.\mathbf{\Delta}\right] + \left[\mathbf{u}_l -
+        2 u_q \mathbf{\Delta}\right]^T.\mathbf{x} + u_q \mathbf{x}^T.\mathbf{x} = 0
+        \end{equation}
 
-    /*!
-       \brief Project a point on the algebraic hypersphere
+        By identification, the parametrization \f$\left[u_c', \mathbf{u}_l'^T, u_q'\right]^T\f$ of the sphere in the new
+        basis is given by
 
-        This projection is realized in closed-form: the algebraic hypersphere is converted
-        to a geometrical representation (hyperplane or hypersphere), and _q is orthogonally
-        projected on the primitive.
-        \note This function is in most cases more accurate and faster than #projectDescent
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType project (const VectorType& _q) const;
+        \f$u_c' = u_c - \mathbf{u}_l^T.\mathbf{\Delta} + u_q \mathbf{\Delta}^T.\mathbf{\Delta}\f$
 
-    /*! \brief Approximation of the scalar field gradient at \f$ \mathbf{q}\f$
-        \warning The gradient is not normalized by default */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient (const VectorType& _q) const
-    {
-        // Turn to centered basis
-        const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
-        return primitiveGradientLocal(lq);
-    }
+        \f$\mathbf{u}_l' = \mathbf{u}_l - 2 u_q \mathbf{\Delta}\f$
 
-    /*! \brief Approximation of the scalar field gradient at the evaluation point
-        \warning The gradient is not normalized by default */
-    PONCA_MULTIARCH [[nodiscard]] inline const VectorType& primitiveGradient () const { return m_ul; }
+        \f$u_q'=u_q\f$
 
-    /*!
-        \brief Used to know if the fitting result to a plane
-        \return true if finalize() have been called and the fitting result to a plane
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline bool isPlane() const
-    {
-        PONCA_MULTIARCH_STD_MATH(abs);
-        bool bPlanar   = Eigen::internal::isApprox(m_uq,Scalar(0)); 
-        bool bReady    = Base::isReady();
-        return bReady && bPlanar;
-    }
+        */
+        PONCA_MULTIARCH inline void changeBasis(const VectorType& newbasis)
+        {
+            VectorType diff = Base::getNeighborFilter().evalPos() - newbasis;
+            Base::m_nFilter.changeNeighborhoodFrame(newbasis);
+            Base::init();
+            m_uc = m_uc - m_ul.dot(diff) + m_uq * diff.dot(diff);
+            m_ul = m_ul - Scalar(2.) * m_uq * diff;
+            // m_uq is not changed
+            m_isNormalized = false;
+            applyPrattNorm();
+        }
 
-protected:
-    /// \copydoc AlgebraicSphere::potential
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal (const VectorType& _lq) const;
+        /*! \brief compute the Pratt norm of the implicit scalar field. */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar prattNorm() const
+        {
+            PONCA_MULTIARCH_STD_MATH(sqrt);
+            return sqrt(prattNorm2());
+        }
 
-    /// \copydoc AlgebraicSphere::primitiveGradient
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal (const VectorType& _lq) const;
-}; //class AlgebraicSphere
+        /*! \brief compute the squared Pratt norm of the implicit scalar field. */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar prattNorm2() const
+        {
+            return m_ul.squaredNorm() - Scalar(4.) * m_uc * m_uq;
+        }
+
+        /*!
+            \brief Normalize the scalar field by the Pratt norm
+            \return false when the normalization fails (sphere is already normalized)
+        */
+        PONCA_MULTIARCH inline bool applyPrattNorm()
+        {
+            if (!m_isNormalized)
+            {
+                Scalar pn = prattNorm();
+                m_uc /= pn;
+                m_ul *= Scalar(1.) / pn;
+                m_uq /= pn;
+
+                m_isNormalized = true;
+            }
+            return true;
+        }
+
+        /*!
+            \brief return the estimated radius of the sphere
+            \warning return inf if the fitted surface is planar
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar radius() const
+        {
+            PONCA_MULTIARCH_STD_MATH(numeric_limits);
+            if (isPlane())
+                return numeric_limits<Scalar>::infinity(); // non-sense value
+
+            PONCA_MULTIARCH_STD_MATH(sqrt);
+            Scalar b = Scalar(1.) / m_uq;
+            return Scalar(sqrt(((Scalar(-0.5) * b) * m_ul).squaredNorm() - m_uc * b));
+        }
+
+        /*!
+            \brief return the estimated center of the sphere
+            \warning return Vector inf if the fitted surface is planar
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType center() const
+        {
+            PONCA_MULTIARCH_STD_MATH(numeric_limits);
+            if (isPlane())
+                return VectorType::Constant(numeric_limits<Scalar>::infinity()); // non-sense value
+
+            Scalar b = Scalar(1.) / m_uq;
+            return Base::getNeighborFilter().convertToGlobalBasis((Scalar(-0.5) * b) * m_ul);
+        }
+
+        //! \brief State indicating when the sphere has been normalized
+        PONCA_MULTIARCH [[nodiscard]] inline bool isNormalized() const { return m_isNormalized; }
+
+        //! \brief Value of the scalar field at the location \f$ \mathbf{q}\f$.
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential(const VectorType& _q) const
+        {
+            // Turn to centered basis
+            const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
+            return potentialLocal(lq);
+        }
+
+        //! \brief Value of the scalar field at the evaluation point
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential() const { return m_uc; }
+
+        /*!
+           \brief Project a point on the algebraic hypersphere
+
+            This projection is realized in closed-form: the algebraic hypersphere is converted
+            to a geometrical representation (hyperplane or hypersphere), and _q is orthogonally
+            projected on the primitive.
+            \note This function is in most cases more accurate and faster than #projectDescent
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType project(const VectorType& _q) const;
+
+        /*! \brief Approximation of the scalar field gradient at \f$ \mathbf{q}\f$
+            \warning The gradient is not normalized by default */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient(const VectorType& _q) const
+        {
+            // Turn to centered basis
+            const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
+            return primitiveGradientLocal(lq);
+        }
+
+        /*! \brief Approximation of the scalar field gradient at the evaluation point
+            \warning The gradient is not normalized by default */
+        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& primitiveGradient() const { return m_ul; }
+
+        /*!
+            \brief Used to know if the fitting result to a plane
+            \return true if finalize() have been called and the fitting result to a plane
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline bool isPlane() const
+        {
+            PONCA_MULTIARCH_STD_MATH(abs);
+            bool bPlanar = Eigen::internal::isApprox(m_uq, Scalar(0));
+            bool bReady  = Base::isReady();
+            return bReady && bPlanar;
+        }
+
+    protected:
+        /// \copydoc AlgebraicSphere::potential
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal(const VectorType& _lq) const;
+
+        /// \copydoc AlgebraicSphere::primitiveGradient
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal(const VectorType& _lq) const;
+    }; // class AlgebraicSphere
 
 #include "algebraicSphere.hpp"
-}
+} // namespace Ponca

--- a/Ponca/src/Fitting/algebraicSphere.hpp
+++ b/Ponca/src/Fitting/algebraicSphere.hpp
@@ -13,35 +13,32 @@ AlgebraicSphere<DataPoint, _NFilter, T>::project(const VectorType& _q) const
     // turn to centered basis
     const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
 
-
-
-    if(isPlane())
+    if (isPlane())
     {
         Scalar sqnorm = m_ul.squaredNorm();
-        return Base::getNeighborFilter().convertToGlobalBasis( lq - m_ul*(lq.dot(m_ul))/sqnorm );
+        return Base::getNeighborFilter().convertToGlobalBasis(lq - m_ul * (lq.dot(m_ul)) / sqnorm);
     }
     else
     {
         Scalar potential = potentialLocal(lq);
-        VectorType grad = primitiveGradientLocal(lq);
-        Scalar norm = grad.norm();
-        Scalar t = - (norm - sqrt(norm*norm - Scalar(4) * m_uq * potential)) / (Scalar(2) * m_uq * norm);
-        return Base::getNeighborFilter().convertToGlobalBasis( lq + t * grad );
+        VectorType grad  = primitiveGradientLocal(lq);
+        Scalar norm      = grad.norm();
+        Scalar t         = -(norm - sqrt(norm * norm - Scalar(4) * m_uq * potential)) / (Scalar(2) * m_uq * norm);
+        return Base::getNeighborFilter().convertToGlobalBasis(lq + t * grad);
     }
-
 }
 
-template < class DataPoint, class _NFilter, typename T>
-typename AlgebraicSphere<DataPoint, _NFilter, T>::Scalar
-AlgebraicSphere<DataPoint, _NFilter, T>::potentialLocal( const VectorType &_lq ) const
+template <class DataPoint, class _NFilter, typename T>
+typename AlgebraicSphere<DataPoint, _NFilter, T>::Scalar AlgebraicSphere<DataPoint, _NFilter, T>::potentialLocal(
+    const VectorType& _lq) const
 {
     return m_uc + _lq.dot(m_ul) + m_uq * _lq.squaredNorm();
 }
 
-template < class DataPoint, class _NFilter, typename T>
-typename AlgebraicSphere<DataPoint, _NFilter, T>::VectorType
-AlgebraicSphere<DataPoint, _NFilter, T>::primitiveGradientLocal( const VectorType &_lq ) const
+template <class DataPoint, class _NFilter, typename T>
+typename AlgebraicSphere<DataPoint, _NFilter, T>::VectorType AlgebraicSphere<
+    DataPoint, _NFilter, T>::primitiveGradientLocal(const VectorType& _lq) const
 {
-        return (m_ul + Scalar(2.) * m_uq * _lq);
+    return (m_ul + Scalar(2.) * m_uq * _lq);
 }
 

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -18,104 +18,94 @@ namespace Ponca
 #define BSKP typename BasketType::DataPoint
 
 #ifndef PARSED_WITH_DOXYGEN
-/*! \brief Namespace used for structure or classes used internally by the lib */
-namespace internal
-{
-    /*!
-     * \brief This class unrolls the extension (from left to right) from the CRTP variadic list
-     *
-     * \tparam P Implements \ref ponca_concepts "PointConcept"
-     * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
-     * \tparam Aggregate The base CRTP class
-     * \tparam Ext First (left-side) extension in the CTRP variadic list
-     * \tparam Exts Remaining elements (excluding Ext) of the CRTP variadic list
-     */
-    template <class P, class NF,
-        typename Aggregate,
-        template <class, class, typename> class Ext,
-        template <class, class, typename> class... Exts>
-    struct BasketAggregateImpl
+    /*! \brief Namespace used for structure or classes used internally by the lib */
+    namespace internal
     {
-        using type = typename BasketAggregateImpl<P, NF, Ext<P, NF, Aggregate>, Exts...>::type;
-    };
+        /*!
+         * \brief This class unrolls the extension (from left to right) from the CRTP variadic list
+         *
+         * \tparam P Implements \ref ponca_concepts "PointConcept"
+         * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+         * \tparam Aggregate The base CRTP class
+         * \tparam Ext First (left-side) extension in the CTRP variadic list
+         * \tparam Exts Remaining elements (excluding Ext) of the CRTP variadic list
+         */
+        template <class P, class NF, typename Aggregate, template <class, class, typename> class Ext,
+                  template <class, class, typename> class... Exts>
+        struct BasketAggregateImpl
+        {
+            using type = typename BasketAggregateImpl<P, NF, Ext<P, NF, Aggregate>, Exts...>::type;
+        };
 
-    /*!
-     * \brief Specialized version of BasketAggregateImpl when the variadic list is empty
-     *
-     * \tparam P Implements \ref ponca_concepts "PointConcept"
-     * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
-     * \tparam Aggregate The base CRTP class
-     * \tparam Ext Unique (or last) extension of the CTRP variadic list
-     */
-    template <class P, class NF,
-        typename Aggregate,
-        template <class, class, typename> class Ext>
-    struct BasketAggregateImpl<P, NF, Aggregate, Ext>
-    {
-        using type = Ext<P, NF, Aggregate>;
-    };
+        /*!
+         * \brief Specialized version of BasketAggregateImpl when the variadic list is empty
+         *
+         * \tparam P Implements \ref ponca_concepts "PointConcept"
+         * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+         * \tparam Aggregate The base CRTP class
+         * \tparam Ext Unique (or last) extension of the CTRP variadic list
+         */
+        template <class P, class NF, typename Aggregate, template <class, class, typename> class Ext>
+        struct BasketAggregateImpl<P, NF, Aggregate, Ext>
+        {
+            using type = Ext<P, NF, Aggregate>;
+        };
 
-    /*!
-     * \brief Internal class used to build the Basket structure
-     * Uses BasketAggregateImpl to unroll the CRTP variadic list
-     *
-     * \tparam P Implements \ref ponca_concepts "PointConcept"
-     * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
-     * \tparam Exts CRTP variadic list
-     */
-    template <class P, class NF,
-        template <class, class, typename> class... Exts>
-    struct BasketAggregate : BasketAggregateImpl<P, NF, PrimitiveBase<P, NF>, Exts...>
-    {
-    };
+        /*!
+         * \brief Internal class used to build the Basket structure
+         * Uses BasketAggregateImpl to unroll the CRTP variadic list
+         *
+         * \tparam P Implements \ref ponca_concepts "PointConcept"
+         * \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+         * \tparam Exts CRTP variadic list
+         */
+        template <class P, class NF, template <class, class, typename> class... Exts>
+        struct BasketAggregate : BasketAggregateImpl<P, NF, PrimitiveBase<P, NF>, Exts...>
+        {
+        };
 
-    /*!
-     * \brief This class unrolls the extension (from left to right) from the CRTP variadic list
-     * \see BasketDiffAggregateImpl
-     *
-     * \tparam Type Differentiation type
-     * \tparam BasketType Input Basket Type
-     * \tparam Ext First (left-side) extension in the CTRP variadic list
-     * \tparam Exts Remaining elements (excluding Ext) of the CRTP variadic list
-     */
-    template <int Type,
-        typename BasketType,
-        template <class, class, int, typename> class Ext,
-        template <class, class, int, typename> class... Exts>
-    struct BasketDiffAggregateImpl
-    {
-        using type = typename BasketDiffAggregateImpl<Type, Ext<BSKP, BSKNF, Type, BasketType>, Exts...>::type;
-    };
+        /*!
+         * \brief This class unrolls the extension (from left to right) from the CRTP variadic list
+         * \see BasketDiffAggregateImpl
+         *
+         * \tparam Type Differentiation type
+         * \tparam BasketType Input Basket Type
+         * \tparam Ext First (left-side) extension in the CTRP variadic list
+         * \tparam Exts Remaining elements (excluding Ext) of the CRTP variadic list
+         */
+        template <int Type, typename BasketType, template <class, class, int, typename> class Ext,
+                  template <class, class, int, typename> class... Exts>
+        struct BasketDiffAggregateImpl
+        {
+            using type = typename BasketDiffAggregateImpl<Type, Ext<BSKP, BSKNF, Type, BasketType>, Exts...>::type;
+        };
 
-    /*!
-     * \brief Specialized version of BasketDiffAggregateImpl when the variadic list is empty
-     *
-     * \tparam Type Differentiation type
-     * \tparam BasketType Input Basket Type
-     * \tparam Ext Unique (or last) extension of the CTRP variadic list
-     */
-    template <int Type,
-        typename BasketType,
-        template <class, class, int, typename> class Ext>
-    struct BasketDiffAggregateImpl<Type, BasketType, Ext>
-    {
-        using type = Ext<BSKP, BSKNF, Type, BasketType>;
-    };
+        /*!
+         * \brief Specialized version of BasketDiffAggregateImpl when the variadic list is empty
+         *
+         * \tparam Type Differentiation type
+         * \tparam BasketType Input Basket Type
+         * \tparam Ext Unique (or last) extension of the CTRP variadic list
+         */
+        template <int Type, typename BasketType, template <class, class, int, typename> class Ext>
+        struct BasketDiffAggregateImpl<Type, BasketType, Ext>
+        {
+            using type = Ext<BSKP, BSKNF, Type, BasketType>;
+        };
 
-    /*!
-     * \brief Internal class used to build the BasketDiff structure
-     * Uses BasketDiffAggregateImpl to unroll the CRTP variadic list
-     *
-     * \tparam BasketType BasketType Input Basket Type
-     * \tparam Type Differentiation type
-     * \tparam Exts CRTP variadic list
-     */
-    template <typename BasketType, int Type,
-        template <class, class, int, typename> class... Exts>
-    struct BasketDiffAggregate : BasketDiffAggregateImpl<Type, BasketType, PrimitiveDer, Exts...>
-    {
-    };
-}
+        /*!
+         * \brief Internal class used to build the BasketDiff structure
+         * Uses BasketDiffAggregateImpl to unroll the CRTP variadic list
+         *
+         * \tparam BasketType BasketType Input Basket Type
+         * \tparam Type Differentiation type
+         * \tparam Exts CRTP variadic list
+         */
+        template <typename BasketType, int Type, template <class, class, int, typename> class... Exts>
+        struct BasketDiffAggregate : BasketDiffAggregateImpl<Type, BasketType, PrimitiveDer, Exts...>
+        {
+        };
+    } // namespace internal
 #endif
 
     /*!
@@ -129,8 +119,8 @@ namespace internal
      *   \code
      *   typedef
      *   BasketDiff <BasketType,           // Existing Basket, to be differentiated
-     *   DiffType,                         // Differentiation space: FitScaleDer, FitSpaceDer, or FitScaleDer|FitSpaceDer
-     *   ComputationalDerivativesConcept1, // Implementation of ComputationalDerivativesConcept
+     *   DiffType,                         // Differentiation space: FitScaleDer, FitSpaceDer, or
+     * FitScaleDer|FitSpaceDer ComputationalDerivativesConcept1, // Implementation of ComputationalDerivativesConcept
      *   ComputationalDerivativesConcept2, // Implementation of ComputationalDerivativesConcept
      *   ... ,                             //
      *   > myFitDer;                       // Final structure to fit and derive a primitive over weighted samples
@@ -139,15 +129,19 @@ namespace internal
      * \tparam Derived Derived class that provides the addNeighbor method (either Basket or BasketDiff)
      * \tparam Base Base class that provides, through the CRTP the init, startNewPass, addNeighbor and finalize methods
      */
-    template<typename _Derived, typename _Base>
-    struct BasketComputeObject : public ComputeObject<_Derived>, public virtual _Base {
+    template <typename _Derived, typename _Base>
+    struct BasketComputeObject : public ComputeObject<_Derived>, public virtual _Base
+    {
         using Base    = _Base;    /// <\brief Alias to the Base type
         using Derived = _Derived; /// \brief Alias to the Derived type
         using Scalar  = typename Base::Scalar;
+
     protected:
         using ComputeObject<Derived>::derived;
+
     public:
-        using ComputeObject<Derived>::compute; // Makes the default compute(container) accessible when using a CPU architecture
+        using ComputeObject<Derived>::compute; // Makes the default compute(container) accessible when using a CPU
+                                               // architecture
 
         /*!
          * \brief Convenience function for STL-like iterators
@@ -156,17 +150,20 @@ namespace internal
          * \see addNeighbor()
          */
         template <typename IteratorBegin, typename IteratorEnd>
-        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end){
+        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& begin, const IteratorEnd& end)
+        {
             Base::init();
             FIT_RESULT res = UNDEFINED;
 
-            do {
+            do
+            {
                 derived().startNewPass();
-                for (auto it = begin; it != end; ++it){
+                for (auto it = begin; it != end; ++it)
+                {
                     derived().addNeighbor(*it);
                 }
                 res = Base::finalize();
-            } while ( res == NEED_OTHER_PASS );
+            } while (res == NEED_OTHER_PASS);
 
             return res;
         }
@@ -179,17 +176,20 @@ namespace internal
          * \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
          */
         template <typename IndexRange, typename PointContainer>
-        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points){
+        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange ids, const PointContainer& points)
+        {
             Base::init();
             FIT_RESULT res = UNDEFINED;
 
-            do {
+            do
+            {
                 derived().startNewPass();
-                for (const auto& i : ids){
+                for (const auto& i : ids)
+                {
                     derived().addNeighbor(points[i]);
                 }
                 res = Base::finalize();
-            } while ( res == NEED_OTHER_PASS );
+            } while (res == NEED_OTHER_PASS);
 
             return res;
         }
@@ -202,21 +202,26 @@ namespace internal
          * \param mlsIter The amount of MLS iteration that is being done for this fit
          * \return The result of the fit
          */
-        template<typename Func>
-        PONCA_MULTIARCH FIT_RESULT computeMLSImpl(Func&& computeFunc, const int mlsIter, const Scalar epsilon) {
+        template <typename Func>
+        PONCA_MULTIARCH FIT_RESULT computeMLSImpl(Func&& computeFunc, const int mlsIter, const Scalar epsilon)
+        {
             FIT_RESULT res = UNDEFINED;
-            auto lastPos = Base::getNeighborFilter().evalPos();
+            auto lastPos   = Base::getNeighborFilter().evalPos();
 
-            for (int mm = 0; mm < mlsIter; ++mm) {
+            for (int mm = 0; mm < mlsIter; ++mm)
+            {
                 Base::m_nFilter.changeNeighborhoodFrame(lastPos);
                 res = computeFunc();
 
-                if (Base::isStable()) {
+                if (Base::isStable())
+                {
                     auto newPos = Base::project(lastPos);
                     if (newPos.isApprox(lastPos, epsilon))
                         return res;
                     lastPos = newPos;
-                } else {
+                }
+                else
+                {
                     return res;
                 }
             }
@@ -228,16 +233,11 @@ namespace internal
          * \copydoc BasketComputeObject::computeMLSImpl
          * \tparam PointContainer STL-like container storing the points
          */
-        template<typename PointContainer>
-        PONCA_MULTIARCH FIT_RESULT computeMLS(
-            const PointContainer& points,
-            const int mlsIter    = 5,
-            const Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision()
-        ) {
-            return computeMLSImpl(
-                [&]() { return compute(points); },
-                mlsIter, epsilon
-            );
+        template <typename PointContainer>
+        PONCA_MULTIARCH FIT_RESULT computeMLS(const PointContainer& points, const int mlsIter = 5,
+                                              const Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision())
+        {
+            return computeMLSImpl([&]() { return compute(points); }, mlsIter, epsilon);
         }
 
         /*!
@@ -245,24 +245,19 @@ namespace internal
          * \tparam IndexRange STL-Like range storing indices
          * \tparam PointContainer STL-like container storing the points
          */
-        template<typename IndexRange, typename PointContainer>
-        PONCA_MULTIARCH FIT_RESULT computeWithIdsMLS(
-            const IndexRange& ids,
-            const PointContainer& points,
-            const int mlsIter    = 5,
-            const Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision()
-        ) {
-            return computeMLSImpl(
-                [&]() { return computeWithIds(ids, points); },
-                mlsIter, epsilon
-            );
+        template <typename IndexRange, typename PointContainer>
+        PONCA_MULTIARCH FIT_RESULT computeWithIdsMLS(const IndexRange& ids, const PointContainer& points,
+                                                     const int mlsIter    = 5,
+                                                     const Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision())
+        {
+            return computeMLSImpl([&]() { return computeWithIds(ids, points); }, mlsIter, epsilon);
         }
     };
 
-#define WRITE_COMPUTE_FUNCTIONS \
-    using BasketComputeObject<Self, Base>::compute; \
+#define WRITE_COMPUTE_FUNCTIONS                            \
+    using BasketComputeObject<Self, Base>::compute;        \
     using BasketComputeObject<Self, Base>::computeWithIds; \
-    using BasketComputeObject<Self, Base>::computeMLS; \
+    using BasketComputeObject<Self, Base>::computeMLS;     \
     using BasketComputeObject<Self, Base>::computeWithIdsMLS;
 
     /*!
@@ -273,59 +268,62 @@ namespace internal
          \tparam Ext0 Implements \ref concepts_computObjectBasketDiff "ComputationalDerivativesConcept"
          \tparam Exts Implements \ref concepts_computObjectBasketDiff "ComputationalDerivativesConcept" (optional)
      */
-    template <typename BasketType, int Type,
-        template <class, class, int, typename> class Ext0,
-        template <class, class, int, typename> class... Exts>
-    class BasketDiff : public BasketComputeObject<BasketDiff<BasketType, Type, Ext0, Exts...>,
-                                                  typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type>
+    template <typename BasketType, int Type, template <class, class, int, typename> class Ext0,
+              template <class, class, int, typename> class... Exts>
+    class BasketDiff
+        : public BasketComputeObject<BasketDiff<BasketType, Type, Ext0, Exts...>,
+                                     typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type>
     {
     private:
         using Self = BasketDiff;
+
     public:
-        using Base = typename internal::BasketDiffAggregate<BasketType,Type,Ext0,Exts...>::type;
+        using Base = typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type;
         /// Neighbor Filter
         using NeighborFilter = BSKNF;
         /// Point type used for computation
         using DataPoint = BSKP;
         /// Scalar type used for computation, as defined from Basket
         using Scalar = typename BasketType::Scalar;
-    WRITE_COMPUTE_FUNCTIONS
+        WRITE_COMPUTE_FUNCTIONS
 
-    /// \copydoc Basket::addNeighbor
-    PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {
-        // compute weight
-        auto neiFilterOutput = Base::getNeighborFilter()(_nei);
-        typename Base::ScalarArray dw;
+        /// \copydoc Basket::addNeighbor
+        PONCA_MULTIARCH inline bool addNeighbor(const DataPoint& _nei)
+        {
+            // compute weight
+            auto neiFilterOutput = Base::getNeighborFilter()(_nei);
+            typename Base::ScalarArray dw;
 
-        if (neiFilterOutput.first > Scalar(0.)) {
-            Base::addLocalNeighbor(neiFilterOutput.first, neiFilterOutput.second, _nei, dw);
-            return true;
+            if (neiFilterOutput.first > Scalar(0.))
+            {
+                Base::addLocalNeighbor(neiFilterOutput.first, neiFilterOutput.second, _nei, dw);
+                return true;
+            }
+            return false;
         }
-        return false;
-    }
-};
+    };
 
-/*!
-    \brief Aggregator class used to declare specialized structures using CRTP
-    \copydoc BasketComputeObject
-    \tparam P Implements \ref ponca_concepts "PointConcept"
-    \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
-    \tparam Ext0 Implements \ref concepts_computObjectBasket "ComputationalObjectConcept"
-    \tparam Exts Implements \ref concepts_computObjectBasket "ComputationalObjectConcept" (optional)
-*/
-    template <class P, class NF,
-        template <class, class, typename> class Ext0,
-        template <class, class, typename> class... Exts>
+    /*!
+        \brief Aggregator class used to declare specialized structures using CRTP
+        \copydoc BasketComputeObject
+        \tparam P Implements \ref ponca_concepts "PointConcept"
+        \tparam W Implements \ref concepts_weighting "WeightKernelConcept"
+        \tparam Ext0 Implements \ref concepts_computObjectBasket "ComputationalObjectConcept"
+        \tparam Exts Implements \ref concepts_computObjectBasket "ComputationalObjectConcept" (optional)
+    */
+    template <class P, class NF, template <class, class, typename> class Ext0,
+              template <class, class, typename> class... Exts>
     class Basket : public BasketComputeObject<Basket<P, NF, Ext0, Exts...>,
                                               typename internal::BasketAggregate<P, NF, Ext0, Exts...>::type>
     {
     private:
         using Self = Basket;
+
     public:
         /// Base type, which aggregates all the computational objects using the CRTP
         using Base = typename internal::BasketAggregate<P, NF, Ext0, Exts...>::type;
         /// Scalar type used for computation, as defined from template parameter `P`
-        using Scalar = typename P::Scalar;
+        using Scalar     = typename P::Scalar;
         using VectorType = typename P::VectorType;
         /// Point type used for computation
         using DataPoint = P;
@@ -340,18 +338,18 @@ namespace internal
         /// \see compute Prefer when using a range of Points
         /// \see computeWithIds Prefer when using a range of ids
         /// \return false if param nei is not a valid neighbor (weight = 0)
-        PONCA_MULTIARCH inline bool addNeighbor(const DataPoint &_nei) {
+        PONCA_MULTIARCH inline bool addNeighbor(const DataPoint& _nei)
+        {
             // compute weight
             auto neiFilterOutput = Base::getNeighborFilter()(_nei);
 
-            if (neiFilterOutput.first > Scalar(0.)) {
+            if (neiFilterOutput.first > Scalar(0.))
+            {
                 Base::addLocalNeighbor(neiFilterOutput.first, neiFilterOutput.second, _nei);
                 return true;
             }
             return false;
         }
-
-
 
         /*!
            \brief Project a point on the primitive using Gradient Descent
@@ -360,7 +358,7 @@ namespace internal
            \param _q Starting point
            \param nbIter Number of iterations (default = 16)
          */
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType projectDescent (const VectorType& _q, int nbIter = 16) const
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType projectDescent(const VectorType& _q, int nbIter = 16) const
         {
             PONCA_MULTIARCH_STD_MATH(min)
 
@@ -369,23 +367,23 @@ namespace internal
 
             VectorType grad;
             VectorType dir  = Base::primitiveGradientLocal(lq);
-            Scalar ilg      = Scalar(1.)/dir.norm();
-            dir             = dir*ilg;
+            Scalar ilg      = Scalar(1.) / dir.norm();
+            dir             = dir * ilg;
             Scalar ad       = Base::potentialLocal(lq);
-            Scalar delta    = -ad*min(ilg,Scalar(1.));
-            VectorType proj = lq + dir*delta;
+            Scalar delta    = -ad * min(ilg, Scalar(1.));
+            VectorType proj = lq + dir * delta;
 
-            for (int i=0; i<nbIter; ++i)
+            for (int i = 0; i < nbIter; ++i)
             {
                 grad  = Base::primitiveGradientLocal(proj);
-                ilg   = Scalar(1.)/grad.norm();
-                delta = -Base::potentialLocal(proj)*min(ilg,Scalar(1.));
-                proj += dir*delta;
+                ilg   = Scalar(1.) / grad.norm();
+                delta = -Base::potentialLocal(proj) * min(ilg, Scalar(1.));
+                proj += dir * delta;
             }
-            return Base::getNeighborFilter().convertToGlobalBasis( proj );
+            return Base::getNeighborFilter().convertToGlobalBasis(proj);
         }
     }; // class Basket
 
 #undef WRITE_COMPUTE_FUNCTIONS
-} //namespace Ponca
+} // namespace Ponca
 

--- a/Ponca/src/Fitting/basket.h
+++ b/Ponca/src/Fitting/basket.h
@@ -136,8 +136,8 @@ namespace internal
      *   > myFitDer;                       // Final structure to fit and derive a primitive over weighted samples
      *   \endcode
      *
-     * @tparam Derived Derived class that provides the addNeighbor method (either Basket or BasketDiff)
-     * @tparam Base Base class that provides, through the CRTP the init, startNewPass, addNeighbor and finalize methods
+     * \tparam Derived Derived class that provides the addNeighbor method (either Basket or BasketDiff)
+     * \tparam Base Base class that provides, through the CRTP the init, startNewPass, addNeighbor and finalize methods
      */
     template<typename _Derived, typename _Base>
     struct BasketComputeObject : public ComputeObject<_Derived>, public virtual _Base {

--- a/Ponca/src/Fitting/cnc.h
+++ b/Ponca/src/Fitting/cnc.h
@@ -56,8 +56,8 @@ public:
 
     /*! \brief Get the position of the point at the given index.
      *
-     * @param index Index of one of the three vertices of the triangle (between 0 and 2)
-     * @return The position of vertex
+     * \param index Index of one of the three vertices of the triangle (between 0 and 2)
+     * \return The position of vertex
      */
     PONCA_MULTIARCH [[nodiscard]] VectorType& getPos(const int index) {
         return m_points[index];

--- a/Ponca/src/Fitting/cnc.h
+++ b/Ponca/src/Fitting/cnc.h
@@ -14,249 +14,241 @@ All rights reserved.
 #include "weightFunc.h"
 #include "weightKernel.h"
 
-
 namespace Ponca
 {
 
-namespace internal {
-/*!
- * Stores the three points and normals of the triangles and provides access to Corrected Normal Current formula
- *
- * \tparam DataPoint Type of input points.
- *
- * \see CNCEigen
- */
-template < class DataPoint >
-struct Triangle {
-public:
-    typedef typename DataPoint::Scalar Scalar;
-    typedef typename DataPoint::VectorType VectorType;
-    typedef typename DataPoint::MatrixType MatrixType;
-protected:
-    std::array < VectorType, 3 > m_points;
-    std::array < VectorType, 3 > m_normals;
-public:
-    Triangle(DataPoint pointA, DataPoint pointB, DataPoint pointC) {
-        m_points = {
-            pointA.pos(),
-            pointB.pos(),
-            pointC.pos()
-        };
-        m_normals = {
-            pointA.normal(),
-            pointB.normal(),
-            pointC.normal()
-        };
-    }
-
-    Triangle(const std::array < VectorType, 3 >& points, const std::array < VectorType, 3 >& normals) {
-        m_points = points;
-        m_normals = normals;
-    }
-
-    /*! \brief Get the position of the point at the given index.
-     *
-     * \param index Index of one of the three vertices of the triangle (between 0 and 2)
-     * \return The position of vertex
-     */
-    PONCA_MULTIARCH [[nodiscard]] VectorType& getPos(const int index) {
-        return m_points[index];
-    }
-
-    PONCA_MULTIARCH [[nodiscard]] bool operator==(const Triangle& other) const {
-        return (m_points[0] == other.m_points[0])
-			&& (m_points[1] == other.m_points[1])
-			&& (m_points[2] == other.m_points[2]);
-    }
-
-    PONCA_MULTIARCH [[nodiscard]] bool operator!=(const Triangle& other) const {
-        return !((*this) == other);
-    }
-
-#define DEFINE_CNC_FUNC(CNC_FUNC, RETURN_TYPE)                                      \
-    template<bool differentOrder = false>                                           \
-    inline RETURN_TYPE CNC_FUNC () {                                                \
-        return CNCEigen<DataPoint>::CNC_FUNC(                                       \
-            m_points[0] ,  m_points[2-differentOrder],  m_points[1+differentOrder], \
-            m_normals[0], m_normals[2-differentOrder], m_normals[1+differentOrder]  \
-        );                                                                          \
-    }
-
-	DEFINE_CNC_FUNC(mu0InterpolatedU , Scalar)
-	DEFINE_CNC_FUNC(mu1InterpolatedU , Scalar)
-	DEFINE_CNC_FUNC(mu2InterpolatedU , Scalar)
-	DEFINE_CNC_FUNC(muXYInterpolatedU, MatrixType)
-};
-} // namespace internal
-
-
-/*!
- * \breif Generation method of the triangles for the Corrected Normal Current formula
- */
-enum TriangleGenerationMethod {
-    UniformGeneration, HexagramGeneration, IndependentGeneration, AvgHexagramGeneration
-};
-
-/*!
- * \brief Corrected Normal Current Fit type.
- *
- * This fitting method generates triangles from a set a points cloud and use a statistical formula to compute :
- * - The principal curvatures values and directions
- * - The mean and gaussian curvatures
- *
- * \see PROVIDES_PRINCIPAL_CURVATURES
-*/
-template < class P, TriangleGenerationMethod _method = UniformGeneration>
-class CNC : ComputeObject<CNC<P, _method>> {
-protected:
-    enum
+    namespace internal
     {
-        PROVIDES_PRINCIPAL_CURVATURES
+        /*!
+         * Stores the three points and normals of the triangles and provides access to Corrected Normal Current formula
+         *
+         * \tparam DataPoint Type of input points.
+         *
+         * \see CNCEigen
+         */
+        template <class DataPoint>
+        struct Triangle
+        {
+        public:
+            typedef typename DataPoint::Scalar Scalar;
+            typedef typename DataPoint::VectorType VectorType;
+            typedef typename DataPoint::MatrixType MatrixType;
+
+        protected:
+            std::array<VectorType, 3> m_points;
+            std::array<VectorType, 3> m_normals;
+
+        public:
+            Triangle(DataPoint pointA, DataPoint pointB, DataPoint pointC)
+            {
+                m_points  = {pointA.pos(), pointB.pos(), pointC.pos()};
+                m_normals = {pointA.normal(), pointB.normal(), pointC.normal()};
+            }
+
+            Triangle(const std::array<VectorType, 3>& points, const std::array<VectorType, 3>& normals)
+            {
+                m_points  = points;
+                m_normals = normals;
+            }
+
+            /*! \brief Get the position of the point at the given index.
+             *
+             * \param index Index of one of the three vertices of the triangle (between 0 and 2)
+             * \return The position of vertex
+             */
+            PONCA_MULTIARCH [[nodiscard]] VectorType& getPos(const int index) { return m_points[index]; }
+
+            PONCA_MULTIARCH [[nodiscard]] bool operator==(const Triangle& other) const
+            {
+                return (m_points[0] == other.m_points[0]) && (m_points[1] == other.m_points[1]) &&
+                       (m_points[2] == other.m_points[2]);
+            }
+
+            PONCA_MULTIARCH [[nodiscard]] bool operator!=(const Triangle& other) const { return !((*this) == other); }
+
+#define DEFINE_CNC_FUNC(CNC_FUNC, RETURN_TYPE)                                                                        \
+    template <bool differentOrder = false>                                                                            \
+    inline RETURN_TYPE CNC_FUNC()                                                                                     \
+    {                                                                                                                 \
+        return CNCEigen<DataPoint>::CNC_FUNC(m_points[0], m_points[2 - differentOrder], m_points[1 + differentOrder], \
+                                             m_normals[0], m_normals[2 - differentOrder],                             \
+                                             m_normals[1 + differentOrder]);                                          \
+    }
+
+            DEFINE_CNC_FUNC(mu0InterpolatedU, Scalar)
+            DEFINE_CNC_FUNC(mu1InterpolatedU, Scalar)
+            DEFINE_CNC_FUNC(mu2InterpolatedU, Scalar)
+            DEFINE_CNC_FUNC(muXYInterpolatedU, MatrixType)
+        };
+    } // namespace internal
+
+    /*!
+     * \breif Generation method of the triangles for the Corrected Normal Current formula
+     */
+    enum TriangleGenerationMethod
+    {
+        UniformGeneration,
+        HexagramGeneration,
+        IndependentGeneration,
+        AvgHexagramGeneration
     };
-public:
-    using DataPoint = P;
-    using MatrixType = typename DataPoint::MatrixType;
-    using Scalar     = typename DataPoint::Scalar;
-    using VectorType = typename DataPoint::VectorType;
-    typedef Eigen::VectorXd  DenseVector;
-    typedef Eigen::MatrixXd  DenseMatrix;
-    using NeighborFilter = NeighborFilterStoreNormal<DataPoint, NoWeightFunc<DataPoint>>;
-protected:
-	// Basis
-    NeighborFilter m_nFilter;
-
-    // Triangles used for the computation
-    int m_nb_vt {0}; // Number of valid triangles
-    std::vector <internal::Triangle < DataPoint > > m_triangles;
-
-    // Results of the fit
-    Scalar m_A   {0}; // Area
-    Scalar m_H   {0}; // Mean Curvatures
-    Scalar m_G   {0}; // Gaussian Curvatures
-    Scalar m_T11 {0}; // T11
-    Scalar m_T12 {0}; // T12
-    Scalar m_T13 {0}; // T13
-    Scalar m_T22 {0}; // T22
-    Scalar m_T23 {0}; // T23
-    Scalar m_T33 {0}; // T33
-
-    Scalar m_k1 {0};
-    Scalar m_k2 {0};
-
-    VectorType m_v1;
-    VectorType m_v2;
-
-    /*! \brief Represent the current state of the fit
-     * (finalize function update the state)
-     */
-    FIT_RESULT m_eCurrentState {UNDEFINED};
-public:
-    PONCA_FITTING_DECLARE_FINALIZE
-
-    //! \brief Set the scalar field values to 0 and reset the isNormalized() status
-    PONCA_MULTIARCH inline void init() {
-        m_eCurrentState = UNDEFINED;
-        m_A  = Scalar(0);
-        m_H  = Scalar(0);
-        m_G  = Scalar(0);
-
-        m_k1 = Scalar(0);
-        m_k2 = Scalar(0);
-
-        m_triangles.clear();
-    }
 
     /*!
-     * \brief Compute function for STL-like containers.
-     * \tparam PointContainer An STL-like container storing the points
-     */
-    template <typename PointContainer>
-    PONCA_MULTIARCH inline FIT_RESULT compute( const PointContainer& points);
-
-    /*!
-     * \brief Compute function that iterates over a subset of sampled points from an STL-Like container.
-     * \tparam IndexRange An STL-like container storing the indices of the neighbors
-     * \tparam PointContainer An STL-like container storing the points
-     */
-    template <typename IndexRange, typename PointContainer>
-    PONCA_MULTIARCH inline FIT_RESULT computeWithIds( const IndexRange& ids, const PointContainer& points );
-
-    /*!
-     * \brief Get the number of triangles that were generated with the compute method.
-     * \return Returns the number of triangles
-     * \see CNC::compute
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline size_t getNumTriangles() const {
-        return static_cast<size_t>(m_nb_vt);
-    }
-
-    PONCA_FITTING_APIDOC_SETWFUNC
-    PONCA_MULTIARCH inline void setNeighborFilter (const NeighborFilter& _nFilter) {
-        m_nFilter  = _nFilter;
-    }
-
-    /*!
-     * \brief Returns the triangles
+     * \brief Corrected Normal Current Fit type.
      *
-     * \return A pointer to the array of triangle that was generated during the CNC Fit
+     * This fitting method generates triangles from a set a points cloud and use a statistical formula to compute :
+     * - The principal curvatures values and directions
+     * - The mean and gaussian curvatures
+     *
+     * \see PROVIDES_PRINCIPAL_CURVATURES
      */
-    PONCA_MULTIARCH [[nodiscard]] std::vector< internal::Triangle<DataPoint> >& getTriangles() {
-        return m_triangles;
-    }
+    template <class P, TriangleGenerationMethod _method = UniformGeneration>
+    class CNC : ComputeObject<CNC<P, _method>>
+    {
+    protected:
+        enum
+        {
+            PROVIDES_PRINCIPAL_CURVATURES
+        };
 
-    //! \brief Comparison operator
-    PONCA_MULTIARCH [[nodiscard]] bool operator==(const CNC& other) const {
-        // We use the matrix to compare the fitting results
-        return (m_eCurrentState == other.m_eCurrentState)
-            && (kMean() == other.kMean())
-            && (kmin() == other.kmin())
-            && (kmax() == other.kmax())
-            && (kminDirection() == other.kminDirection())
-            && (kmaxDirection() == other.kmaxDirection())
-            && (GaussianCurvature() == other.GaussianCurvature())
-            && (m_T11 == other.m_T11) && (m_T12 == other.m_T12) && (m_T13 == other.m_T13)
-            && (m_T22 == other.m_T22) && (m_T23 == other.m_T23)
-            && (m_T33 == other.m_T33);
-    }
+    public:
+        using DataPoint  = P;
+        using MatrixType = typename DataPoint::MatrixType;
+        using Scalar     = typename DataPoint::Scalar;
+        using VectorType = typename DataPoint::VectorType;
+        typedef Eigen::VectorXd DenseVector;
+        typedef Eigen::MatrixXd DenseMatrix;
+        using NeighborFilter = NeighborFilterStoreNormal<DataPoint, NoWeightFunc<DataPoint>>;
 
-    //! \brief Comparison operator, convenience function
-    PONCA_MULTIARCH [[nodiscard]] bool operator!=(const CNC& other) const {
-        // We use the matrix to compare the fitting results
-        return !(this == &other);
-    }
+    protected:
+        // Basis
+        NeighborFilter m_nFilter;
 
-    //! \brief Approximate operator
-    PONCA_MULTIARCH [[nodiscard]] bool isApprox(const CNC& other, const Scalar& epsilon = Eigen::NumTraits<Scalar>::dummy_precision()) const {
-        PONCA_MULTIARCH_STD_MATH(abs);
+        // Triangles used for the computation
+        int m_nb_vt{0}; // Number of valid triangles
+        std::vector<internal::Triangle<DataPoint>> m_triangles;
 
-        return (m_eCurrentState == other.m_eCurrentState)
-            && (std::abs(kMean()  - other.kMean())  < epsilon)
-            && (std::abs(GaussianCurvature() - other.GaussianCurvature()) < epsilon)
-            && (std::abs(kmin() - other.kmin()) < epsilon)
-            && (std::abs(kmax() - other.kmax()) < epsilon);
-    }
+        // Results of the fit
+        Scalar m_A{0};   // Area
+        Scalar m_H{0};   // Mean Curvatures
+        Scalar m_G{0};   // Gaussian Curvatures
+        Scalar m_T11{0}; // T11
+        Scalar m_T12{0}; // T12
+        Scalar m_T13{0}; // T13
+        Scalar m_T22{0}; // T22
+        Scalar m_T23{0}; // T23
+        Scalar m_T33{0}; // T33
 
-    //! \brief Is the fitted primitive ready to use (finalize has been called and the result is stable)
-    PONCA_MULTIARCH [[nodiscard]] inline bool isStable() const { return m_eCurrentState == STABLE; }
+        Scalar m_k1{0};
+        Scalar m_k2{0};
 
-    //! \brief Returns an estimate of the minimal principal curvature value
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar kmin() const { return m_k1; }
+        VectorType m_v1;
+        VectorType m_v2;
 
-    //! \brief Returns an estimate of the maximal principal curvature value
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar kmax() const { return m_k2; }
+        /*! \brief Represent the current state of the fit
+         * (finalize function update the state)
+         */
+        FIT_RESULT m_eCurrentState{UNDEFINED};
 
-    //! \brief Returns an estimate of the minimal principal curvature direction
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType kminDirection() const { return m_v1; }
+    public:
+        PONCA_FITTING_DECLARE_FINALIZE
 
-    //! \brief Returns an estimate of the maximal principal curvature direction
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType kmaxDirection() const { return m_v2; }
+        //! \brief Set the scalar field values to 0 and reset the isNormalized() status
+        PONCA_MULTIARCH inline void init()
+        {
+            m_eCurrentState = UNDEFINED;
+            m_A             = Scalar(0);
+            m_H             = Scalar(0);
+            m_G             = Scalar(0);
 
-    //! \brief Returns an estimate of the mean curvature
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar kMean() const { return m_H; }
+            m_k1 = Scalar(0);
+            m_k2 = Scalar(0);
 
-    //! \brief Returns an estimate of the Gaussian curvature
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar GaussianCurvature() const { return m_G; }
-}; //class CNC
+            m_triangles.clear();
+        }
+
+        /*!
+         * \brief Compute function for STL-like containers.
+         * \tparam PointContainer An STL-like container storing the points
+         */
+        template <typename PointContainer>
+        PONCA_MULTIARCH inline FIT_RESULT compute(const PointContainer& points);
+
+        /*!
+         * \brief Compute function that iterates over a subset of sampled points from an STL-Like container.
+         * \tparam IndexRange An STL-like container storing the indices of the neighbors
+         * \tparam PointContainer An STL-like container storing the points
+         */
+        template <typename IndexRange, typename PointContainer>
+        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(const IndexRange& ids, const PointContainer& points);
+
+        /*!
+         * \brief Get the number of triangles that were generated with the compute method.
+         * \return Returns the number of triangles
+         * \see CNC::compute
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline size_t getNumTriangles() const { return static_cast<size_t>(m_nb_vt); }
+
+        PONCA_FITTING_APIDOC_SETWFUNC
+        PONCA_MULTIARCH inline void setNeighborFilter(const NeighborFilter& _nFilter) { m_nFilter = _nFilter; }
+
+        /*!
+         * \brief Returns the triangles
+         *
+         * \return A pointer to the array of triangle that was generated during the CNC Fit
+         */
+        PONCA_MULTIARCH [[nodiscard]] std::vector<internal::Triangle<DataPoint>>& getTriangles() { return m_triangles; }
+
+        //! \brief Comparison operator
+        PONCA_MULTIARCH [[nodiscard]] bool operator==(const CNC& other) const
+        {
+            // We use the matrix to compare the fitting results
+            return (m_eCurrentState == other.m_eCurrentState) && (kMean() == other.kMean()) &&
+                   (kmin() == other.kmin()) && (kmax() == other.kmax()) && (kminDirection() == other.kminDirection()) &&
+                   (kmaxDirection() == other.kmaxDirection()) && (GaussianCurvature() == other.GaussianCurvature()) &&
+                   (m_T11 == other.m_T11) && (m_T12 == other.m_T12) && (m_T13 == other.m_T13) &&
+                   (m_T22 == other.m_T22) && (m_T23 == other.m_T23) && (m_T33 == other.m_T33);
+        }
+
+        //! \brief Comparison operator, convenience function
+        PONCA_MULTIARCH [[nodiscard]] bool operator!=(const CNC& other) const
+        {
+            // We use the matrix to compare the fitting results
+            return !(this == &other);
+        }
+
+        //! \brief Approximate operator
+        PONCA_MULTIARCH [[nodiscard]] bool isApprox(
+            const CNC& other, const Scalar& epsilon = Eigen::NumTraits<Scalar>::dummy_precision()) const
+        {
+            PONCA_MULTIARCH_STD_MATH(abs);
+
+            return (m_eCurrentState == other.m_eCurrentState) && (std::abs(kMean() - other.kMean()) < epsilon) &&
+                   (std::abs(GaussianCurvature() - other.GaussianCurvature()) < epsilon) &&
+                   (std::abs(kmin() - other.kmin()) < epsilon) && (std::abs(kmax() - other.kmax()) < epsilon);
+        }
+
+        //! \brief Is the fitted primitive ready to use (finalize has been called and the result is stable)
+        PONCA_MULTIARCH [[nodiscard]] inline bool isStable() const { return m_eCurrentState == STABLE; }
+
+        //! \brief Returns an estimate of the minimal principal curvature value
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar kmin() const { return m_k1; }
+
+        //! \brief Returns an estimate of the maximal principal curvature value
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar kmax() const { return m_k2; }
+
+        //! \brief Returns an estimate of the minimal principal curvature direction
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType kminDirection() const { return m_v1; }
+
+        //! \brief Returns an estimate of the maximal principal curvature direction
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType kmaxDirection() const { return m_v2; }
+
+        //! \brief Returns an estimate of the mean curvature
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar kMean() const { return m_H; }
+
+        //! \brief Returns an estimate of the Gaussian curvature
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar GaussianCurvature() const { return m_G; }
+    }; // class CNC
 
 } // namespace Ponca
 

--- a/Ponca/src/Fitting/cnc.hpp
+++ b/Ponca/src/Fitting/cnc.hpp
@@ -11,27 +11,29 @@ All rights reserved.
 
 #include <random>
 
-namespace Ponca::internal {
+namespace Ponca::internal
+{
     /*! \internal
      *
      * \brief Generates the triangles used by the CNC Fit depending on the method.
      *
-     * As an output, pushes every generated triangle into the `triangles` vector and returns the number of triangle that was pushed to the List.
+     * As an output, pushes every generated triangle into the `triangles` vector and returns the number of triangle that
+     * was pushed to the List.
      *
-     * \note Needs to be implemented for each triangle generation method by specializing the template over the `TriangleGenerationMethod` enum.
+     * \note Needs to be implemented for each triangle generation method by specializing the template over the
+     * `TriangleGenerationMethod` enum.
      *
      * \see TriangleGenerationMethod
      */
     template <TriangleGenerationMethod Method, typename P>
-    struct TriangleGenerator {
+    struct TriangleGenerator
+    {
         using VectorType = typename P::VectorType;
         template <typename IndexRange, typename PointContainer, typename NeighborFilter>
-        static FIT_RESULT generate(
-            const IndexRange& /*ids*/,
-            const PointContainer& /*points*/,
-            const NeighborFilter& /*w*/,
-            std::vector<Triangle<P>>& /*triangles*/
-        ) {
+        static FIT_RESULT generate(const IndexRange& /*ids*/, const PointContainer& /*points*/,
+                                   const NeighborFilter& /*w*/, std::vector<Triangle<P>>& /*triangles*/
+        )
+        {
             throw std::invalid_argument("Triangle generation method not implemented!");
         }
     };
@@ -41,25 +43,25 @@ namespace Ponca::internal {
      * Generates the triangles using UniformGeneration
      */
     template <typename P>
-    struct TriangleGenerator<UniformGeneration, P> {
+    struct TriangleGenerator<UniformGeneration, P>
+    {
     private:
-        static constexpr int maxTriangles {100};
+        static constexpr int maxTriangles{100};
+
     public:
         using VectorType = typename P::VectorType;
         using Scalar     = typename P::Scalar;
 
         template <typename IndexRange, typename PointContainer, typename NeighborFilter>
-        static FIT_RESULT generate(
-            const IndexRange& ids,
-            const PointContainer& points,
-            const NeighborFilter& w,
-            std::vector<Triangle<P>>& triangles
-        ) {
+        static FIT_RESULT generate(const IndexRange& ids, const PointContainer& points, const NeighborFilter& w,
+                                   std::vector<Triangle<P>>& triangles)
+        {
             // Makes a new array
             std::vector<int> indices;
-            for ( int index : ids ) {
+            for (int index : ids)
+            {
                 // Skip the points that are outside the kernel radius
-                if (w(points[ index ]).first == Scalar(0.))
+                if (w(points[index]).first == Scalar(0.))
                     continue;
                 indices.push_back(index);
             }
@@ -67,12 +69,14 @@ namespace Ponca::internal {
                 return UNDEFINED;
 
             const int lastIndex = int(indices.size()) - 1;
-            for (int i = 0; i < maxTriangles; ++i) {
+            for (int i = 0; i < maxTriangles; ++i)
+            {
                 // Randomly select triangles
                 int i1 = indices[Eigen::internal::random<int>(0, lastIndex)];
                 int i2 = indices[Eigen::internal::random<int>(0, lastIndex)];
                 int i3 = indices[Eigen::internal::random<int>(0, lastIndex)];
-                if (i1 == i2 || i1 == i3 || i2 == i3) continue;
+                if (i1 == i2 || i1 == i3 || i2 == i3)
+                    continue;
 
                 triangles.push_back(internal::Triangle<P>(points[i1], points[i2], points[i3]));
             }
@@ -85,25 +89,25 @@ namespace Ponca::internal {
      * Generates the triangles using IndependentGeneration
      */
     template <typename P>
-    struct TriangleGenerator<IndependentGeneration, P> {
+    struct TriangleGenerator<IndependentGeneration, P>
+    {
     private:
-        static constexpr int maxTriangles {100};
+        static constexpr int maxTriangles{100};
+
     public:
         using VectorType = typename P::VectorType;
         using Scalar     = typename P::Scalar;
 
         template <typename IndexRange, typename PointContainer, typename NeighborFilter>
-        static FIT_RESULT generate(
-            const IndexRange& ids,
-            const PointContainer& points,
-            const NeighborFilter& w,
-            std::vector<Triangle<P>>& triangles
-        ) {
+        static FIT_RESULT generate(const IndexRange& ids, const PointContainer& points, const NeighborFilter& w,
+                                   std::vector<Triangle<P>>& triangles)
+        {
             // Makes a new array to shuffle
             std::vector<int> indices;
-            for ( int index : ids ) {
+            for (int index : ids)
+            {
                 // Skip the points that are outside the kernel radius
-                if (w(points[ index ]).first == Scalar(0.))
+                if (w(points[index]).first == Scalar(0.))
                     continue;
                 indices.push_back(index);
             }
@@ -118,114 +122,116 @@ namespace Ponca::internal {
             // Compute the triangles
             triangles.clear();
             const int max_triangles = std::min(maxTriangles, int(ids.size() / 3));
-            for (int nb_vt = 0; nb_vt < max_triangles-2; nb_vt++) {
+            for (int nb_vt = 0; nb_vt < max_triangles - 2; nb_vt++)
+            {
                 int i1 = indices[nb_vt];
-                int i2 = indices[nb_vt+1];
-                int i3 = indices[nb_vt+2];
+                int i2 = indices[nb_vt + 1];
+                int i3 = indices[nb_vt + 2];
                 triangles.push_back(internal::Triangle<P>(points[i1], points[i2], points[i3]));
             }
             return STABLE;
         }
     };
 
-    template<typename P>
-    struct HexagramBase {
+    template <typename P>
+    struct HexagramBase
+    {
         using Scalar = typename P::Scalar;
-        static constexpr Scalar avg_normal_coef {Scalar(0.5)};
+        static constexpr Scalar avg_normal_coef{Scalar(0.5)};
     };
-
 
     /*! \copydoc TriangleGenerator
      *
      * Generates the triangles using HexagramGeneration
      */
     template <typename P>
-    struct TriangleGenerator<HexagramGeneration, P> : protected HexagramBase<P> {
+    struct TriangleGenerator<HexagramGeneration, P> : protected HexagramBase<P>
+    {
         using VectorType = typename P::VectorType;
         using Scalar     = typename P::Scalar;
 
         template <typename IndexRange, typename PointContainer, typename NeighborFilter>
-        static FIT_RESULT generate(
-            const IndexRange& ids,
-            const PointContainer& points,
-            const NeighborFilter& w,
-            std::vector<Triangle<P>>& triangles
-        ) {
+        static FIT_RESULT generate(const IndexRange& ids, const PointContainer& points, const NeighborFilter& w,
+                                   std::vector<Triangle<P>>& triangles)
+        {
             PONCA_MULTIARCH_STD_MATH(abs);
             // Compute normal and maximum distance.
             VectorType c = w.evalPos();
             VectorType n = w.evalNormal();
-            VectorType a {VectorType::Zero()};
+            VectorType a{VectorType::Zero()};
             Scalar avg_d = Scalar(0);
 
-            bool isUndefined = true;
+            bool isUndefined       = true;
             int valid_points_count = 0;
-            for ( int index : ids ) {
+            for (int index : ids)
+            {
                 // Skip the points that are outside the kernel radius
-                if (w(points[ index ]).first == Scalar(0.))
+                if (w(points[index]).first == Scalar(0.))
                     continue;
-                auto p = points[ index ];
-                avg_d += ( p.pos() - c ).norm();
-                a     += p.normal();
+                auto p = points[index];
+                avg_d += (p.pos() - c).norm();
+                a += p.normal();
                 isUndefined = false;
-                valid_points_count ++;
+                valid_points_count++;
             }
             if (isUndefined)
                 return UNDEFINED;
 
-            a     /= a.norm();
-            n      = ( Scalar(1) - HexagramBase<P>::avg_normal_coef ) * n + HexagramBase<P>::avg_normal_coef * a;
-            n     /= n.norm();
+            a /= a.norm();
+            n = (Scalar(1) - HexagramBase<P>::avg_normal_coef) * n + HexagramBase<P>::avg_normal_coef * a;
+            n /= n.norm();
             avg_d /= valid_points_count;
 
             // Define basis for sector analysis.
-            const int m = abs( n[0] ) > abs( n[1] )
-                      ? ( abs( n[0] ) > abs( n[2] ) ? 0 : 2 )
-                      : ( abs( n[1] ) > abs( n[2] ) ? 1 : 2 ) ;
+            const int m = abs(n[0]) > abs(n[1]) ? (abs(n[0]) > abs(n[2]) ? 0 : 2) : (abs(n[1]) > abs(n[2]) ? 1 : 2);
 
-            const VectorType e =
-                ( m == 0 ) ? VectorType( 0, 1, 0 ) :
-                ( m == 1 ) ? VectorType( 0, 0, 1 ) :
-                             VectorType( 1, 0, 0 ) ;
+            const VectorType e = (m == 0) ? VectorType(0, 1, 0) : (m == 1) ? VectorType(0, 0, 1) : VectorType(1, 0, 0);
 
-            VectorType u = n.cross( e );
-            VectorType v = n.cross( u );
+            VectorType u = n.cross(e);
+            VectorType v = n.cross(u);
             u /= u.norm();
             v /= v.norm();
 
-            std::array<VectorType , 6> positions ;
-            std::array<VectorType , 6> normals   ;
-            std::array< Scalar    , 6 > distance2;
-            std::array< VectorType, 6 > targets;
+            std::array<VectorType, 6> positions;
+            std::array<VectorType, 6> normals;
+            std::array<Scalar, 6> distance2;
+            std::array<VectorType, 6> targets;
 
-            for ( int i = 0 ; i < 6 ; i++ ) {
-                distance2[ i ] = avg_d * avg_d;
-                targets  [ i ] = avg_d * ( u * cos(i * M_PI / 3.0) + v * sin(i * M_PI / 3.0) );
-                positions[ i ] = w.evalPos();
-                normals  [ i ] = w.evalNormal();
+            for (int i = 0; i < 6; i++)
+            {
+                distance2[i] = avg_d * avg_d;
+                targets[i]   = avg_d * (u * cos(i * M_PI / 3.0) + v * sin(i * M_PI / 3.0));
+                positions[i] = w.evalPos();
+                normals[i]   = w.evalNormal();
             }
 
             // Compute closest points.
-            for ( int index : ids ) {
+            for (int index : ids)
+            {
                 // Skip the points that are outside the kernel radius
-                if (w(points[ index ]).first == Scalar(0.))
+                if (w(points[index]).first == Scalar(0.))
                     continue;
 
-                VectorType p = points[ index ].pos();
-                if ( p == c ) continue; // Skip the eval point
+                VectorType p = points[index].pos();
+                if (p == c)
+                    continue; // Skip the eval point
                 const VectorType d = p - c;
 
-                for ( int j = 0 ; j < 6 ; j++ ) {
-                    const Scalar d2 = ( d - targets[ j ]).squaredNorm();
-                    if ( d2 < distance2[ j ] ) {
-                        distance2[ j ] = d2;
-                        positions[ j ] = p;
-                        normals  [ j ] = points[ index ].normal();
+                for (int j = 0; j < 6; j++)
+                {
+                    const Scalar d2 = (d - targets[j]).squaredNorm();
+                    if (d2 < distance2[j])
+                    {
+                        distance2[j] = d2;
+                        positions[j] = p;
+                        normals[j]   = points[index].normal();
                     }
                 }
             }
-            triangles.push_back(internal::Triangle<P>({positions[0] , positions[2] , positions[4]}, {normals[0] , normals[2], normals[4]}));
-            triangles.push_back(internal::Triangle<P>({positions[1] , positions[3] , positions[5]}, {normals[1] , normals[3], normals[5]}));
+            triangles.push_back(internal::Triangle<P>({positions[0], positions[2], positions[4]},
+                                                      {normals[0], normals[2], normals[4]}));
+            triangles.push_back(internal::Triangle<P>({positions[1], positions[3], positions[5]},
+                                                      {normals[1], normals[3], normals[5]}));
 
             return STABLE;
         }
@@ -236,178 +242,191 @@ namespace Ponca::internal {
      * Generates the triangles using AvgHexagramGeneration
      */
     template <typename P>
-    struct TriangleGenerator<AvgHexagramGeneration, P> : protected HexagramBase<P> {
+    struct TriangleGenerator<AvgHexagramGeneration, P> : protected HexagramBase<P>
+    {
         using VectorType = typename P::VectorType;
         using Scalar     = typename P::Scalar;
 
         template <typename IndexRange, typename PointContainer, typename NeighborFilter>
-        static FIT_RESULT generate(
-            const IndexRange& ids,
-            const PointContainer& points,
-            const NeighborFilter& w,
-            std::vector<Triangle<P>>& triangles
-        ) {
+        static FIT_RESULT generate(const IndexRange& ids, const PointContainer& points, const NeighborFilter& w,
+                                   std::vector<Triangle<P>>& triangles)
+        {
             // Compute normal and maximum distance.
             VectorType c = w.evalPos();
             VectorType n = w.evalNormal();
             VectorType a = VectorType::Zero();
             Scalar avg_d = Scalar(0);
 
-            std::array< VectorType, 6 > targets;
-            Scalar avg_normal  = Scalar(0.5);
+            std::array<VectorType, 6> targets;
+            Scalar avg_normal = Scalar(0.5);
 
-            bool isUndefined = true;
+            bool isUndefined       = true;
             int valid_points_count = 0;
-            for ( int index : ids ) {
-                if (w(points[ index ]).first == Scalar(0.))
+            for (int index : ids)
+            {
+                if (w(points[index]).first == Scalar(0.))
                     continue; // Skip the points that are outside the kernel radius
-                a     += points[ index ].normal();
-                avg_d += ( points[ index ].pos() - c ).norm();
+                a += points[index].normal();
+                avg_d += (points[index].pos() - c).norm();
                 isUndefined = false;
-                valid_points_count ++;
+                valid_points_count++;
             }
             if (isUndefined)
                 return UNDEFINED;
 
-            a     /= a.norm();
-            n      = ( Scalar(1) - HexagramBase<P>::avg_normal_coef ) * n + HexagramBase<P>::avg_normal_coef * a;
-            n     /= n.norm();
+            a /= a.norm();
+            n = (Scalar(1) - HexagramBase<P>::avg_normal_coef) * n + HexagramBase<P>::avg_normal_coef * a;
+            n /= n.norm();
             avg_d /= valid_points_count;
 
             // Define basis for sector analysis.
-            const int m = ( std::abs( n[0] ) > std::abs ( n[1] ))
-                    ? ( ( std::abs( n[0] ) ) > std::abs( n[2] ) ? 0 : 2 )
-                    : ( ( std::abs( n[1] ) ) > std::abs( n[2] ) ? 1 : 2 );
+            const int m = (std::abs(n[0]) > std::abs(n[1])) ? ((std::abs(n[0])) > std::abs(n[2]) ? 0 : 2)
+                                                            : ((std::abs(n[1])) > std::abs(n[2]) ? 1 : 2);
 
-            const VectorType e = ( m == 0 ) ? VectorType( 0, 1, 0 ) :
-                                 ( m == 1 ) ? VectorType( 0, 0, 1 ) :
-                                              VectorType( 1, 0, 0 ) ;
-            VectorType u = n.cross( e );
-            VectorType v = n.cross( u );
+            const VectorType e = (m == 0) ? VectorType(0, 1, 0) : (m == 1) ? VectorType(0, 0, 1) : VectorType(1, 0, 0);
+            VectorType u       = n.cross(e);
+            VectorType v       = n.cross(u);
             u /= u.norm();
             v /= v.norm();
 
             // Initialize the average values
-            std::array< VectorType, 6 > array_avg_normals;
-            std::array< VectorType, 6 > array_avg_pos;
-            std::array< int, 6 >    array_nb {};
-            for (int i = 0 ; i < 6 ; i++ ) {
-                targets[ i ]          = avg_d * ( u * cos(i * M_PI / 3.0) + v * sin(i * M_PI / 3.0) );
-                array_avg_normals[ i ] = VectorType::Zero();
-                array_avg_pos    [ i ] = VectorType::Zero();
+            std::array<VectorType, 6> array_avg_normals;
+            std::array<VectorType, 6> array_avg_pos;
+            std::array<int, 6> array_nb{};
+            for (int i = 0; i < 6; i++)
+            {
+                targets[i]           = avg_d * (u * cos(i * M_PI / 3.0) + v * sin(i * M_PI / 3.0));
+                array_avg_normals[i] = VectorType::Zero();
+                array_avg_pos[i]     = VectorType::Zero();
             }
 
             // Compute closest points.
-            for (int index : ids) {
-                if (w(points[ index ]).first == Scalar(0.))
+            for (int index : ids)
+            {
+                if (w(points[index]).first == Scalar(0.))
                     continue; // Skip the points that are outside the kernel radius
-                VectorType p = points[ index ].pos() - c;
-                int best_k = 0;
-                Scalar best_d2 = ( p - targets[ 0 ] ).squaredNorm();
-                for (int k = 1 ; k < 6 ; k++) {
-                    const Scalar d2 = ( p - targets[ k ] ).squaredNorm();
-                    if ( d2 < best_d2 ) {
-                        best_k = k;
+                VectorType p   = points[index].pos() - c;
+                int best_k     = 0;
+                Scalar best_d2 = (p - targets[0]).squaredNorm();
+                for (int k = 1; k < 6; k++)
+                {
+                    const Scalar d2 = (p - targets[k]).squaredNorm();
+                    if (d2 < best_d2)
+                    {
+                        best_k  = k;
                         best_d2 = d2;
                     }
                 }
-                array_avg_normals[ best_k ] += points[ index ].normal();
-                array_avg_pos    [ best_k ] += points[ index ].pos();
-                array_nb[ best_k ] += 1;
+                array_avg_normals[best_k] += points[index].normal();
+                array_avg_pos[best_k] += points[index].pos();
+                array_nb[best_k] += 1;
             }
 
-            for (int i = 0 ; i < 6 ; i++) {
-                if ( array_nb[ i ] == 0 ) {
-                    array_avg_normals[ i ] = w.evalNormal();
-                    array_avg_pos    [ i ] = w.evalPos();
-                } else {
-                    array_avg_normals[ i ] /= array_avg_normals[ i ].norm();
-                    array_avg_pos    [ i ] /= Scalar(array_nb[ i ]);
+            for (int i = 0; i < 6; i++)
+            {
+                if (array_nb[i] == 0)
+                {
+                    array_avg_normals[i] = w.evalNormal();
+                    array_avg_pos[i]     = w.evalPos();
+                }
+                else
+                {
+                    array_avg_normals[i] /= array_avg_normals[i].norm();
+                    array_avg_pos[i] /= Scalar(array_nb[i]);
                 }
             }
 
-            triangles.push_back(internal::Triangle<P>(
-                { array_avg_pos[0] , array_avg_pos[2] , array_avg_pos[4] },
-                { array_avg_normals[0], array_avg_normals[2], array_avg_normals[4] }
-            ));
-            triangles.push_back(internal::Triangle<P>(
-                { array_avg_pos[1] , array_avg_pos[3] , array_avg_pos[5] },
-                { array_avg_normals[1], array_avg_normals[3], array_avg_normals[5] }
-            ));
+            triangles.push_back(
+                internal::Triangle<P>({array_avg_pos[0], array_avg_pos[2], array_avg_pos[4]},
+                                      {array_avg_normals[0], array_avg_normals[2], array_avg_normals[4]}));
+            triangles.push_back(
+                internal::Triangle<P>({array_avg_pos[1], array_avg_pos[3], array_avg_pos[5]},
+                                      {array_avg_normals[1], array_avg_normals[3], array_avg_normals[5]}));
             return STABLE;
         }
     };
 } // namespace Ponca::internal
 
-namespace Ponca {
-    template < class P, TriangleGenerationMethod M>
+namespace Ponca
+{
+    template <class P, TriangleGenerationMethod M>
     template <typename PointContainer>
-    FIT_RESULT CNC<P, M>::compute( const PointContainer& points ) {
+    FIT_RESULT CNC<P, M>::compute(const PointContainer& points)
+    {
         init();
         std::vector<unsigned int> indicesSample(points.size());
         std::iota(indicesSample.begin(), indicesSample.end(), 0);
 
-        m_eCurrentState = internal::TriangleGenerator<M, P>::generate( indicesSample, points, m_nFilter, m_triangles);
-        if (m_eCurrentState != STABLE) return m_eCurrentState;
+        m_eCurrentState = internal::TriangleGenerator<M, P>::generate(indicesSample, points, m_nFilter, m_triangles);
+        if (m_eCurrentState != STABLE)
+            return m_eCurrentState;
         m_nb_vt = int(m_triangles.size());
         return finalize();
     }
 
-    template < class P, TriangleGenerationMethod M>
+    template <class P, TriangleGenerationMethod M>
     template <typename IndexRange, typename PointContainer>
-    FIT_RESULT CNC<P, M>::computeWithIds( const IndexRange& ids, const PointContainer& points ) {
+    FIT_RESULT CNC<P, M>::computeWithIds(const IndexRange& ids, const PointContainer& points)
+    {
         init();
-        m_eCurrentState = internal::TriangleGenerator<M, P>::generate( ids, points, m_nFilter, m_triangles);
-        if (m_eCurrentState != STABLE) return m_eCurrentState;
+        m_eCurrentState = internal::TriangleGenerator<M, P>::generate(ids, points, m_nFilter, m_triangles);
+        if (m_eCurrentState != STABLE)
+            return m_eCurrentState;
         m_nb_vt = int(m_triangles.size());
         return finalize();
     }
 
-    template < class P, TriangleGenerationMethod M>
-    FIT_RESULT CNC<P, M>::finalize( ) {
+    template <class P, TriangleGenerationMethod M>
+    FIT_RESULT CNC<P, M>::finalize()
+    {
         m_A = Scalar(0);
         m_H = Scalar(0);
         m_G = Scalar(0);
 
         MatrixType localT = MatrixType::Zero();
 
-        for (int t = 0; t < m_nb_vt; ++t) {
+        for (int t = 0; t < m_nb_vt; ++t)
+        {
             // Simple estimation.
             Scalar tA = m_triangles[t].mu0InterpolatedU();
-            if (tA < -internal::CNCEigen<P>::epsilon) {
-                m_A     -= tA;
-                m_H     += m_triangles[t].template mu1InterpolatedU<true>();
-                m_G     += m_triangles[t].template mu2InterpolatedU<true>();
-                localT  += m_triangles[t].template muXYInterpolatedU<true>();
-            } else if (tA > internal::CNCEigen<P>::epsilon) {
-                m_A     += tA;
-                m_H     += m_triangles[t].mu1InterpolatedU();
-                m_G     += m_triangles[t].mu2InterpolatedU();
-                localT  += m_triangles[t].muXYInterpolatedU();
+            if (tA < -internal::CNCEigen<P>::epsilon)
+            {
+                m_A -= tA;
+                m_H += m_triangles[t].template mu1InterpolatedU<true>();
+                m_G += m_triangles[t].template mu2InterpolatedU<true>();
+                localT += m_triangles[t].template muXYInterpolatedU<true>();
+            }
+            else if (tA > internal::CNCEigen<P>::epsilon)
+            {
+                m_A += tA;
+                m_H += m_triangles[t].mu1InterpolatedU();
+                m_G += m_triangles[t].mu2InterpolatedU();
+                localT += m_triangles[t].muXYInterpolatedU();
             }
         } // end for t
 
-        m_T11 = localT(0,0);
-        m_T12 = Scalar(0.5) * (localT(0,1) + localT(1,0));
-        m_T13 = Scalar(0.5) * (localT(0,2) + localT(2,0));
-        m_T22 = localT(1,1);
-        m_T23 = Scalar(0.5) * (localT(1,2) + localT(2,1));
-        m_T33 = localT(2,2);
+        m_T11 = localT(0, 0);
+        m_T12 = Scalar(0.5) * (localT(0, 1) + localT(1, 0));
+        m_T13 = Scalar(0.5) * (localT(0, 2) + localT(2, 0));
+        m_T22 = localT(1, 1);
+        m_T23 = Scalar(0.5) * (localT(1, 2) + localT(2, 1));
+        m_T33 = localT(2, 2);
 
         MatrixType T;
-        if (m_A != Scalar(0)) {
-            T  << m_T11, m_T12, m_T13,
-                  m_T12, m_T22, m_T23,
-                  m_T13, m_T23, m_T33;
-            T  /= m_A;
+        if (m_A != Scalar(0))
+        {
+            T << m_T11, m_T12, m_T13, m_T12, m_T22, m_T23, m_T13, m_T23, m_T33;
+            T /= m_A;
             m_H /= m_A;
             m_G /= m_A;
-        } else {
+        }
+        else
+        {
             m_H = Scalar(0);
             m_G = Scalar(0);
         }
 
-        std::tie (m_k2, m_k1, m_v2, m_v1) = internal::CNCEigen<P>::curvaturesFromTensor(T, 1.0, m_nFilter.evalNormal());
+        std::tie(m_k2, m_k1, m_v2, m_v1) = internal::CNCEigen<P>::curvaturesFromTensor(T, 1.0, m_nFilter.evalNormal());
 
         return STABLE;
     }

--- a/Ponca/src/Fitting/cncFormulaEigen.h
+++ b/Ponca/src/Fitting/cncFormulaEigen.h
@@ -63,314 +63,299 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <Eigen/Dense>
 
-namespace Ponca::internal {
+namespace Ponca::internal
+{
 
-/**
- * \brief This class contains some stand-alone CorrectedNormalCurrent formulas for triangles,
- * using eigen as linear algebra backend.
- */
-template<typename DataPoint>
-struct CNCEigen {
-	using MatrixType = typename DataPoint::MatrixType;
-	using Scalar     = typename DataPoint::Scalar;
-	using VectorType = typename DataPoint::VectorType;
-	/// Small constant used to approximate zero.
-	static constexpr Scalar epsilon = Eigen::NumTraits<Scalar>::epsilon();
+    /**
+     * \brief This class contains some stand-alone CorrectedNormalCurrent formulas for triangles,
+     * using eigen as linear algebra backend.
+     */
+    template <typename DataPoint>
+    struct CNCEigen
+    {
+        using MatrixType = typename DataPoint::MatrixType;
+        using Scalar     = typename DataPoint::Scalar;
+        using VectorType = typename DataPoint::VectorType;
+        /// Small constant used to approximate zero.
+        static constexpr Scalar epsilon = Eigen::NumTraits<Scalar>::epsilon();
 
-	/// Represents a triangle on a sphere of radius one.
-	struct SphericalTriangle {
-		///Spherical point data type
-		static bool isDegenerate(const VectorType& a, const VectorType& b, const VectorType& c) {
-			Scalar d[3] = {(a - b).norm(), (a - c).norm(), (b - c).norm()};
-			// Checks that the spherical triangle is small or thin.
-			if ((d[0] < epsilon) || (d[1] < epsilon) || (d[2] < epsilon))
-				return true;
-			// Checks that the spherical triangle is flat.
-			size_t m = 0;
-			if (d[1] > d[m]) m = 1;
-			if (d[2] > d[m]) m = 2;
-			return (fabs(d[m] - d[(m + 1) % 3] - d[(m + 2) % 3]) < epsilon);
-		}
+        /// Represents a triangle on a sphere of radius one.
+        struct SphericalTriangle
+        {
+            /// Spherical point data type
+            static bool isDegenerate(const VectorType& a, const VectorType& b, const VectorType& c)
+            {
+                Scalar d[3] = {(a - b).norm(), (a - c).norm(), (b - c).norm()};
+                // Checks that the spherical triangle is small or thin.
+                if ((d[0] < epsilon) || (d[1] < epsilon) || (d[2] < epsilon))
+                    return true;
+                // Checks that the spherical triangle is flat.
+                size_t m = 0;
+                if (d[1] > d[m])
+                    m = 1;
+                if (d[2] > d[m])
+                    m = 2;
+                return (fabs(d[m] - d[(m + 1) % 3] - d[(m + 2) % 3]) < epsilon);
+            }
 
-		/// \return the polar triangle associated with this triangle.
-		static void polarTriangle(
-			const VectorType& a, const VectorType& b, const VectorType& c,
-			VectorType& Ap     , VectorType& Bp     , VectorType& Cp
-		) {
-			Ap = b.cross(c);
-			Bp = c.cross(a);
-			Cp = a.cross(b);
-			// Reorient points.
-			if (Ap.dot(a) < 0.0) Ap = -Ap;
-			if (Bp.dot(b) < 0.0) Bp = -Bp;
-			if (Cp.dot(c) < 0.0) Cp = -Cp;
-		}
+            /// \return the polar triangle associated with this triangle.
+            static void polarTriangle(const VectorType& a, const VectorType& b, const VectorType& c, VectorType& Ap,
+                                      VectorType& Bp, VectorType& Cp)
+            {
+                Ap = b.cross(c);
+                Bp = c.cross(a);
+                Cp = a.cross(b);
+                // Reorient points.
+                if (Ap.dot(a) < 0.0)
+                    Ap = -Ap;
+                if (Bp.dot(b) < 0.0)
+                    Bp = -Bp;
+                if (Cp.dot(c) < 0.0)
+                    Cp = -Cp;
+            }
 
-		/// Returns the interior angles of the spherical triangle ABC.
-		/// \param[out] alpha the interior angle at vertex A.
-		/// \param[out] beta  the interior angle at vertex B.
-		/// \param[out] gamma the interior angle at vertex C.
-		static void interiorAngles(
-			const VectorType& a, const VectorType& b, const VectorType& c,
-		    Scalar& alpha      , Scalar& beta       , Scalar& gamma
-		) {
-			VectorType Ta, Tb, Tc;
-			polarTriangle(a, b, c, Ta, Tb, Tc);
-			Ta /= Ta.norm();
-			Tb /= Tb.norm();
-			Tc /= Tc.norm();
-			if (Ta == VectorType::Zero() || Tb == VectorType::Zero() || Tc == VectorType::Zero())
-				alpha = beta = gamma = Scalar(0.0);
-			else
-			{
-				Scalar ca = std::max(Scalar(-1.0), std::min(Scalar(1.0), Tb.dot(Tc)));
-				Scalar cb = std::max(Scalar(-1.0), std::min(Scalar(1.0), Tc.dot(Ta)));
-				Scalar cc = std::max(Scalar(-1.0), std::min(Scalar(1.0), Ta.dot(Tb)));
-				alpha = acos(ca);
-				beta = acos(cb);
-				gamma = acos(cc);
-			}
-		}
+            /// Returns the interior angles of the spherical triangle ABC.
+            /// \param[out] alpha the interior angle at vertex A.
+            /// \param[out] beta  the interior angle at vertex B.
+            /// \param[out] gamma the interior angle at vertex C.
+            static void interiorAngles(const VectorType& a, const VectorType& b, const VectorType& c, Scalar& alpha,
+                                       Scalar& beta, Scalar& gamma)
+            {
+                VectorType Ta, Tb, Tc;
+                polarTriangle(a, b, c, Ta, Tb, Tc);
+                Ta /= Ta.norm();
+                Tb /= Tb.norm();
+                Tc /= Tc.norm();
+                if (Ta == VectorType::Zero() || Tb == VectorType::Zero() || Tc == VectorType::Zero())
+                    alpha = beta = gamma = Scalar(0.0);
+                else
+                {
+                    Scalar ca = std::max(Scalar(-1.0), std::min(Scalar(1.0), Tb.dot(Tc)));
+                    Scalar cb = std::max(Scalar(-1.0), std::min(Scalar(1.0), Tc.dot(Ta)));
+                    Scalar cc = std::max(Scalar(-1.0), std::min(Scalar(1.0), Ta.dot(Tb)));
+                    alpha     = acos(ca);
+                    beta      = acos(cb);
+                    gamma     = acos(cc);
+                }
+            }
 
-		/// \return the (unsigned) area of the spherical triangle (below 2pi).
-		static Scalar area(const VectorType& a, const VectorType& b, const VectorType& c) {
-			Scalar alpha, beta, gamma;
-			if (isDegenerate(a, b, c)) return Scalar(0.0);
-			interiorAngles(a, b, c, alpha, beta, gamma);
-			return ((fabs(alpha) < epsilon)
-				       || (fabs(beta) < epsilon)
-				       || (fabs(gamma) < epsilon))
-				       ? Scalar(0.0)
-				       : Scalar(2.0 * M_PI) - alpha - beta - gamma;
-		}
+            /// \return the (unsigned) area of the spherical triangle (below 2pi).
+            static Scalar area(const VectorType& a, const VectorType& b, const VectorType& c)
+            {
+                Scalar alpha, beta, gamma;
+                if (isDegenerate(a, b, c))
+                    return Scalar(0.0);
+                interiorAngles(a, b, c, alpha, beta, gamma);
+                return ((fabs(alpha) < epsilon) || (fabs(beta) < epsilon) || (fabs(gamma) < epsilon))
+                           ? Scalar(0.0)
+                           : Scalar(2.0 * M_PI) - alpha - beta - gamma;
+            }
 
-		/// \return the (signed) area of the spherical triangle (below 2pi).
-		static Scalar algebraicArea(const VectorType& a, const VectorType& b, const VectorType& c) {
-			Scalar S = area(a, b, c);
-			VectorType M = a + b + c;
-			VectorType X = (b - a).cross(c - a);
-			if (M.template lpNorm<1>() <= epsilon || X.template lpNorm<1>() <= epsilon) return 0.0;
-			return M.dot(X) < 0.0 ? -S : S;
-		}
-	};
+            /// \return the (signed) area of the spherical triangle (below 2pi).
+            static Scalar algebraicArea(const VectorType& a, const VectorType& b, const VectorType& c)
+            {
+                Scalar S     = area(a, b, c);
+                VectorType M = a + b + c;
+                VectorType X = (b - a).cross(c - a);
+                if (M.template lpNorm<1>() <= epsilon || X.template lpNorm<1>() <= epsilon)
+                    return 0.0;
+                return M.dot(X) < 0.0 ? -S : S;
+            }
+        };
 
+        // ---------------------- Main functions ----------------
+    public:
+        /// \name Functions for computing measures
+        /// \{
 
-	// ---------------------- Main functions ----------------
-public:
-	/// \name Functions for computing measures
-	/// \{
+        /// Computes mu0 measure (area) of triangle abc given an interpolated
+        /// corrected normal vector \a ua, \a \ub, \a uc.
+        /// \param a any point
+        /// \param b any point
+        /// \param c any point
+        /// \param ua the corrected normal vector at point a
+        /// \param ub the corrected normal vector at point b
+        /// \param uc the corrected normal vector at point c
+        /// \param unit_u when 'true' considers that interpolated
+        /// corrected normals should be made unitary, otherwise
+        /// interpolated corrected normals may have smaller norms.
+        /// \return the mu0-measure of triangle abc, i.e. its area.
+        static Scalar mu0InterpolatedU(const VectorType& a, const VectorType& b, const VectorType& c,
+                                       const VectorType& ua, const VectorType& ub, const VectorType& uc,
+                                       bool unit_u = false)
+        {
+            // MU0=1/2*det( uM, B-A, C-A )
+            //    =  1/2 < ( (u_A + u_B + u_C)/3.0 ) | (AB x AC ) >
+            VectorType uM = (ua + ub + uc) / 3.0;
+            if (unit_u)
+            {
+                auto uM_norm = uM.norm();
+                uM           = uM_norm == Scalar(0.0) ? uM : uM / uM_norm;
+            }
+            return Scalar(0.5) * ((b - a).cross(c - a)).dot(uM);
+        }
 
-	/// Computes mu0 measure (area) of triangle abc given an interpolated
-	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// \param a any point
-	/// \param b any point
-	/// \param c any point
-	/// \param ua the corrected normal vector at point a
-	/// \param ub the corrected normal vector at point b
-	/// \param uc the corrected normal vector at point c
-	/// \param unit_u when 'true' considers that interpolated
-	/// corrected normals should be made unitary, otherwise
-	/// interpolated corrected normals may have smaller norms.
-	/// \return the mu0-measure of triangle abc, i.e. its area.
-	static Scalar mu0InterpolatedU(
-		const VectorType& a,
-	    const VectorType& b,
-	    const VectorType& c,
-		const VectorType& ua,
-		const VectorType& ub,
-		const VectorType& uc,
-		bool unit_u = false
-	) {
-		// MU0=1/2*det( uM, B-A, C-A )
-		//    =  1/2 < ( (u_A + u_B + u_C)/3.0 ) | (AB x AC ) >
-		VectorType uM = (ua + ub + uc) / 3.0;
-		if (unit_u) {
-			auto uM_norm = uM.norm();
-			uM = uM_norm == Scalar(0.0) ? uM : uM / uM_norm;
-		}
-		return Scalar(0.5) * ((b - a).cross(c - a)).dot(uM);
-	}
+        /// Computes mu1 measure (mean curvature) of triangle abc given an interpolated
+        /// corrected normal vector \a ua, \a \ub, \a uc.
+        /// \param a any point
+        /// \param b any point
+        /// \param c any point
+        /// \param ua the corrected normal vector at point a
+        /// \param ub the corrected normal vector at point b
+        /// \param uc the corrected normal vector at point c
+        /// \param unit_u when 'true' considers that interpolated
+        /// corrected normals should be made unitary, otherwise
+        /// interpolated corrected normals may have smaller norms.
+        /// \return the mu1-measure of triangle abc, i.e. its mean curvature.
+        static Scalar mu1InterpolatedU(const VectorType& a, const VectorType& b, const VectorType& c,
+                                       const VectorType& ua, const VectorType& ub, const VectorType& uc,
+                                       bool unit_u = false)
+        {
+            // MU1=1/2( | uM u_C-u_B A | + | uM u_A-u_C B | + | uM u_B-u_A C |
+            VectorType uM = (ua + ub + uc) / Scalar(3.0);
+            if (unit_u)
+                uM /= uM.norm();
+            return Scalar(0.25) * (uM.cross(uc - ub).dot(a) + uM.cross(ua - uc).dot(b) + uM.cross(ub - ua).dot(c));
+        }
 
+        /// Computes mu2 measure (Gaussian curvature) of triangle abc given an interpolated
+        /// corrected normal vector \a ua, \a \ub, \a uc.
+        /// \param a any point
+        /// \param b any point
+        /// \param c any point
+        /// \param ua the corrected normal vector at point a
+        /// \param ub the corrected normal vector at point b
+        /// \param uc the corrected normal vector at point c
+        /// \param unit_u when 'true' considers that interpolated
+        /// corrected normals should be made unitary, otherwise
+        /// interpolated corrected normals may have smaller norms.
+        /// \return the mu2-measure of triangle abc, i.e. its Gaussian curvature.
+        static Scalar mu2InterpolatedU(const VectorType& a, const VectorType& b, const VectorType& c,
+                                       const VectorType& ua, const VectorType& ub, const VectorType& uc,
+                                       bool unit_u = false)
+        {
+            // Using non unitary interpolated normals give
+            // MU2=1/2*det( uA, uB, uC )
+            // When normals are unitary, it is the area of a spherical triangle.
+            if (unit_u)
+                return SphericalTriangle::algebraicArea(ua, ub, uc);
+            else
+                return Scalar(0.5) * (ua.cross(ub).dot(uc));
+        }
 
-	/// Computes mu1 measure (mean curvature) of triangle abc given an interpolated
-	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// \param a any point
-	/// \param b any point
-	/// \param c any point
-	/// \param ua the corrected normal vector at point a
-	/// \param ub the corrected normal vector at point b
-	/// \param uc the corrected normal vector at point c
-	/// \param unit_u when 'true' considers that interpolated
-	/// corrected normals should be made unitary, otherwise
-	/// interpolated corrected normals may have smaller norms.
-	/// \return the mu1-measure of triangle abc, i.e. its mean curvature.
-	static Scalar mu1InterpolatedU(
-		const VectorType& a,
-		const VectorType& b,
-		const VectorType& c,
-		const VectorType& ua,
-		const VectorType& ub,
-		const VectorType& uc,
-		bool unit_u = false
-    ) {
-		// MU1=1/2( | uM u_C-u_B A | + | uM u_A-u_C B | + | uM u_B-u_A C |
-		VectorType uM = (ua + ub + uc) / Scalar(3.0);
-		if (unit_u) uM /= uM.norm();
-		return Scalar(0.25) * (uM.cross(uc - ub).dot(a)
-			+ uM.cross(ua - uc).dot(b)
-			+ uM.cross(ub - ua).dot(c));
-	}
+        /// Computes muXY measure (anisotropic curvature) of triangle abc given an interpolated
+        /// corrected normal vector \a ua, \a \ub, \a uc.
+        /// \param a any point
+        /// \param b any point
+        /// \param c any point
+        /// \param ua the corrected normal vector at point a
+        /// \param ub the corrected normal vector at point b
+        /// \param uc the corrected normal vector at point c
+        /// \return the muXY-measure of triangle abc, i.e. its anisotropic curvature.
+        static MatrixType muXYInterpolatedU(const VectorType& a, const VectorType& b, const VectorType& c,
+                                            const VectorType& ua, const VectorType& ub, const VectorType& uc,
+                                            bool unit_u = false)
+        {
+            MatrixType T  = MatrixType::Zero();
+            VectorType uM = (ua + ub + uc) / 3.0;
+            if (unit_u)
+                uM /= uM.norm();
+            const VectorType uac = uc - ua;
+            const VectorType uab = ub - ua;
+            const VectorType ab  = b - a;
+            const VectorType ac  = c - a;
+            for (size_t i = 0; i < 3; ++i)
+            {
+                VectorType X = VectorType::Zero();
+                X(i)         = Scalar(1.0);
+                for (size_t j = 0; j < 3; ++j)
+                {
+                    // Since RealVector Y = RealVector::base( j, 1.0 );
+                    // < Y | uac > = uac[ j ]
+                    const Scalar tij = Scalar(0.5) * uM.dot(uac[j] * X.cross(ab) - uab[j] * X.cross(ac));
+                    T(i, j)          = tij;
+                }
+            }
+            return T;
+        }
 
+        /// \}
 
-	/// Computes mu2 measure (Gaussian curvature) of triangle abc given an interpolated
-	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// \param a any point
-	/// \param b any point
-	/// \param c any point
-	/// \param ua the corrected normal vector at point a
-	/// \param ub the corrected normal vector at point b
-	/// \param uc the corrected normal vector at point c
-	/// \param unit_u when 'true' considers that interpolated
-	/// corrected normals should be made unitary, otherwise
-	/// interpolated corrected normals may have smaller norms.
-	/// \return the mu2-measure of triangle abc, i.e. its Gaussian curvature.
-	static Scalar mu2InterpolatedU(
-		const VectorType& a,
-		const VectorType& b,
-		const VectorType& c,
-		const VectorType& ua,
-		const VectorType& ub,
-		const VectorType& uc,
-		bool unit_u = false
-	) {
-		// Using non unitary interpolated normals give
-		// MU2=1/2*det( uA, uB, uC )
-		// When normals are unitary, it is the area of a spherical triangle.
-		if (unit_u)
-			return SphericalTriangle::algebraicArea(ua, ub, uc);
-		else
-			return Scalar(0.5) * (ua.cross(ub).dot(uc));
-	}
+        // ---------------------- Helper functions ----------------
+    public:
+        /// \name Helper functions
+        /// \{
 
+        /// Computing principal curvatures k1 and k2 from tensor
+        /// \param tensor The muXY integrated tensor
+        /// \param area Area of the face
+        /// \param N the normal vector
+        /// \return a pair of principal directions.
+        static std::pair<VectorType, VectorType> curvDirFromTensor(const MatrixType& tensor, const Scalar area,
+                                                                   const VectorType& N)
+        {
+            auto Mt = tensor.transpose();
+            auto M  = tensor;
+            M += Mt;
+            M *= 0.5;
+            const Scalar coef_N = Scalar(1000.0) * area;
+            // Adding 1000 area n x n to anisotropic measure
+            for (int j = 0; j < 3; j++)
+                for (int k = 0; k < 3; k++)
+                    M(j, k) += coef_N * N[j] * N[k];
 
-	/// Computes muXY measure (anisotropic curvature) of triangle abc given an interpolated
-	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// \param a any point
-	/// \param b any point
-	/// \param c any point
-	/// \param ua the corrected normal vector at point a
-	/// \param ub the corrected normal vector at point b
-	/// \param uc the corrected normal vector at point c
-	/// \return the muXY-measure of triangle abc, i.e. its anisotropic curvature.
-	static MatrixType muXYInterpolatedU(
-		const VectorType& a,
-		const VectorType& b,
-		const VectorType& c,
-		const VectorType& ua,
-		const VectorType& ub,
-		const VectorType& uc,
-		bool unit_u = false
-	) {
-		MatrixType T = MatrixType::Zero();
-		VectorType uM = (ua + ub + uc) / 3.0;
-		if (unit_u) uM /= uM.norm();
-		const VectorType uac = uc - ua;
-		const VectorType uab = ub - ua;
-		const VectorType ab = b - a;
-		const VectorType ac = c - a;
-		for (size_t i = 0; i < 3; ++i) {
-			VectorType X = VectorType::Zero();
-			X(i) = Scalar(1.0);
-			for (size_t j = 0; j < 3; ++j) {
-				// Since RealVector Y = RealVector::base( j, 1.0 );
-				// < Y | uac > = uac[ j ]
-				const Scalar tij =
-					Scalar(0.5) * uM.dot(uac[j] * X.cross(ab)
-						- uab[j] * X.cross(ac));
-				T(i, j) = tij;
-			}
-		}
-		return T;
-	}
+            Eigen::SelfAdjointEigenSolver<MatrixType> eigensolver(M);
+            if (eigensolver.info() != Eigen::Success)
+                abort();
 
-	/// \}
+            // SelfAdjointEigenSolver returns sorted eigenvalues, no
+            // need to reorder the eigenvectors.
+            assert(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
+            assert(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
+            VectorType v1 = eigensolver.eigenvectors().col(1);
+            VectorType v2 = eigensolver.eigenvectors().col(0);
+            return std::pair<VectorType, VectorType>(v1, v2);
+        }
 
-	// ---------------------- Helper functions ----------------
-public:
-	/// \name Helper functions
-	/// \{
+        /// Computing principal curvatures k1 and k2 from tensor
+        /// \param tensor The muXY integrated tensor
+        /// \param area Area of the face
+        /// \param N the normal vector
+        /// \return a pair of principal directions.
+        static std::tuple<Scalar, Scalar, VectorType, VectorType> curvaturesFromTensor(const MatrixType& tensor,
+                                                                                       const Scalar area,
+                                                                                       const VectorType& N)
+        {
+            auto Mt = tensor.transpose();
+            auto M  = tensor;
+            M += Mt;
+            M *= 0.5;
+            const Scalar coef_N = Scalar(1000.0) * area;
+            // Adding 1000 area n x n to anisotropic measure
+            for (int j = 0; j < 3; j++)
+                for (int k = 0; k < 3; k++)
+                    M(j, k) += coef_N * N[j] * N[k];
 
-	/// Computing principal curvatures k1 and k2 from tensor
-	/// \param tensor The muXY integrated tensor
-	/// \param area Area of the face
-	/// \param N the normal vector
-	/// \return a pair of principal directions.
-	static std::pair<VectorType, VectorType> curvDirFromTensor(
-		const MatrixType& tensor,
-		const Scalar area,
-		const VectorType& N
-	) {
-		auto Mt = tensor.transpose();
-		auto M = tensor;
-		M += Mt;
-		M *= 0.5;
-		const Scalar coef_N = Scalar(1000.0) * area;
-		// Adding 1000 area n x n to anisotropic measure
-		for (int j = 0; j < 3; j++)
-			for (int k = 0; k < 3; k++)
-				M(j, k) += coef_N * N[j] * N[k];
+            Eigen::SelfAdjointEigenSolver<MatrixType> eigensolver(M);
+            if (eigensolver.info() == Eigen::Success)
+            {
+                // SelfAdjointEigenSolver returns sorted eigenvalues, no
+                // need to reorder the eigenvectors.
+                assert(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
+                assert(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
+                VectorType v1 = eigensolver.eigenvectors().col(0);
+                VectorType v2 = eigensolver.eigenvectors().col(1);
+                return std::make_tuple(-eigensolver.eigenvalues()(0), -eigensolver.eigenvalues()(1), v1, v2);
+            }
+            else
+            {
+                std::cerr << "Incorrect diagonalization for tensor " << M << std::endl;
+                VectorType v1, v2;
+                return std::make_tuple(Scalar(0.0), Scalar(0.0), v1, v2);
+            }
+        }
 
-		Eigen::SelfAdjointEigenSolver<MatrixType> eigensolver(M);
-		if (eigensolver.info() != Eigen::Success) abort();
+        /// \}
+    }; // struct CNCEigen
 
-		//SelfAdjointEigenSolver returns sorted eigenvalues, no
-		//need to reorder the eigenvectors.
-		assert(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
-		assert(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
-		VectorType v1 = eigensolver.eigenvectors().col(1);
-		VectorType v2 = eigensolver.eigenvectors().col(0);
-		return std::pair<VectorType, VectorType>(v1, v2);
-	}
-
-	/// Computing principal curvatures k1 and k2 from tensor
-	/// \param tensor The muXY integrated tensor
-	/// \param area Area of the face
-	/// \param N the normal vector
-	/// \return a pair of principal directions.
-	static std::tuple<Scalar, Scalar, VectorType, VectorType> curvaturesFromTensor(
-		const MatrixType& tensor,
-		const Scalar area,
-		const VectorType& N
-	) {
-		auto Mt = tensor.transpose();
-		auto M = tensor;
-		M += Mt;
-		M *= 0.5;
-		const Scalar coef_N = Scalar(1000.0) * area;
-		// Adding 1000 area n x n to anisotropic measure
-		for (int j = 0; j < 3; j++)
-			for (int k = 0; k < 3; k++)
-				M(j, k) += coef_N * N[j] * N[k];
-
-		Eigen::SelfAdjointEigenSolver<MatrixType> eigensolver(M);
-		if (eigensolver.info() == Eigen::Success) {
-			// SelfAdjointEigenSolver returns sorted eigenvalues, no
-			// need to reorder the eigenvectors.
-			assert(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
-			assert(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
-			VectorType v1 = eigensolver.eigenvectors().col(0);
-			VectorType v2 = eigensolver.eigenvectors().col(1);
-			return std::make_tuple(-eigensolver.eigenvalues()(0),
-			                       -eigensolver.eigenvalues()(1),
-			                       v1, v2);
-		} else {
-			std::cerr << "Incorrect diagonalization for tensor " << M << std::endl;
-			VectorType v1, v2;
-			return std::make_tuple(Scalar(0.0), Scalar(0.0), v1, v2);
-		}
-	}
-
-	/// \}
-}; // struct CNCEigen
-
-}
+} // namespace Ponca::internal

--- a/Ponca/src/Fitting/cncFormulaEigen.h
+++ b/Ponca/src/Fitting/cncFormulaEigen.h
@@ -34,19 +34,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /**
- * @file cncFormulaEigen.h
- * @brief Adapted version of CorrectedNormalCurrentFormulaEigen.h for Ponca.
+ * \file cncFormulaEigen.h
+ * \brief Adapted version of CorrectedNormalCurrentFormulaEigen.h for Ponca.
  *
- * @details
+ * \details
  * ## Original file :
  * https://github.com/JacquesOlivierLachaud/PointCloudCurvCNC/blob/main/CorrectedNormalCurrentFormulaEigen.h
  *
- * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr)
+ * \author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr)
  * Laboratory of Mathematics (CNRS, UMR 5127), University of Savoie, France
- * @author David Coeurjolly (\c david.coeurjolly@liris.cnrs.fr)
+ * \author David Coeurjolly (\c david.coeurjolly@liris.cnrs.fr)
  * LIRIS (CNRS, UMR 5205), CNRS, France
  *
- * @date 2022/06/05
+ * \date 2022/06/05
  *
  * ## Modifications made :
  *
@@ -54,9 +54,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * - Moved CNCEigen struct to Ponca::internal namespace
  * - Adapted CNCEigen to use the Ponca DataPoint Types
  *
- * @author Florian Auberval (\c florian.auberval@irit.fr)
+ * \author Florian Auberval (\c florian.auberval@irit.fr)
  *
- * @date 2025/11/19
+ * \date 2025/11/19
  */
 
 #pragma once
@@ -66,7 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Ponca::internal {
 
 /**
- * @brief This class contains some stand-alone CorrectedNormalCurrent formulas for triangles,
+ * \brief This class contains some stand-alone CorrectedNormalCurrent formulas for triangles,
  * using eigen as linear algebra backend.
  */
 template<typename DataPoint>
@@ -92,7 +92,7 @@ struct CNCEigen {
 			return (fabs(d[m] - d[(m + 1) % 3] - d[(m + 2) % 3]) < epsilon);
 		}
 
-		/// @return the polar triangle associated with this triangle.
+		/// \return the polar triangle associated with this triangle.
 		static void polarTriangle(
 			const VectorType& a, const VectorType& b, const VectorType& c,
 			VectorType& Ap     , VectorType& Bp     , VectorType& Cp
@@ -107,9 +107,9 @@ struct CNCEigen {
 		}
 
 		/// Returns the interior angles of the spherical triangle ABC.
-		/// @param[out] alpha the interior angle at vertex A.
-		/// @param[out] beta  the interior angle at vertex B.
-		/// @param[out] gamma the interior angle at vertex C.
+		/// \param[out] alpha the interior angle at vertex A.
+		/// \param[out] beta  the interior angle at vertex B.
+		/// \param[out] gamma the interior angle at vertex C.
 		static void interiorAngles(
 			const VectorType& a, const VectorType& b, const VectorType& c,
 		    Scalar& alpha      , Scalar& beta       , Scalar& gamma
@@ -132,7 +132,7 @@ struct CNCEigen {
 			}
 		}
 
-		/// @return the (unsigned) area of the spherical triangle (below 2pi).
+		/// \return the (unsigned) area of the spherical triangle (below 2pi).
 		static Scalar area(const VectorType& a, const VectorType& b, const VectorType& c) {
 			Scalar alpha, beta, gamma;
 			if (isDegenerate(a, b, c)) return Scalar(0.0);
@@ -144,7 +144,7 @@ struct CNCEigen {
 				       : Scalar(2.0 * M_PI) - alpha - beta - gamma;
 		}
 
-		/// @return the (signed) area of the spherical triangle (below 2pi).
+		/// \return the (signed) area of the spherical triangle (below 2pi).
 		static Scalar algebraicArea(const VectorType& a, const VectorType& b, const VectorType& c) {
 			Scalar S = area(a, b, c);
 			VectorType M = a + b + c;
@@ -157,21 +157,21 @@ struct CNCEigen {
 
 	// ---------------------- Main functions ----------------
 public:
-	/// @name Functions for computing measures
-	/// @{
+	/// \name Functions for computing measures
+	/// \{
 
 	/// Computes mu0 measure (area) of triangle abc given an interpolated
 	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// @param a any point
-	/// @param b any point
-	/// @param c any point
-	/// @param ua the corrected normal vector at point a
-	/// @param ub the corrected normal vector at point b
-	/// @param uc the corrected normal vector at point c
-	/// @param unit_u when 'true' considers that interpolated
+	/// \param a any point
+	/// \param b any point
+	/// \param c any point
+	/// \param ua the corrected normal vector at point a
+	/// \param ub the corrected normal vector at point b
+	/// \param uc the corrected normal vector at point c
+	/// \param unit_u when 'true' considers that interpolated
 	/// corrected normals should be made unitary, otherwise
 	/// interpolated corrected normals may have smaller norms.
-	/// @return the mu0-measure of triangle abc, i.e. its area.
+	/// \return the mu0-measure of triangle abc, i.e. its area.
 	static Scalar mu0InterpolatedU(
 		const VectorType& a,
 	    const VectorType& b,
@@ -194,16 +194,16 @@ public:
 
 	/// Computes mu1 measure (mean curvature) of triangle abc given an interpolated
 	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// @param a any point
-	/// @param b any point
-	/// @param c any point
-	/// @param ua the corrected normal vector at point a
-	/// @param ub the corrected normal vector at point b
-	/// @param uc the corrected normal vector at point c
-	/// @param unit_u when 'true' considers that interpolated
+	/// \param a any point
+	/// \param b any point
+	/// \param c any point
+	/// \param ua the corrected normal vector at point a
+	/// \param ub the corrected normal vector at point b
+	/// \param uc the corrected normal vector at point c
+	/// \param unit_u when 'true' considers that interpolated
 	/// corrected normals should be made unitary, otherwise
 	/// interpolated corrected normals may have smaller norms.
-	/// @return the mu1-measure of triangle abc, i.e. its mean curvature.
+	/// \return the mu1-measure of triangle abc, i.e. its mean curvature.
 	static Scalar mu1InterpolatedU(
 		const VectorType& a,
 		const VectorType& b,
@@ -224,16 +224,16 @@ public:
 
 	/// Computes mu2 measure (Gaussian curvature) of triangle abc given an interpolated
 	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// @param a any point
-	/// @param b any point
-	/// @param c any point
-	/// @param ua the corrected normal vector at point a
-	/// @param ub the corrected normal vector at point b
-	/// @param uc the corrected normal vector at point c
-	/// @param unit_u when 'true' considers that interpolated
+	/// \param a any point
+	/// \param b any point
+	/// \param c any point
+	/// \param ua the corrected normal vector at point a
+	/// \param ub the corrected normal vector at point b
+	/// \param uc the corrected normal vector at point c
+	/// \param unit_u when 'true' considers that interpolated
 	/// corrected normals should be made unitary, otherwise
 	/// interpolated corrected normals may have smaller norms.
-	/// @return the mu2-measure of triangle abc, i.e. its Gaussian curvature.
+	/// \return the mu2-measure of triangle abc, i.e. its Gaussian curvature.
 	static Scalar mu2InterpolatedU(
 		const VectorType& a,
 		const VectorType& b,
@@ -255,13 +255,13 @@ public:
 
 	/// Computes muXY measure (anisotropic curvature) of triangle abc given an interpolated
 	/// corrected normal vector \a ua, \a \ub, \a uc.
-	/// @param a any point
-	/// @param b any point
-	/// @param c any point
-	/// @param ua the corrected normal vector at point a
-	/// @param ub the corrected normal vector at point b
-	/// @param uc the corrected normal vector at point c
-	/// @return the muXY-measure of triangle abc, i.e. its anisotropic curvature.
+	/// \param a any point
+	/// \param b any point
+	/// \param c any point
+	/// \param ua the corrected normal vector at point a
+	/// \param ub the corrected normal vector at point b
+	/// \param uc the corrected normal vector at point c
+	/// \return the muXY-measure of triangle abc, i.e. its anisotropic curvature.
 	static MatrixType muXYInterpolatedU(
 		const VectorType& a,
 		const VectorType& b,
@@ -293,18 +293,18 @@ public:
 		return T;
 	}
 
-	/// @}
+	/// \}
 
 	// ---------------------- Helper functions ----------------
 public:
-	/// @name Helper functions
-	/// @{
+	/// \name Helper functions
+	/// \{
 
 	/// Computing principal curvatures k1 and k2 from tensor
-	/// @param tensor The muXY integrated tensor
-	/// @param area Area of the face
-	/// @param N the normal vector
-	/// @return a pair of principal directions.
+	/// \param tensor The muXY integrated tensor
+	/// \param area Area of the face
+	/// \param N the normal vector
+	/// \return a pair of principal directions.
 	static std::pair<VectorType, VectorType> curvDirFromTensor(
 		const MatrixType& tensor,
 		const Scalar area,
@@ -333,10 +333,10 @@ public:
 	}
 
 	/// Computing principal curvatures k1 and k2 from tensor
-	/// @param tensor The muXY integrated tensor
-	/// @param area Area of the face
-	/// @param N the normal vector
-	/// @return a pair of principal directions.
+	/// \param tensor The muXY integrated tensor
+	/// \param area Area of the face
+	/// \param N the normal vector
+	/// \return a pair of principal directions.
 	static std::tuple<Scalar, Scalar, VectorType, VectorType> curvaturesFromTensor(
 		const MatrixType& tensor,
 		const Scalar area,
@@ -370,7 +370,7 @@ public:
 		}
 	}
 
-	/// @}
+	/// \}
 }; // struct CNCEigen
 
 }

--- a/Ponca/src/Fitting/compute.h
+++ b/Ponca/src/Fitting/compute.h
@@ -9,22 +9,25 @@
 #include "defines.h"
 #include PONCA_MULTIARCH_INCLUDE_STD(iterator)
 
-namespace Ponca{
+namespace Ponca
+{
     /*!
-      \brief ComputeObject is a virtual object that represents an algorithm which can be used with the compute functions.
+      \brief ComputeObject is a virtual object that represents an algorithm which can be used with the compute
+      functions.
 
       The compute(begin, end) and computeWithIds(ids, points) methods must be implemented by the inheriting class.
       \note The compute(container) that is defined in this structure can be reused in the inheriting class by adding
       "using ComputeObject<Self>::compute;" to make it accessible
  */
     template <typename Derived>
-    struct ComputeObject {
+    struct ComputeObject
+    {
     protected:
         /// \brief Retrieve the top layer object
         /// Returns a reference to the derived class so that we can use its overwritten methods
         PONCA_MULTIARCH Derived& derived() { return static_cast<Derived&>(*this); }
-    public:
 
+    public:
 #ifdef PONCA_CPU_ARCH
         /*! \brief Convenience function for STL-like container
          *
@@ -33,7 +36,8 @@ namespace Ponca{
          * \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
          */
         template <typename Container>
-        FIT_RESULT compute(const Container& c) {
+        FIT_RESULT compute(const Container& c)
+        {
             return derived().compute(std::begin(c), std::end(c));
         }
 #endif
@@ -43,7 +47,8 @@ namespace Ponca{
             \tparam IteratorEnd   The end of the iterator (std::end(iterator)
         */
         template <typename IteratorBegin, typename IteratorEnd>
-        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& /*begin*/, const IteratorEnd& /*end*/) {
+        PONCA_MULTIARCH inline FIT_RESULT compute(const IteratorBegin& /*begin*/, const IteratorEnd& /*end*/)
+        {
             return UNDEFINED;
         };
 
@@ -53,10 +58,11 @@ namespace Ponca{
             \see #compute(const IteratorBegin& begin, const IteratorEnd& end)
         */
         template <typename IndexRange, typename PointContainer>
-        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/) {
+        PONCA_MULTIARCH inline FIT_RESULT computeWithIds(IndexRange /*ids*/, const PointContainer& /*points*/)
+        {
             return UNDEFINED;
         };
     }; // struct ComputeObject
 
-}
+} // namespace Ponca
 

--- a/Ponca/src/Fitting/covarianceFit.h
+++ b/Ponca/src/Fitting/covarianceFit.h
@@ -15,44 +15,47 @@
 namespace Ponca
 {
 
-/*!
-   \brief Procedure that compute and decompose the covariance matrix of the neighbors positions in \f$3d\f$.
+    /*!
+       \brief Procedure that compute and decompose the covariance matrix of the neighbors positions in \f$3d\f$.
 
-   This process is commonly used for plane fitting and local variance analysis. It is often called Principal
-   Component Analysis (PCA) of the neighborhood, and used in Geometry Processing and Computer Vision.
+       This process is commonly used for plane fitting and local variance analysis. It is often called Principal
+       Component Analysis (PCA) of the neighborhood, and used in Geometry Processing and Computer Vision.
 
-   \inherit Concept::FittingProcedureConcept
-   \see CovariancePlaneFit which use a similar approach for Plane estimation
+       \inherit Concept::FittingProcedureConcept
+       \see CovariancePlaneFit which use a similar approach for Plane estimation
 
-   ### Computation details
-   Standard PCA algorithm involves a two-steps process where the barycenter \f$\mathbf{b}\f$ is first computed,
-   and then the covariance matrix \f$\text{C}\f$ (in the following, the weights are ignored for clarity but without
-   loss of generality):
-   \f{align}
-   \mathbf{b} &= \frac{1}{n}\sum_i\mathbf{p}_i \\
-   \text{C}   &= \frac{1}{n}\sum_i(\mathbf{p}_i-\mathbf{b})(\mathbf{p}_i-\mathbf{b})^T
-   \f}
-   This class implements a single-pass version, where the first formulation is re-expressed as follows:
-   \f{align}
-   \text{C} &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T - \mathbf{b}\mathbf{p}_i^T - \mathbf{p}_i\mathbf{b}^T + \mathbf{b}\mathbf{b}^T) \\
-            &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) -  \frac{1}{n}\sum_i(\mathbf{b}\mathbf{p}_i^T)  -  \frac{1}{n}\sum_i(\mathbf{p}_i\mathbf{b}^T)  +  \frac{1}{n}\sum_i (\mathbf{b}\mathbf{b}^T) \\
-            &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) - \mathbf{b}\frac{1}{n}\sum_i(\mathbf{p}_i^T) - \frac{1}{n}\sum_i(\mathbf{p}_i)\mathbf{b}^T  + \frac{1}{n}\sum_i(1) \mathbf{b}\mathbf{b}^T \\
-            &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) - \mathbf{b}\mathbf{b}^T - \mathbf{b}\mathbf{b}^T + \mathbf{b}\mathbf{b}^T \f}
-   Leading to a single pass where \f$\text{C}\f$ is express by subtracting two terms that can be computed independently
-   in one run:
-   \f[ \text{C} = \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) - \mathbf{b}\mathbf{b}^T \f]
+       ### Computation details
+       Standard PCA algorithm involves a two-steps process where the barycenter \f$\mathbf{b}\f$ is first computed,
+       and then the covariance matrix \f$\text{C}\f$ (in the following, the weights are ignored for clarity but without
+       loss of generality):
+       \f{align}
+       \mathbf{b} &= \frac{1}{n}\sum_i\mathbf{p}_i \\
+       \text{C}   &= \frac{1}{n}\sum_i(\mathbf{p}_i-\mathbf{b})(\mathbf{p}_i-\mathbf{b})^T
+       \f}
+       This class implements a single-pass version, where the first formulation is re-expressed as follows:
+       \f{align}
+       \text{C} &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T - \mathbf{b}\mathbf{p}_i^T - \mathbf{p}_i\mathbf{b}^T +
+       \mathbf{b}\mathbf{b}^T) \\
+                &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) -  \frac{1}{n}\sum_i(\mathbf{b}\mathbf{p}_i^T)  -
+       \frac{1}{n}\sum_i(\mathbf{p}_i\mathbf{b}^T)  +  \frac{1}{n}\sum_i (\mathbf{b}\mathbf{b}^T) \\
+                &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) - \mathbf{b}\frac{1}{n}\sum_i(\mathbf{p}_i^T) -
+       \frac{1}{n}\sum_i(\mathbf{p}_i)\mathbf{b}^T  + \frac{1}{n}\sum_i(1) \mathbf{b}\mathbf{b}^T \\
+                &= \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) - \mathbf{b}\mathbf{b}^T - \mathbf{b}\mathbf{b}^T +
+       \mathbf{b}\mathbf{b}^T \f} Leading to a single pass where \f$\text{C}\f$ is express by subtracting two terms that
+       can be computed independently in one run:
+       \f[ \text{C} = \frac{1}{n}\sum_i (\mathbf{p}_i\mathbf{p}_i^T) - \mathbf{b}\mathbf{b}^T \f]
 
-   All the computed features are defined for the 3 eigenvalues \f$ 0 < \lambda_0
-   \leq \lambda_1 \leq \lambda_2 \f$.
+       All the computed features are defined for the 3 eigenvalues \f$ 0 < \lambda_0
+       \leq \lambda_1 \leq \lambda_2 \f$.
 
 
-   \warning This class is valid only in 3D.
- */
+       \warning This class is valid only in 3D.
+     */
 
-    template < class DataPoint, class _NFilter, typename T>
+    template <class DataPoint, class _NFilter, typename T>
     class CovarianceFitBase : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
     protected:
         enum
@@ -68,15 +71,16 @@ namespace Ponca
 
     protected:
         // computation data
-        MatrixType m_cov {MatrixType::Zero()};     /*!< \brief Covariance matrix */
-        Solver m_solver;  /*!<\brief Solver used to analyse the covariance matrix */
+        MatrixType m_cov{MatrixType::Zero()}; /*!< \brief Covariance matrix */
+        Solver m_solver;                      /*!<\brief Solver used to analyse the covariance matrix */
 
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS(CovarianceFitBase,covarianceFit)
+        PONCA_EXPLICIT_CAST_OPERATORS(CovarianceFitBase, covarianceFit)
         PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
 
         /*! \brief Implements \cite Pauly:2002:PSSimplification surface variation.
-            It computes the ratio \f$ d \frac{\lambda_0}{\sum_i \lambda_i} \f$ with \c d the dimension of the ambient space.
+            It computes the ratio \f$ d \frac{\lambda_0}{\sum_i \lambda_i} \f$ with \c d the dimension of the ambient
+           space.
             \return 0 for invalid fits
         */
         PONCA_MULTIARCH [[nodiscard]] inline Scalar surfaceVariation() const;
@@ -112,52 +116,50 @@ namespace Ponca
         PONCA_MULTIARCH [[nodiscard]] inline Scalar eigenentropy() const;
 
         /*! \brief The minimum eigenvalue \f$ \lambda_0 \f$.
-        */
+         */
         PONCA_MULTIARCH [[nodiscard]] inline Scalar lambda_0() const;
 
         /*! \brief The second eigenvalue \f$ \lambda_1 \f$.
-        */
+         */
         PONCA_MULTIARCH [[nodiscard]] inline Scalar lambda_1() const;
 
         /*! \brief The maximum eigenvalue \f$ \lambda_2 \f$.
-        */
+         */
         PONCA_MULTIARCH [[nodiscard]] inline Scalar lambda_2() const;
 
         /*! \brief Reading access to the Solver used to analyse the covariance matrix */
         PONCA_MULTIARCH [[nodiscard]] inline const Solver& solver() const { return m_solver; }
     };
 
-
-/*!
-    \brief Internal generic class computing the derivatives of covariance matrix
-    computed by CovarianceFitBase
-    \inherit Concept::FittingExtensionConcept
-*/
-    template < class DataPoint, class _NFilter, int DiffType, typename T>
+    /*!
+        \brief Internal generic class computing the derivatives of covariance matrix
+        computed by CovarianceFitBase
+        \inherit Concept::FittingExtensionConcept
+    */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     class CovarianceFitDer : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_MATRIX_TYPE
-    PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_MATRIX_TYPE
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
 
     protected:
         enum
         {
-            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE &&
-                    Base::PROVIDES_MEAN_POSITION_DERIVATIVE &&
+            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE && Base::PROVIDES_MEAN_POSITION_DERIVATIVE &&
                     Base::PROVIDES_POSITION_COVARIANCE,
             PROVIDES_POSITION_COVARIANCE_DERIVATIVE
         };
 
     protected:
         /// Computation data: derivatives of the covariance matrix
-        MatrixType  m_dCov[Base::NbDerivatives];
+        MatrixType m_dCov[Base::NbDerivatives];
 
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS_DER(CovarianceFitDer,covarianceFitDer)
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(CovarianceFitDer, covarianceFitDer)
         PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
-    }; //class CovarianceFitDer
+    }; // class CovarianceFitDer
 
 #include "covarianceFit.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/covarianceFit.hpp
+++ b/Ponca/src/Fitting/covarianceFit.hpp
@@ -7,144 +7,128 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
-template < class DataPoint, class _NFilter, typename T>
-void
-CovarianceFitBase<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void CovarianceFitBase<DataPoint, _NFilter, T>::init()
 {
     Base::init();
     m_cov.setZero();
 }
 
-template < class DataPoint, class _NFilter, typename T>
-bool
-CovarianceFitBase<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                              const VectorType &localQ,
-                                                              const DataPoint &attributes)
+template <class DataPoint, class _NFilter, typename T>
+bool CovarianceFitBase<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                 const DataPoint& attributes)
 {
-    if( Base::addLocalNeighbor(w, localQ, attributes) ) {
-        m_cov  += w * localQ * localQ.transpose();
+    if (Base::addLocalNeighbor(w, localQ, attributes))
+    {
+        m_cov += w * localQ * localQ.transpose();
         return true;
     }
     return false;
 }
 
-
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-CovarianceFitBase<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT CovarianceFitBase<DataPoint, _NFilter, T>::finalize()
 {
     // handle specific configurations
-    if(Base::finalize() != STABLE) 
+    if (Base::finalize() != STABLE)
         return Base::m_eCurrentState;
     // With less than Dim neighbors the fitting is undefined
-    if(Base::getNumNeighbors() < DataPoint::Dim)
+    if (Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
 
     // Center the covariance on the centroid
     auto centroid = Base::barycenterLocal();
-    m_cov = m_cov/Base::getWeightSum() - centroid * centroid.transpose();
+    m_cov         = m_cov / Base::getWeightSum() - centroid * centroid.transpose();
 
 #ifdef __CUDACC__
     m_solver.computeDirect(m_cov);
 #else
     m_solver.compute(m_cov);
 #endif
-    Base::m_eCurrentState = ( m_solver.info() == Eigen::Success ? STABLE : UNDEFINED );
+    Base::m_eCurrentState = (m_solver.info() == Eigen::Success ? STABLE : UNDEFINED);
 
     return Base::m_eCurrentState;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-typename CovarianceFitBase<DataPoint, _NFilter, T>::Scalar
-CovarianceFitBase<DataPoint, _NFilter, T>::surfaceVariation () const
+template <class DataPoint, class _NFilter, typename T>
+typename CovarianceFitBase<DataPoint, _NFilter, T>::Scalar CovarianceFitBase<DataPoint, _NFilter, T>::surfaceVariation()
+    const
 {
     return m_solver.eigenvalues()(0) / m_solver.eigenvalues().mean();
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::planarity() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::planarity()
+    const
 {
-    return (m_solver.eigenvalues()(1) - m_solver.eigenvalues()(0)) /
-          m_solver.eigenvalues()(2);
+    return (m_solver.eigenvalues()(1) - m_solver.eigenvalues()(0)) / m_solver.eigenvalues()(2);
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::linearity() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::linearity()
+    const
 {
-    return (m_solver.eigenvalues()(2) - m_solver.eigenvalues()(1)) /
-          m_solver.eigenvalues()(2);
+    return (m_solver.eigenvalues()(2) - m_solver.eigenvalues()(1)) / m_solver.eigenvalues()(2);
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::sphericity() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::sphericity()
+    const
 {
     return (m_solver.eigenvalues()(0)) / m_solver.eigenvalues()(2);
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::anisotropy() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::anisotropy()
+    const
 {
-    return (m_solver.eigenvalues()(2) - m_solver.eigenvalues()(0)) /
-          m_solver.eigenvalues()(2);
+    return (m_solver.eigenvalues()(2) - m_solver.eigenvalues()(0)) / m_solver.eigenvalues()(2);
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::eigenentropy() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::eigenentropy()
+    const
 {
     return -(m_solver.eigenvalues()(0) * log(m_solver.eigenvalues()(0)) +
-            m_solver.eigenvalues()(1) * log(m_solver.eigenvalues()(1)) +
-            m_solver.eigenvalues()(2) * log(m_solver.eigenvalues()(2)));
+             m_solver.eigenvalues()(1) * log(m_solver.eigenvalues()(1)) +
+             m_solver.eigenvalues()(2) * log(m_solver.eigenvalues()(2)));
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::lambda_0() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::lambda_0() const
 {
     return m_solver.eigenvalues()(0);
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::lambda_1() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::lambda_1() const
 {
     return m_solver.eigenvalues()(1);
 }
 
 template <class DataPoint, class _WFunctor, typename T>
-typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar
-CovarianceFitBase<DataPoint, _WFunctor, T>::lambda_2() const
+typename CovarianceFitBase<DataPoint, _WFunctor, T>::Scalar CovarianceFitBase<DataPoint, _WFunctor, T>::lambda_2() const
 {
     return m_solver.eigenvalues()(2);
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-void
-CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::init()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+void CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::init()
 {
     Base::init();
 
-    for(int k=0; k<Base::NbDerivatives; ++k)
+    for (int k = 0; k < Base::NbDerivatives; ++k)
         m_dCov[k].setZero();
 }
 
-
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
-                                                                      const VectorType &localQ,
-                                                                      const DataPoint &attributes,
-                                                                      ScalarArray &dw)
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+bool CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                          const DataPoint& attributes, ScalarArray& dw)
 {
-    if( Base::addLocalNeighbor(w, localQ, attributes, dw) ) {
-        for(int k=0; k<Base::NbDerivatives; ++k)
-            m_dCov[k]  += dw[k] * localQ * localQ.transpose();
+    if (Base::addLocalNeighbor(w, localQ, attributes, dw))
+    {
+        for (int k = 0; k < Base::NbDerivatives; ++k)
+            m_dCov[k] += dw[k] * localQ * localQ.transpose();
 
         return true;
     }
@@ -152,10 +136,8 @@ CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
     return false;
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-FIT_RESULT
-CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::finalize()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+FIT_RESULT CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::finalize()
 {
     PONCA_MULTIARCH_STD_MATH(sqrt);
 
@@ -163,16 +145,14 @@ CovarianceFitDer<DataPoint, _NFilter, DiffType, T>::finalize()
     // Test if base finalize end on a viable case (stable / unstable)
     if (this->isReady())
     {
-        VectorType cog = Base::barycenterLocal();
+        VectorType cog   = Base::barycenterLocal();
         MatrixType cogSq = cog * cog.transpose();
         // \fixme Better use eigen here
-        for(int k=0; k<Base::NbDerivatives; ++k)
+        for (int k = 0; k < Base::NbDerivatives; ++k)
         {
             // Finalize the computation of dCov.
-            m_dCov[k] = m_dCov[k]
-                        - cog * Base::m_dSumP.col(k).transpose()
-                        - Base::m_dSumP.col(k) * cog.transpose()
-                        + Base::m_dSumW[k] * cogSq;
+            m_dCov[k] = m_dCov[k] - cog * Base::m_dSumP.col(k).transpose() - Base::m_dSumP.col(k) * cog.transpose() +
+                        Base::m_dSumW[k] * cogSq;
         }
     }
 

--- a/Ponca/src/Fitting/covarianceLineFit.h
+++ b/Ponca/src/Fitting/covarianceLineFit.h
@@ -17,54 +17,54 @@
 namespace Ponca
 {
 
-/*!
-   \brief Line fitting procedure that minimize the orthogonal distance
-   between the samples and the fitted primitive.
+    /*!
+       \brief Line fitting procedure that minimize the orthogonal distance
+       between the samples and the fitted primitive.
 
-   \inherit Concept::FittingProcedureConcept
-   \see Line
-   \see CovariancePlaneFit which use a similar approach for Plane estimation
+       \inherit Concept::FittingProcedureConcept
+       \see Line
+       \see CovariancePlaneFit which use a similar approach for Plane estimation
 
-   \todo Add equations
+       \todo Add equations
 
-   \warning This class is valid only in 3D.
- */
+       \warning This class is valid only in 3D.
+     */
 
-template < class DataPoint, class _NFilter, typename T>
-class CovarianceLineFitImpl : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_MATRIX_TYPE
-
-protected:
-    enum
+    template <class DataPoint, class _NFilter, typename T>
+    class CovarianceLineFitImpl : public T
     {
-        check = Base::PROVIDES_LINE &&
-                Base::PROVIDES_POSITION_COVARIANCE,
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_MATRIX_TYPE
+
+    protected:
+        enum
+        {
+            check = Base::PROVIDES_LINE && Base::PROVIDES_POSITION_COVARIANCE,
+        };
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(CovarianceLineFitImpl, covarianceLineFit)
+
+        PONCA_FITTING_APIDOC_FINALIZE
+        PONCA_MULTIARCH inline FIT_RESULT finalize()
+        {
+            static const int smallestEigenValue = DataPoint::Dim - 1;
+            if (Base::finalize() == STABLE)
+            {
+                if (Base::line().isValid())
+                    Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
+                Base::setLine(Base::barycenterLocal(),
+                              Base::m_solver.eigenvectors().col(smallestEigenValue).normalized());
+            }
+            return Base::m_eCurrentState;
+        }
+        PONCA_FITTING_IS_SIGNED(false)
     };
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(CovarianceLineFitImpl,covarianceLineFit)
+    /// \brief Helper alias for Line fitting on 3D points using CovarianceLineFitImpl
+    template <class DataPoint, class _NFilter, typename T>
+    using CovarianceLineFit = CovarianceLineFitImpl<
+        DataPoint, _NFilter,
+        CovarianceFitBase<DataPoint, _NFilter, MeanPosition<DataPoint, _NFilter, Line<DataPoint, _NFilter, T>>>>;
 
-    PONCA_FITTING_APIDOC_FINALIZE
-    PONCA_MULTIARCH inline FIT_RESULT finalize()
-    {
-        static const int smallestEigenValue = DataPoint::Dim - 1;
-        if (Base::finalize() == STABLE) {
-            if (Base::line().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-            Base::setLine(Base::barycenterLocal(), Base::m_solver.eigenvectors().col(smallestEigenValue).normalized());
-        }
-        return Base::m_eCurrentState;
-    }
-    PONCA_FITTING_IS_SIGNED(false)
-};
-
-/// \brief Helper alias for Line fitting on 3D points using CovarianceLineFitImpl
-template < class DataPoint, class _NFilter, typename T>
-using CovarianceLineFit =
-                CovarianceLineFitImpl<DataPoint, _NFilter,
-                CovarianceFitBase<DataPoint, _NFilter,
-                MeanPosition<DataPoint, _NFilter,
-                Line<DataPoint, _NFilter, T>>>>;
-
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/covariancePlaneFit.h
+++ b/Ponca/src/Fitting/covariancePlaneFit.h
@@ -65,7 +65,7 @@ public:
      * Output vector is: [h, u, v]^T, where u, v are 2d coordinates on the plane,
      * and h the height of the sample.
      * \param _q Vector expressed in ambient space
-     * @param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
      *        (e.g., in contrast to displacement or normal vectors)
      * \return Vector expressed in local tangent frame
      */
@@ -76,7 +76,7 @@ public:
      * \brief Transform a point from the tangent plane [h, u, v]^T to ambient space
      *
      * \param _q Vector expressed in local tangent frame
-     * @param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
      *        (e.g., in contrast to displacement or normal vectors)
      * \return Vector expressed in ambient space
      */

--- a/Ponca/src/Fitting/covariancePlaneFit.h
+++ b/Ponca/src/Fitting/covariancePlaneFit.h
@@ -20,134 +20,128 @@
 namespace Ponca
 {
 
-/*!
-    \brief Plane fitting procedure using only points position
+    /*!
+        \brief Plane fitting procedure using only points position
 
-    This class can also computes the surface variation measure introduced in
-    \cite Pauly:2002:PSSimplification.
+        This class can also computes the surface variation measure introduced in
+        \cite Pauly:2002:PSSimplification.
 
-    \inherit Concept::FittingProcedureConcept
+        \inherit Concept::FittingProcedureConcept
 
-    \see Plane
-*/
-template < class DataPoint, class _NFilter, typename T >
-class CovariancePlaneFitImpl : public T
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-PONCA_FITTING_DECLARE_MATRIX_TYPE
-
-protected:
-    enum
+        \see Plane
+    */
+    template <class DataPoint, class _NFilter, typename T>
+    class CovariancePlaneFitImpl : public T
     {
-        Check = Base::PROVIDES_PLANE &&
-                Base::PROVIDES_POSITION_COVARIANCE,
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_MATRIX_TYPE
+
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_PLANE && Base::PROVIDES_POSITION_COVARIANCE,
+            /*!
+             * \brief Expose a method worldToTangentPlane(VectorType), which turns a point
+             * in ambient 3D space to the tangent plane.
+             * \see worldToTangentPlane
+             * \see tangentPlaneToWorld
+             */
+            PROVIDES_TANGENT_PLANE_BASIS
+        };
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(CovariancePlaneFitImpl, covariancePlaneFit)
+        PONCA_FITTING_DECLARE_FINALIZE
+        PONCA_FITTING_IS_SIGNED(false)
+
+        /**************************************************************************/
+        /* Results                                                                */
+        /**************************************************************************/
+
         /*!
-         * \brief Expose a method worldToTangentPlane(VectorType), which turns a point
-         * in ambient 3D space to the tangent plane.
-         * \see worldToTangentPlane
-         * \see tangentPlaneToWorld
+         * \brief Express a point in ambient space relatively to the tangent plane.
+         *
+         * Output vector is: [h, u, v]^T, where u, v are 2d coordinates on the plane,
+         * and h the height of the sample.
+         * \param _q Vector expressed in ambient space
+         * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+         *        (e.g., in contrast to displacement or normal vectors)
+         * \return Vector expressed in local tangent frame
          */
-        PROVIDES_TANGENT_PLANE_BASIS
-    };
+        PONCA_MULTIARCH inline VectorType worldToTangentPlane(const VectorType& _q,
+                                                              bool _isPositionVector = true) const;
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(CovariancePlaneFitImpl,covariancePlaneFit)
-    PONCA_FITTING_DECLARE_FINALIZE
-    PONCA_FITTING_IS_SIGNED(false)
+        /*!
+         * \brief Transform a point from the tangent plane [h, u, v]^T to ambient space
+         *
+         * \param _q Vector expressed in local tangent frame
+         * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+         *        (e.g., in contrast to displacement or normal vectors)
+         * \return Vector expressed in ambient space
+         */
+        PONCA_MULTIARCH inline VectorType tangentPlaneToWorld(const VectorType& _q,
+                                                              bool _isPositionVector = true) const;
+    }; // class CovariancePlaneFitImpl
 
-    /**************************************************************************/
-    /* Results                                                                */
-    /**************************************************************************/
-
-    /*!
-     * \brief Express a point in ambient space relatively to the tangent plane.
-     *
-     * Output vector is: [h, u, v]^T, where u, v are 2d coordinates on the plane,
-     * and h the height of the sample.
-     * \param _q Vector expressed in ambient space
-     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
-     *        (e.g., in contrast to displacement or normal vectors)
-     * \return Vector expressed in local tangent frame
-     */
-    PONCA_MULTIARCH inline VectorType worldToTangentPlane(const VectorType &_q,
-                                                          bool _isPositionVector = true) const;
+    /// \brief Helper alias for Plane fitting on 3D points using CovariancePlaneFitImpl
+    //! [CovariancePlaneFit Definition]
+    template <class DataPoint, class _NFilter, typename T>
+    using CovariancePlaneFit = CovariancePlaneFitImpl<
+        DataPoint, _NFilter,
+        CovarianceFitBase<DataPoint, _NFilter, MeanPosition<DataPoint, _NFilter, Plane<DataPoint, _NFilter, T>>>>;
+    //! [CovariancePlaneFit Definition]
 
     /*!
-     * \brief Transform a point from the tangent plane [h, u, v]^T to ambient space
-     *
-     * \param _q Vector expressed in local tangent frame
-     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
-     *        (e.g., in contrast to displacement or normal vectors)
-     * \return Vector expressed in ambient space
-     */
-    PONCA_MULTIARCH inline VectorType tangentPlaneToWorld(const VectorType &_q,
-                                                          bool _isPositionVector = true) const;
-}; //class CovariancePlaneFitImpl
+        \brief Internal generic class computing the derivatives of covariance plane fits
+        \inherit Concept::FittingExtensionConcept
 
-/// \brief Helper alias for Plane fitting on 3D points using CovariancePlaneFitImpl
-//! [CovariancePlaneFit Definition]
-    template < class DataPoint, class _NFilter, typename T>
-    using CovariancePlaneFit =
-    CovariancePlaneFitImpl<DataPoint, _NFilter,
-            CovarianceFitBase<DataPoint, _NFilter,
-                    MeanPosition<DataPoint, _NFilter,
-                            Plane<DataPoint, _NFilter, T>>>>;
-//! [CovariancePlaneFit Definition]
-
-/*!
-    \brief Internal generic class computing the derivatives of covariance plane fits
-    \inherit Concept::FittingExtensionConcept
-
-    \warning Defined in 3D only
-*/
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-class CovariancePlaneDerImpl : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_MATRIX_TYPE
-    PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
-    static_assert ( DataPoint::Dim == 3, "CovariancePlaneDer is only valid in 3D");
-
-protected:
-    enum
+        \warning Defined in 3D only
+    */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class CovariancePlaneDerImpl : public T
     {
-        Check = Base::PROVIDES_PLANE &
-                Base::PROVIDES_POSITION_COVARIANCE_DERIVATIVE,
-        PROVIDES_COVARIANCE_PLANE_DERIVATIVE,                    /*!< \brief Provides derivatives for hyper-planes */
-        PROVIDES_NORMAL_DERIVATIVE
-    };
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_MATRIX_TYPE
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
+        static_assert(DataPoint::Dim == 3, "CovariancePlaneDer is only valid in 3D");
 
-private:
-    VectorArray m_dNormal {VectorArray::Zero()};    /*!< \brief Derivatives of the hyper-plane normal */
-    ScalarArray m_dDist {ScalarArray::Zero()};      /*!< \brief Derivatives of the MLS scalar field */
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_PLANE & Base::PROVIDES_POSITION_COVARIANCE_DERIVATIVE,
+            PROVIDES_COVARIANCE_PLANE_DERIVATIVE, /*!< \brief Provides derivatives for hyper-planes */
+            PROVIDES_NORMAL_DERIVATIVE
+        };
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS_DER(CovariancePlaneDerImpl,covariancePlaneDer)
+    private:
+        VectorArray m_dNormal{VectorArray::Zero()}; /*!< \brief Derivatives of the hyper-plane normal */
+        ScalarArray m_dDist{ScalarArray::Zero()};   /*!< \brief Derivatives of the MLS scalar field */
 
-    /*! \see Concept::FittingProcedureConcept::finalize() */
-    PONCA_MULTIARCH FIT_RESULT finalize();
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(CovariancePlaneDerImpl, covariancePlaneDer)
 
-    /**************************************************************************/
-    /* Use results                                                            */
-    /**************************************************************************/
+        /*! \see Concept::FittingProcedureConcept::finalize() */
+        PONCA_MULTIARCH FIT_RESULT finalize();
 
-    // \brief Returns the derivatives of the scalar field at the evaluation point
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dPotential() const { return m_dDist; }
+        /**************************************************************************/
+        /* Use results                                                            */
+        /**************************************************************************/
 
-    /*! \brief Returns the derivatives of the primitive normal */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorArray dNormal() const { return m_dNormal; }
+        // \brief Returns the derivatives of the scalar field at the evaluation point
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dPotential() const { return m_dDist; }
 
-}; //class CovariancePlaneDer
+        /*! \brief Returns the derivatives of the primitive normal */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorArray dNormal() const { return m_dNormal; }
 
+    }; // class CovariancePlaneDer
 
-/// \brief Helper alias for Plane fitting on 3D points using CovariancePlaneFitImpl
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-using CovariancePlaneDer =
-CovariancePlaneDerImpl<DataPoint, _NFilter, DiffType,
-        CovarianceFitDer<DataPoint, _NFilter, DiffType,
-                MeanPositionDer<DataPoint, _NFilter, DiffType, T>>>;
+    /// \brief Helper alias for Plane fitting on 3D points using CovariancePlaneFitImpl
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    using CovariancePlaneDer = CovariancePlaneDerImpl<
+        DataPoint, _NFilter, DiffType,
+        CovarianceFitDer<DataPoint, _NFilter, DiffType, MeanPositionDer<DataPoint, _NFilter, DiffType, T>>>;
 
 #include "covariancePlaneFit.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/covariancePlaneFit.hpp
+++ b/Ponca/src/Fitting/covariancePlaneFit.hpp
@@ -10,39 +10,37 @@
 #include PONCA_MULTIARCH_INCLUDE_STD(cmath)
 #include PONCA_MULTIARCH_INCLUDE_STD(limits)
 
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-CovariancePlaneFitImpl<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT CovariancePlaneFitImpl<DataPoint, _NFilter, T>::finalize()
 {
-    if (Base::finalize() == STABLE) {
-        if (Base::plane().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
+    if (Base::finalize() == STABLE)
+    {
+        if (Base::plane().isValid())
+            Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
         Base::setPlane(Base::m_solver.eigenvectors().col(0), Base::barycenterLocal());
     }
 
     return Base::m_eCurrentState;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-typename CovariancePlaneFitImpl<DataPoint, _NFilter, T>::VectorType
-CovariancePlaneFitImpl<DataPoint, _NFilter, T>::worldToTangentPlane (const VectorType& _q, bool _isPositionVector) const
+template <class DataPoint, class _NFilter, typename T>
+typename CovariancePlaneFitImpl<DataPoint, _NFilter, T>::VectorType CovariancePlaneFitImpl<
+    DataPoint, _NFilter, T>::worldToTangentPlane(const VectorType& _q, bool _isPositionVector) const
 {
-    return Base::m_solver.eigenvectors().transpose() * Base::getNeighborFilter().convertToLocalBasis(_q,
-                                                                                                     _isPositionVector);
+    return Base::m_solver.eigenvectors().transpose() *
+           Base::getNeighborFilter().convertToLocalBasis(_q, _isPositionVector);
 }
 
-template < class DataPoint, class _NFilter, typename T>
-typename CovariancePlaneFitImpl<DataPoint, _NFilter, T>::VectorType
-CovariancePlaneFitImpl<DataPoint, _NFilter, T>::tangentPlaneToWorld (const VectorType& _lq, bool _isPositionVector) const
+template <class DataPoint, class _NFilter, typename T>
+typename CovariancePlaneFitImpl<DataPoint, _NFilter, T>::VectorType CovariancePlaneFitImpl<
+    DataPoint, _NFilter, T>::tangentPlaneToWorld(const VectorType& _lq, bool _isPositionVector) const
 {
     return Base::getNeighborFilter().convertToGlobalBasis(Base::m_solver.eigenvectors().transpose().inverse() * _lq,
                                                           _isPositionVector);
 }
 
-
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-FIT_RESULT
-CovariancePlaneDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+FIT_RESULT CovariancePlaneDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
 {
     PONCA_MULTIARCH_STD_MATH(sqrt);
     PONCA_MULTIARCH_STD_MATH(numeric_limits);
@@ -51,41 +49,46 @@ CovariancePlaneDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
     // Test if base finalize end on a viable case (stable / unstable)
     if (this->isReady())
     {
-      VectorType   barycenter = Base::barycenterLocal();
-      VectorArray dBarycenter = Base::barycenterDerivatives();
+        VectorType barycenter   = Base::barycenterLocal();
+        VectorArray dBarycenter = Base::barycenterDerivatives();
 
-      // pre-compute shifted eigenvalues to apply the pseudo inverse of C - lambda_0 I
-      Scalar epsilon          = Scalar(2) * Eigen::NumTraits<Scalar>::epsilon();
-      Scalar consider_as_zero = Scalar(2) * numeric_limits<Scalar>::denorm_min();
+        // pre-compute shifted eigenvalues to apply the pseudo inverse of C - lambda_0 I
+        Scalar epsilon          = Scalar(2) * Eigen::NumTraits<Scalar>::epsilon();
+        Scalar consider_as_zero = Scalar(2) * numeric_limits<Scalar>::denorm_min();
 
-      // This is where the limitation to 3d comes from.
-      // \fixme Replace shift in 2d subspace by any subspace with co-dimension 1
-      Eigen::Matrix<Scalar,2,1> shifted_eivals = Base::m_solver.eigenvalues().template tail<2>().array() - Base::m_solver.eigenvalues()(0);
-      if(shifted_eivals(0) < consider_as_zero || shifted_eivals(0) < epsilon * shifted_eivals(1)) shifted_eivals(0) = 0;
-      if(shifted_eivals(1) < consider_as_zero) shifted_eivals(1) = 0;
+        // This is where the limitation to 3d comes from.
+        // \fixme Replace shift in 2d subspace by any subspace with co-dimension 1
+        Eigen::Matrix<Scalar, 2, 1> shifted_eivals =
+            Base::m_solver.eigenvalues().template tail<2>().array() - Base::m_solver.eigenvalues()(0);
+        if (shifted_eivals(0) < consider_as_zero || shifted_eivals(0) < epsilon * shifted_eivals(1))
+            shifted_eivals(0) = 0;
+        if (shifted_eivals(1) < consider_as_zero)
+            shifted_eivals(1) = 0;
 
+        for (int k = 0; k < Base::NbDerivatives; ++k)
+        {
+            VectorType normal = Base::primitiveGradient();
+            // The derivative of 'normal' is the derivative of the smallest eigenvector.
+            // Since the covariance matrix is real and symmetric, it is equal to:
+            //    n' = - (C - lambda_0 I)^+ C' n
+            // Where ^+ denotes the pseudo-inverse.
+            // Since we already performed the eigenvalue decomposition of the matrix C,
+            // we can directly apply the pseudo inverse by observing that:
+            //    (C - lambda_0 I) = V (L - lambda_0 I) V^T
+            // where V is the eigenvector matrix, and L the eigenvalue diagonal matrix.
+            Eigen::Matrix<Scalar, 2, 1> z =
+                -Base::m_solver.eigenvectors().template rightCols<2>().transpose() * (Base::m_dCov[k] * normal);
+            if (shifted_eivals(0) > 0)
+                z(0) /= shifted_eivals(0);
+            if (shifted_eivals(1) > 0)
+                z(1) /= shifted_eivals(1);
+            m_dNormal.col(k) = Base::m_solver.eigenvectors().template rightCols<2>() * z;
 
-      for(int k=0; k<Base::NbDerivatives; ++k)
-      {
-        VectorType normal = Base::primitiveGradient();
-        // The derivative of 'normal' is the derivative of the smallest eigenvector.
-        // Since the covariance matrix is real and symmetric, it is equal to:
-        //    n' = - (C - lambda_0 I)^+ C' n
-        // Where ^+ denotes the pseudo-inverse.
-        // Since we already performed the eigenvalue decomposition of the matrix C,
-        // we can directly apply the pseudo inverse by observing that:
-        //    (C - lambda_0 I) = V (L - lambda_0 I) V^T
-        // where V is the eigenvector matrix, and L the eigenvalue diagonal matrix.
-        Eigen::Matrix<Scalar,2,1> z = - Base::m_solver.eigenvectors().template rightCols<2>().transpose() * (Base::m_dCov[k] * normal);
-        if(shifted_eivals(0)>0) z(0) /= shifted_eivals(0);
-        if(shifted_eivals(1)>0) z(1) /= shifted_eivals(1);
-        m_dNormal.col(k) = Base::m_solver.eigenvectors().template rightCols<2>() * z;
-
-        VectorType dDiff = dBarycenter.col(k);
-        if(k>0 || !Base::isScaleDer())
-          dDiff(Base::isScaleDer() ? k-1 : k) += 1;
-        m_dDist(k) = m_dNormal.col(k).dot(barycenter) + normal.dot(dDiff);
-      }
+            VectorType dDiff = dBarycenter.col(k);
+            if (k > 0 || !Base::isScaleDer())
+                dDiff(Base::isScaleDer() ? k - 1 : k) += 1;
+            m_dDist(k) = m_dNormal.col(k).dot(barycenter) + normal.dot(dDiff);
+        }
     }
 
     return Base::m_eCurrentState;

--- a/Ponca/src/Fitting/curvature.h
+++ b/Ponca/src/Fitting/curvature.h
@@ -12,18 +12,18 @@ namespace Ponca
 {
     namespace internal
     {
-        template < class DataPoint, class _NFilter, typename T>
-    /**
-     *
-     * \brief Base class for any 3d curvature estimator: holds \f$k_{\min}\f$, \f$k_{\max}\f$ and associated vectors,
-     * such that \f$ k_{\min} <= k_{\max} \f$
-     */
+        template <class DataPoint, class _NFilter, typename T>
+        /**
+         *
+         * \brief Base class for any 3d curvature estimator: holds \f$k_{\min}\f$, \f$k_{\max}\f$ and associated
+         * vectors, such that \f$ k_{\min} <= k_{\max} \f$
+         */
         class CurvatureEstimatorBase : public T
         {
             PONCA_FITTING_DECLARE_DEFAULT_TYPES
             PONCA_FITTING_DECLARE_MATRIX_TYPE
 
-            protected:
+        protected:
             enum
             {
                 PROVIDES_PRINCIPAL_CURVATURES
@@ -31,18 +31,19 @@ namespace Ponca
 
         private:
             /// \brief Minimal principal curvature
-            Scalar m_kmin {0},
-            /// \brief Maximal principal curvature
-            m_kmax {0};
+            Scalar m_kmin{0},
+                /// \brief Maximal principal curvature
+                m_kmax{0};
             /// \brief Direction associated to the minimal principal curvature
-            VectorType m_vmin {VectorType::Zero()},
-            /// \brief Direction associated to the maximal principal curvature
-            m_vmax {VectorType::Zero()};
+            VectorType m_vmin{VectorType::Zero()},
+                /// \brief Direction associated to the maximal principal curvature
+                m_vmax{VectorType::Zero()};
 
-            /// \brief Internal state indicating if the curvature are set to default (false), or have been computed (true)
-            bool m_isValid {false};
+            /// \brief Internal state indicating if the curvature are set to default (false), or have been computed
+            /// (true)
+            bool m_isValid{false};
 
-            static_assert ( DataPoint::Dim == 3, "CurvatureEstimatorBase is only valid in 3D");
+            static_assert(DataPoint::Dim == 3, "CurvatureEstimatorBase is only valid in 3D");
 
         public:
             PONCA_FITTING_DECLARE_INIT
@@ -66,10 +67,10 @@ namespace Ponca
             PONCA_MULTIARCH [[nodiscard]] inline VectorType kmaxDirection() const { return m_vmax; }
 
             //! \brief Returns an estimate of the mean curvature
-            PONCA_MULTIARCH [[nodiscard]] inline Scalar kMean() const { return (m_kmin + m_kmax)/Scalar(2);}
+            PONCA_MULTIARCH [[nodiscard]] inline Scalar kMean() const { return (m_kmin + m_kmax) / Scalar(2); }
 
             //! \brief Returns an estimate of the Gaussian curvature
-            PONCA_MULTIARCH [[nodiscard]] inline Scalar GaussianCurvature() const { return m_kmin * m_kmax;}
+            PONCA_MULTIARCH [[nodiscard]] inline Scalar GaussianCurvature() const { return m_kmin * m_kmax; }
 
         protected:
             /// \brief Set curvature values. To be called in finalize() by child classes
@@ -78,12 +79,13 @@ namespace Ponca
             /// method swap the two curvature values and directions and store them such that
             /// \f$ k_{\min} <= k_{\max} \f$.
             ///
-            PONCA_MULTIARCH inline void setCurvatureValues(Scalar kmin, Scalar kmax, const VectorType& vmin, const VectorType& vmax);
+            PONCA_MULTIARCH inline void setCurvatureValues(Scalar kmin, Scalar kmax, const VectorType& vmin,
+                                                           const VectorType& vmax);
         };
-    }
+    } // namespace internal
 
     /// Make CurvatureEstimatorBase available to standard Basket object
-    template < class DataPoint, class _NFilter, typename T>
+    template <class DataPoint, class _NFilter, typename T>
     class CurvatureEstimator : public internal::CurvatureEstimatorBase<DataPoint, _NFilter, T>
     {
     public:
@@ -91,13 +93,13 @@ namespace Ponca
     };
 
     /// Make CurvatureEstimatorBase available to BasketDiff object
-    template < class DataPoint, class _NFilter, int DiffType, typename T>
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     class CurvatureEstimatorDer : public internal::CurvatureEstimatorBase<DataPoint, _NFilter, T>
     {
     public:
         PONCA_EXPLICIT_CAST_OPERATORS_DER(CurvatureEstimatorDer, curvatureEstimator)
     };
 
-} //namespace Ponca
+} // namespace Ponca
 
 #include "curvature.hpp"

--- a/Ponca/src/Fitting/curvature.hpp
+++ b/Ponca/src/Fitting/curvature.hpp
@@ -1,36 +1,41 @@
 
-namespace Ponca {
+namespace Ponca
+{
     namespace internal
     {
         ///////// CurvatureEstimatorBase
-        template<class DataPoint, class _NFilter, typename T>
+        template <class DataPoint, class _NFilter, typename T>
         void
-#if defined(__GNUC__) && ! defined(__clang__)
-        // attribute 'no-tree-vectorize' is required for the init function.
-        // It resolves a crash when compiling with GCC 11.4.0
-        // with the default optimization level (-O3) for release builds.
-        __attribute__((optimize("no-tree-vectorize")))
+#if defined(__GNUC__) && !defined(__clang__)
+            // attribute 'no-tree-vectorize' is required for the init function.
+            // It resolves a crash when compiling with GCC 11.4.0
+            // with the default optimization level (-O3) for release builds.
+            __attribute__((optimize("no-tree-vectorize")))
 #endif
-        CurvatureEstimatorBase<DataPoint, _NFilter, T>::init() {
+            CurvatureEstimatorBase<DataPoint, _NFilter, T>::init()
+        {
             Base::init();
-            m_kmin = 0;
-            m_kmax = 0;
-            m_vmin = VectorType::Zero();
-            m_vmax = VectorType::Zero();
+            m_kmin    = 0;
+            m_kmax    = 0;
+            m_vmin    = VectorType::Zero();
+            m_vmax    = VectorType::Zero();
             m_isValid = false;
         }
 
-
-        template<class DataPoint, class _NFilter, typename T>
-        void
-        CurvatureEstimatorBase<DataPoint, _NFilter, T>::setCurvatureValues(
-                Scalar kmin, Scalar kmax, const VectorType &vmin, const VectorType &vmax) {
-            if(kmin <= kmax) {
+        template <class DataPoint, class _NFilter, typename T>
+        void CurvatureEstimatorBase<DataPoint, _NFilter, T>::setCurvatureValues(Scalar kmin, Scalar kmax,
+                                                                                const VectorType& vmin,
+                                                                                const VectorType& vmax)
+        {
+            if (kmin <= kmax)
+            {
                 m_kmin = kmin;
                 m_kmax = kmax;
                 m_vmin = vmin;
                 m_vmax = vmax;
-            } else {
+            }
+            else
+            {
                 m_kmin = kmax;
                 m_kmax = kmin;
                 m_vmin = vmax;
@@ -38,5 +43,5 @@ namespace Ponca {
             }
             m_isValid = true;
         }
-    }
-}
+    } // namespace internal
+} // namespace Ponca

--- a/Ponca/src/Fitting/defines.h
+++ b/Ponca/src/Fitting/defines.h
@@ -13,8 +13,8 @@
   *
   * \defgroup fitting Fitting module
   * \brief This modules includes classes and methods for primitive fitting
-  * @{
-  * @}
+  * \{
+  * \}
   *
   */
 #include "../Common/defines.h"

--- a/Ponca/src/Fitting/defines.h
+++ b/Ponca/src/Fitting/defines.h
@@ -4,71 +4,75 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 #pragma once
 
 #include <type_traits> // std::true_type
 
 /**
-  *
-  * \defgroup fitting Fitting module
-  * \brief This modules includes classes and methods for primitive fitting
-  * \{
-  * \}
-  *
-  */
+ *
+ * \defgroup fitting Fitting module
+ * \brief This modules includes classes and methods for primitive fitting
+ * \{
+ * \}
+ *
+ */
 #include "../Common/defines.h"
 
-#define PONCA_EXPLICIT_CAST_OPERATORS(CLASSNAME,CONVERTER)                                                         \
-/*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */                   \
-PONCA_MULTIARCH inline                                                                                             \
-CLASSNAME<DataPoint, _NFilter, T>& CONVERTER()                                                                    \
-{ return * static_cast<CLASSNAME<DataPoint, _NFilter, T>*>(this); }                                               \
-/*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */                   \
-PONCA_MULTIARCH inline                                                                                             \
-const CLASSNAME<DataPoint, _NFilter, T>& CONVERTER() const                                                        \
-{ return * static_cast<const CLASSNAME<DataPoint, _NFilter, T>*>(this); }
+#define PONCA_EXPLICIT_CAST_OPERATORS(CLASSNAME, CONVERTER)                                          \
+    /*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */ \
+    PONCA_MULTIARCH inline CLASSNAME<DataPoint, _NFilter, T>& CONVERTER()                            \
+    {                                                                                                \
+        return *static_cast<CLASSNAME<DataPoint, _NFilter, T>*>(this);                               \
+    }                                                                                                \
+    /*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */ \
+    PONCA_MULTIARCH inline const CLASSNAME<DataPoint, _NFilter, T>& CONVERTER() const                \
+    {                                                                                                \
+        return *static_cast<const CLASSNAME<DataPoint, _NFilter, T>*>(this);                         \
+    }
 
 // CAST OPERATORS
 
-#define PONCA_EXPLICIT_CAST_OPERATORS_DER(CLASSNAME,CONVERTER)                                                     \
-/*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */                   \
-PONCA_MULTIARCH inline                                                                                             \
-CLASSNAME<DataPoint, _NFilter, DiffType, T>& CONVERTER()                                                          \
-{ return * static_cast<CLASSNAME<DataPoint, _NFilter, DiffType, T>*>(this); }                                     \
-/*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */                   \
-PONCA_MULTIARCH inline                                                                                             \
-const CLASSNAME<DataPoint, _NFilter, DiffType, T>& CONVERTER() const                                              \
-{ return * static_cast<const CLASSNAME<DataPoint, _NFilter, DiffType, T>*>(this); }
-
+#define PONCA_EXPLICIT_CAST_OPERATORS_DER(CLASSNAME, CONVERTER)                                      \
+    /*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */ \
+    PONCA_MULTIARCH inline CLASSNAME<DataPoint, _NFilter, DiffType, T>& CONVERTER()                  \
+    {                                                                                                \
+        return *static_cast<CLASSNAME<DataPoint, _NFilter, DiffType, T>*>(this);                     \
+    }                                                                                                \
+    /*! \brief Explicit conversion to CLASSNAME, to access methods potentially hidden by heritage */ \
+    PONCA_MULTIARCH inline const CLASSNAME<DataPoint, _NFilter, DiffType, T>& CONVERTER() const      \
+    {                                                                                                \
+        return *static_cast<const CLASSNAME<DataPoint, _NFilter, DiffType, T>*>(this);               \
+    }
 
 // FIT DEFAULT TYPES
 
 /// Declare the following defaults types: Base, Scalar, VectorType, NeighborFilter
-#define PONCA_FITTING_DECLARE_DEFAULT_TYPES                                                                         \
-protected:                                                                                                          \
-using Base = T;  /*!< \brief Base class of the procedure*/                                                          \
-public:                                                                                                             \
-using Scalar         = typename DataPoint::Scalar;    /*!< \brief Alias to scalar type*/                            \
-using VectorType     = typename Base::VectorType;     /*!< \brief Alias to vector type*/                            \
-using NeighborFilter = typename Base::NeighborFilter; /*!< \brief Alias to the filter applied on the neighbors */
+#define PONCA_FITTING_DECLARE_DEFAULT_TYPES                                                  \
+protected:                                                                                   \
+    using Base = T; /*!< \brief Base class of the procedure*/                                \
+public:                                                                                      \
+    using Scalar         = typename DataPoint::Scalar;    /*!< \brief Alias to scalar type*/ \
+    using VectorType     = typename Base::VectorType;     /*!< \brief Alias to vector type*/ \
+    using NeighborFilter = typename Base::NeighborFilter; /*!< \brief Alias to the filter applied on the neighbors */
 
 /// Declare the following defaults types: Base, Scalar, VectorType, NeighborFilter
-#define PONCA_FITTING_DECLARE_MATRIX_TYPE                                                                           \
-public:                                                                                                             \
-using MatrixType  = typename DataPoint::MatrixType; /*!< \brief Alias to matrix type*/                              \
+#define PONCA_FITTING_DECLARE_MATRIX_TYPE \
+public:                                   \
+    using MatrixType = typename DataPoint::MatrixType; /*!< \brief Alias to matrix type*/
 
 /// Declare the following defaults types: Base, Scalar, VectorType, NeighborFilter
-#define PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES                                                                     \
-public:                                                                                                             \
-using ScalarArray = typename Base::ScalarArray;     /*!< \brief Alias to scalar derivatives array */                \
-using VectorArray = typename Base::VectorArray;     /*!< \brief Alias to vector derivatives array */
+#define PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES                                                      \
+public:                                                                                              \
+    using ScalarArray = typename Base::ScalarArray; /*!< \brief Alias to scalar derivatives array */ \
+    using VectorArray = typename Base::VectorArray; /*!< \brief Alias to vector derivatives array */
 
 // FIT API DOCUMENTATION
-#define PONCA_FITTING_APIDOC_SETWFUNC \
-/*! Init the WeightFunc, without changing the other internal states. Calls #startNewPass internally. \warning Must be called be for any computation (and before #init). \see getWeightFunc */
-#define PONCA_FITTING_APIDOC_INIT \
-/*! Set the evaluation position and reset the internal states. \warning Must be called be for any computation (but after #setNeighborFilter) */
+#define PONCA_FITTING_APIDOC_SETWFUNC                                                                                 \
+/*! Init the WeightFunc, without changing the other internal states. Calls #startNewPass internally. \warning Must be \
+ * called be for any computation (and before #init). \see getWeightFunc */
+#define PONCA_FITTING_APIDOC_INIT                                                                                  \
+/*! Set the evaluation position and reset the internal states. \warning Must be called be for any computation (but \
+ * after #setNeighborFilter) */
 #define PONCA_FITTING_APIDOC_ADDNEIGHBOR \
 /*! Add a neighbor to perform the fit \return false if param nei is not a valid neighbour (weight = 0) */
 #define PONCA_FITTING_APIDOC_ADDNEIGHBOR_DER \
@@ -79,50 +83,53 @@ using VectorArray = typename Base::VectorArray;     /*!< \brief Alias to vector 
 // FIT API DECLARATION
 
 /// Declare Primitive::isiSigned()
-#define PONCA_FITTING_IS_SIGNED(IS_SIGNED)                                                                         \
-/*! \brief Is scalar field signed. If not, the method the sign of `potential()` must be ignored */                 \
-PONCA_MULTIARCH inline                                                                                             \
-constexpr bool isSigned() { return IS_SIGNED; }
+#define PONCA_FITTING_IS_SIGNED(IS_SIGNED)                                                             \
+    /*! \brief Is scalar field signed. If not, the method the sign of `potential()` must be ignored */ \
+    PONCA_MULTIARCH inline constexpr bool isSigned() { return IS_SIGNED; }
 
 /// Declare Concept::ComputationalObjectConcept::init()
-#define PONCA_FITTING_DECLARE_INIT                                                                                 \
-PONCA_FITTING_APIDOC_INIT                                                                                          \
-PONCA_MULTIARCH inline void init ();
+#define PONCA_FITTING_DECLARE_INIT \
+    PONCA_FITTING_APIDOC_INIT      \
+    PONCA_MULTIARCH inline void init();
 
 /// Declare Concept::ComputationalObjectConcept::addLocalNeighbor
-#define PONCA_FITTING_DECLARE_ADDNEIGHBOR                                                                          \
-PONCA_FITTING_APIDOC_ADDNEIGHBOR                                                                                   \
-PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType &localQ, const DataPoint &attributes);
+#define PONCA_FITTING_DECLARE_ADDNEIGHBOR \
+    PONCA_FITTING_APIDOC_ADDNEIGHBOR      \
+    PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType& localQ, const DataPoint& attributes);
 
 /// Declare Concept::ComputationalDerivativesConcept::addLocalNeighbor
-#define PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER                                                                      \
-PONCA_FITTING_APIDOC_ADDNEIGHBOR_DER                                                                               \
-PONCA_MULTIARCH inline bool                                                                                        \
-addLocalNeighbor(Scalar w, const VectorType &localQ, const DataPoint &attributes, ScalarArray &dw);
+#define PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER                                                                     \
+    PONCA_FITTING_APIDOC_ADDNEIGHBOR_DER                                                                          \
+    PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType& localQ, const DataPoint& attributes, \
+                                                 ScalarArray& dw);
 
 /// Declare Concept::ComputationalObjectConcept::finalize
-#define PONCA_FITTING_DECLARE_FINALIZE                                                                             \
-PONCA_FITTING_APIDOC_FINALIZE                                                                                      \
-PONCA_MULTIARCH inline FIT_RESULT finalize();
+#define PONCA_FITTING_DECLARE_FINALIZE \
+    PONCA_FITTING_APIDOC_FINALIZE      \
+    PONCA_MULTIARCH inline FIT_RESULT finalize();
 
-#define PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE                                                                    \
-PONCA_FITTING_DECLARE_INIT                                                                                         \
-PONCA_FITTING_DECLARE_ADDNEIGHBOR                                                                                  \
-PONCA_FITTING_DECLARE_FINALIZE
+#define PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE \
+    PONCA_FITTING_DECLARE_INIT                  \
+    PONCA_FITTING_DECLARE_ADDNEIGHBOR           \
+    PONCA_FITTING_DECLARE_FINALIZE
 
-#define PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE                                                                 \
-PONCA_FITTING_DECLARE_INIT                                                                                         \
-PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER                                                                              \
-PONCA_FITTING_DECLARE_FINALIZE
+#define PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE \
+    PONCA_FITTING_DECLARE_INIT                     \
+    PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER          \
+    PONCA_FITTING_DECLARE_FINALIZE
 
 namespace Ponca
 {
-/// \FIXME create a macro to automatically generate the testing functions
+    /// \FIXME create a macro to automatically generate the testing functions
     template <typename T, typename = void>
-    struct hasFirstFundamentalForm : std::false_type {};
+    struct hasFirstFundamentalForm : std::false_type
+    {
+    };
 
     template <typename T>
-    struct hasFirstFundamentalForm<T, std::void_t<decltype(std::declval<T>().firstFundamentalForm())>> : std::true_type {};
+    struct hasFirstFundamentalForm<T, std::void_t<decltype(std::declval<T>().firstFundamentalForm())>> : std::true_type
+    {
+    };
 
 } // namespace Ponca
 

--- a/Ponca/src/Fitting/dryFit.h
+++ b/Ponca/src/Fitting/dryFit.h
@@ -15,47 +15,62 @@
 namespace Ponca
 {
 
-/*!
-   \brief Empty fitting object doing no computation
- */
+    /*!
+       \brief Empty fitting object doing no computation
+     */
 
-    template < class DataPoint, class _NFilter, typename T>
-    class DryFit :  public T
+    template <class DataPoint, class _NFilter, typename T>
+    class DryFit : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
     protected:
-        enum { check = Base::PROVIDES_PRIMITIVE_BASE };
+        enum
+        {
+            check = Base::PROVIDES_PRIMITIVE_BASE
+        };
 
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS(DryFit,dryfit)
+        PONCA_EXPLICIT_CAST_OPERATORS(DryFit, dryfit)
 
         PONCA_FITTING_APIDOC_ADDNEIGHBOR
-        PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType &localQ, const DataPoint &attributes)
-        { return Base::addLocalNeighbor(w, localQ, attributes);}
+        PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType& localQ, const DataPoint& attributes)
+        {
+            return Base::addLocalNeighbor(w, localQ, attributes);
+        }
 
         PONCA_FITTING_APIDOC_FINALIZE
         PONCA_MULTIARCH [[nodiscard]] inline FIT_RESULT finalize() { return Base::finalize(); }
 
         //! \brief Simulate Scalar field computation
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential ( ) const { return Scalar(0); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential() const { return Scalar(0); }
 
         //! \brief Simulate Scalar field computation
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential (const VectorType& /*_q*/) const { return Scalar(0); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential(const VectorType& /*_q*/) const { return Scalar(0); }
 
         //! \brief Simulate point projection
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType project (const VectorType& _q) const { return _q; }
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType project(const VectorType& _q) const { return _q; }
 
         //! \brief Simulate gradient direction computation
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient () const { return VectorType::Zero(); }
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient() const { return VectorType::Zero(); }
 
         //! \brief Simulate gradient direction computation
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient (const VectorType&) const { return VectorType::Zero(); }
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient(const VectorType&) const
+        {
+            return VectorType::Zero();
+        }
+
     protected:
         /// \copydoc DryFit::potential
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal (const VectorType& /*_lq*/) const { return Scalar(0); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal(const VectorType& /*_lq*/) const
+        {
+            return Scalar(0);
+        }
         /// \copydoc DryFit::primitiveGradient
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal (const VectorType&  /*_lq*/) const { return VectorType::Zero(); }
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal(const VectorType& /*_lq*/) const
+        {
+            return VectorType::Zero();
+        }
     };
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/enums.h
+++ b/Ponca/src/Fitting/enums.h
@@ -8,16 +8,16 @@
 
 namespace Ponca
 {
-   /*!
-      Enum corresponding to the state of a fitting method (and what the finalize function returns)
-    */
+    /*!
+       Enum corresponding to the state of a fitting method (and what the finalize function returns)
+     */
     enum FIT_RESULT : unsigned char
     {
         /*! \brief The fitting is stable and ready to use*/
-        STABLE    = 0,
-        /*! \brief The fitting is ready to use but it is considered 
+        STABLE = 0,
+        /*! \brief The fitting is ready to use but it is considered
         as unstable (if the number of neighbors is low for example)*/
-        UNSTABLE  = 1,
+        UNSTABLE = 1,
         /*! \brief The fitting is undefined, you can't use it for valid results*/
         UNDEFINED = 2,
         /*! \brief The fitting procedure needs to analyse the neighborhood
@@ -28,13 +28,13 @@ namespace Ponca
         NBMAX /*!< \brief Nb enums */
     };
 
-/// Flags defining which derivatives need to be computed.
-/// \warning Flags have to be combined using `|`
-enum DiffType: unsigned int
-{
-FitScaleDer = 0x01,                          /*!< \brief Flag indicating a scale differentiation. */
-FitSpaceDer = 0x02,                          /*!< \brief Flag indicating a space differentiation. */
-FitScaleSpaceDer = FitScaleDer | FitSpaceDer /*!< \brief Flag indicating a scale-space differentiation. */
-};
+    /// Flags defining which derivatives need to be computed.
+    /// \warning Flags have to be combined using `|`
+    enum DiffType : unsigned int
+    {
+        FitScaleDer      = 0x01,                     /*!< \brief Flag indicating a scale differentiation. */
+        FitSpaceDer      = 0x02,                     /*!< \brief Flag indicating a space differentiation. */
+        FitScaleSpaceDer = FitScaleDer | FitSpaceDer /*!< \brief Flag indicating a scale-space differentiation. */
+    };
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/gls.h
+++ b/Ponca/src/Fitting/gls.h
@@ -12,154 +12,158 @@
 namespace Ponca
 {
 
-/*!
-    \brief Growing Least Squares reparametrization of the OrientedSphereFit
-    \inherit Concept::FittingExtensionConcept
-
-    Method published in \cite Mellado:2012:GLS
-
-    This class assumes that the WeightFunc defines the accessor
-    \code
-        w.evalScale();
-    \endcode
-    in order to access to the evaluation scale, needed to compute the
-    scale invariant GLS reparametrization (all *_normalized methods).
-
-    Computed values:
-    - tau(), eta() and kappa(): the GLS descriptor
-    \f$ \left[ \tau \; \eta \; \kappa \right]\f$
-    - tau_normalized(), eta_normalized() and kappa_normalized():
-    the scale invariant GLS descriptor
-    \f$ \left[ \frac{\tau}{t} \; \eta \; t\kappa \right]\f$
-
-    Requirements:
-    \verbatim PROVIDES_ALGEBRAIC_SPHERE \endverbatim
-    Provides:
-    \verbatim PROVIDES_GLS_PARAMETRIZATION \endverbatim
-*/
-template < class DataPoint, class _NFilter, typename T>
-class GLSParam : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-
-//! [Requirements]
-protected:
-    enum
-    {
-        Check = Base::PROVIDES_ALGEBRAIC_SPHERE,
-        PROVIDES_GLS_PARAMETRIZATION
-    };
-//! [Requirements]
-
-protected:
-    Scalar m_fitness {0};   /*!< \brief Save the fitness value to avoid side effect with Pratt normalization*/
-
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(GLSParam,glsParam)
-    PONCA_FITTING_DECLARE_FINALIZE
-
-    /**************************************************************************/
-    /* Use results                                                            */
-    /**************************************************************************/
-    /*! \brief Compute and return \f$ \tau \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar tau() const
-    {
-        return Base::isNormalized() ? Base::m_uc : Base::m_uc / Base::prattNorm();
-    }
-
-    /*! \brief Compute and return \f$ \eta \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType eta() const { return Base::primitiveGradient(); }
-
-    /*! \brief Compute and return \f$ \kappa \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar kappa() const
-    {
-        return Scalar(2.) * (Base::isNormalized() ? Base::m_uq : Base::m_uq / Base::prattNorm());
-    }
-
-    /*! \brief Compute and return \f$ \frac{\tau}{t} \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar tau_normalized() const { return tau() / Base::getNeighborFilter().evalScale(); }
-
-    /*! \brief Compute and return \f$ \eta \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType eta_normalized() const { return eta(); }
-
-    /*! \brief Compute and return \f$ t \kappa \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar kappa_normalized() const { return kappa() * Base::getNeighborFilter().evalScale(); }
-
-    /*! \brief Return the fitness, e.g. the pratt norm of the initial scalar field */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar fitness() const { return m_fitness; }
-
     /*!
-    \brief Compare current instance with other.
-    \return a distance between two fits (0 correspond to two similar fits)
-    \warning Use the same scale to have a useful comparison (normalized value are used)
+        \brief Growing Least Squares reparametrization of the OrientedSphereFit
+        \inherit Concept::FittingExtensionConcept
+
+        Method published in \cite Mellado:2012:GLS
+
+        This class assumes that the WeightFunc defines the accessor
+        \code
+            w.evalScale();
+        \endcode
+        in order to access to the evaluation scale, needed to compute the
+        scale invariant GLS reparametrization (all *_normalized methods).
+
+        Computed values:
+        - tau(), eta() and kappa(): the GLS descriptor
+        \f$ \left[ \tau \; \eta \; \kappa \right]\f$
+        - tau_normalized(), eta_normalized() and kappa_normalized():
+        the scale invariant GLS descriptor
+        \f$ \left[ \frac{\tau}{t} \; \eta \; t\kappa \right]\f$
+
+        Requirements:
+        \verbatim PROVIDES_ALGEBRAIC_SPHERE \endverbatim
+        Provides:
+        \verbatim PROVIDES_GLS_PARAMETRIZATION \endverbatim
     */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar compareTo (const GLSParam<DataPoint, _NFilter, T>& _other,
-                                        bool _useFitness = true) const
+    template <class DataPoint, class _NFilter, typename T>
+    class GLSParam : public T
     {
-        Scalar nTau     = this->tau_normalized()   - _other.tau_normalized();
-        Scalar nKappa   = this->kappa_normalized() - _other.kappa_normalized();
-        Scalar nFitness = _useFitness ? this->fitness() - _other.fitness() : Scalar(0.);
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
-        return nTau * nTau + nKappa * nKappa + nFitness * nFitness;
-    }
+        //! [Requirements]
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE,
+            PROVIDES_GLS_PARAMETRIZATION
+        };
+        //! [Requirements]
 
-}; //class GLSParam
+    protected:
+        Scalar m_fitness{0}; /*!< \brief Save the fitness value to avoid side effect with Pratt normalization*/
 
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(GLSParam, glsParam)
+        PONCA_FITTING_DECLARE_FINALIZE
 
-/*!
-    \brief Differentiation of GLSParam
-    \inherit Concept::FittingExtensionConcept
+        /**************************************************************************/
+        /* Use results                                                            */
+        /**************************************************************************/
+        /*! \brief Compute and return \f$ \tau \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar tau() const
+        {
+            return Base::isNormalized() ? Base::m_uc : Base::m_uc / Base::prattNorm();
+        }
 
-    Method published in \cite Mellado:2012:GLS
-*/
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-class GLSDer : public T
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
+        /*! \brief Compute and return \f$ \eta \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType eta() const { return Base::primitiveGradient(); }
 
-protected:
-    enum
-    {
-        Check = Base::PROVIDES_GLS_PARAMETRIZATION &
-                Base::PROVIDES_PRIMITIVE_DERIVATIVE &
-                Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
-        PROVIDES_GLS_DERIVATIVE,
-        PROVIDES_GLS_GEOM_VAR
-    };
+        /*! \brief Compute and return \f$ \kappa \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar kappa() const
+        {
+            return Scalar(2.) * (Base::isNormalized() ? Base::m_uq : Base::m_uq / Base::prattNorm());
+        }
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS_DER(GLSDer,glsDer)
+        /*! \brief Compute and return \f$ \frac{\tau}{t} \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar tau_normalized() const
+        {
+            return tau() / Base::getNeighborFilter().evalScale();
+        }
 
-    PONCA_MULTIARCH inline ScalarArray dtau()   const; /*!< \brief Compute and return \f$ \tau \f$ derivatives */
-    PONCA_MULTIARCH inline VectorArray deta()   const; /*!< \brief Compute and return \f$ \eta \f$ derivatives */
-    PONCA_MULTIARCH inline ScalarArray dkappa() const; /*!< \brief Compute and return \f$ \kappa \f$ derivatives */
+        /*! \brief Compute and return \f$ \eta \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType eta_normalized() const { return eta(); }
 
-    PONCA_MULTIARCH inline ScalarArray dtau_normalized()   const; /*!< \brief Compute and return \f$ \tau \f$ derivatives */
-    PONCA_MULTIARCH inline VectorArray deta_normalized()   const; /*!< \brief Compute and return \f$ t * d\eta \f$ */
-    PONCA_MULTIARCH inline ScalarArray dkappa_normalized() const; /*!< \brief Compute and return \f$ d\kappa * t^{2} \f$ */
+        /*! \brief Compute and return \f$ t \kappa \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar kappa_normalized() const
+        {
+            return kappa() * Base::getNeighborFilter().evalScale();
+        }
+
+        /*! \brief Return the fitness, e.g. the pratt norm of the initial scalar field */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar fitness() const { return m_fitness; }
+
+        /*!
+        \brief Compare current instance with other.
+        \return a distance between two fits (0 correspond to two similar fits)
+        \warning Use the same scale to have a useful comparison (normalized value are used)
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar compareTo(const GLSParam<DataPoint, _NFilter, T>& _other,
+                                                              bool _useFitness = true) const
+        {
+            Scalar nTau     = this->tau_normalized() - _other.tau_normalized();
+            Scalar nKappa   = this->kappa_normalized() - _other.kappa_normalized();
+            Scalar nFitness = _useFitness ? this->fitness() - _other.fitness() : Scalar(0.);
+
+            return nTau * nTau + nKappa * nKappa + nFitness * nFitness;
+        }
+
+    }; // class GLSParam
 
     /*!
-       \brief The Geometric Variation is computed as the weighted sum of the GLS scale-invariant partial derivatives
-       \f[
-        \nu(\mathbf{p},t) =
-        w_\tau   \left(\frac{\delta\tau}{\delta t}\right)^2 +
-        w_\eta   \left( t   \frac{\delta\eta}{\delta t}\right)^2 +
-        w_\kappa \left( t^2 \frac{\delta\kappa}{\delta t}\right)^2
-       \f]
+        \brief Differentiation of GLSParam
+        \inherit Concept::FittingExtensionConcept
 
-       Method published in \cite Mellado:2012:GLS
-       \param wtau Weight applied to \f$ \tau \f$
-       \param weta Weight applied to \f$ \eta \f$
-       \param wkappa Weight applied to \f$ \kappa \f$
-       \return
-     */
-    PONCA_MULTIARCH inline Scalar geomVar(Scalar wtau   = Scalar(1),
-                                          Scalar weta   = Scalar(1),
-                                          Scalar wkappa = Scalar(1)) const;
-}; //class GLSScaleDer
+        Method published in \cite Mellado:2012:GLS
+    */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class GLSDer : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
 
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_GLS_PARAMETRIZATION & Base::PROVIDES_PRIMITIVE_DERIVATIVE &
+                    Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
+            PROVIDES_GLS_DERIVATIVE,
+            PROVIDES_GLS_GEOM_VAR
+        };
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(GLSDer, glsDer)
+
+        PONCA_MULTIARCH inline ScalarArray dtau() const;   /*!< \brief Compute and return \f$ \tau \f$ derivatives */
+        PONCA_MULTIARCH inline VectorArray deta() const;   /*!< \brief Compute and return \f$ \eta \f$ derivatives */
+        PONCA_MULTIARCH inline ScalarArray dkappa() const; /*!< \brief Compute and return \f$ \kappa \f$ derivatives */
+
+        PONCA_MULTIARCH inline ScalarArray dtau_normalized()
+            const; /*!< \brief Compute and return \f$ \tau \f$ derivatives */
+        PONCA_MULTIARCH inline VectorArray deta_normalized() const; /*!< \brief Compute and return \f$ t * d\eta \f$ */
+        PONCA_MULTIARCH inline ScalarArray dkappa_normalized()
+            const; /*!< \brief Compute and return \f$ d\kappa * t^{2} \f$ */
+
+        /*!
+           \brief The Geometric Variation is computed as the weighted sum of the GLS scale-invariant partial derivatives
+           \f[
+            \nu(\mathbf{p},t) =
+            w_\tau   \left(\frac{\delta\tau}{\delta t}\right)^2 +
+            w_\eta   \left( t   \frac{\delta\eta}{\delta t}\right)^2 +
+            w_\kappa \left( t^2 \frac{\delta\kappa}{\delta t}\right)^2
+           \f]
+
+           Method published in \cite Mellado:2012:GLS
+           \param wtau Weight applied to \f$ \tau \f$
+           \param weta Weight applied to \f$ \eta \f$
+           \param wkappa Weight applied to \f$ \kappa \f$
+           \return
+         */
+        PONCA_MULTIARCH inline Scalar geomVar(Scalar wtau = Scalar(1), Scalar weta = Scalar(1),
+                                              Scalar wkappa = Scalar(1)) const;
+    }; // class GLSScaleDer
 
 #include "gls.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/gls.h
+++ b/Ponca/src/Fitting/gls.h
@@ -149,10 +149,10 @@ public:
        \f]
 
        Method published in \cite Mellado:2012:GLS
-       @param wtau Weight applied to \f$ \tau \f$
-       @param weta Weight applied to \f$ \eta \f$
-       @param wkappa Weight applied to \f$ \kappa \f$
-       @return
+       \param wtau Weight applied to \f$ \tau \f$
+       \param weta Weight applied to \f$ \eta \f$
+       \param wkappa Weight applied to \f$ \kappa \f$
+       \return
      */
     PONCA_MULTIARCH inline Scalar geomVar(Scalar wtau   = Scalar(1),
                                           Scalar weta   = Scalar(1),

--- a/Ponca/src/Fitting/gls.hpp
+++ b/Ponca/src/Fitting/gls.hpp
@@ -1,16 +1,15 @@
 /*
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template < class DataPoint, class _NFilter, typename T>
-inline FIT_RESULT
-GLSParam<DataPoint, _NFilter, T>::finalize()
+template <class DataPoint, class _NFilter, typename T>
+inline FIT_RESULT GLSParam<DataPoint, _NFilter, T>::finalize()
 {
     FIT_RESULT bResult = Base::finalize();
 
-    if(bResult != UNDEFINED)
+    if (bResult != UNDEFINED)
     {
         m_fitness = Scalar(1.) - Base::prattNorm2();
     }
@@ -18,36 +17,31 @@ GLSParam<DataPoint, _NFilter, T>::finalize()
     return bResult;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::ScalarArray
-GLSDer <DataPoint, _NFilter, DiffType, T>::dtau() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::ScalarArray GLSDer<DataPoint, _NFilter, DiffType, T>::dtau() const
 {
     PONCA_MULTIARCH_STD_MATH(sqrt);
 
-    Scalar prattNorm2 = Base::prattNorm2();
-    Scalar prattNorm  = sqrt(prattNorm2);
-    Scalar cfactor    = Scalar(.5) / prattNorm;
+    Scalar prattNorm2  = Base::prattNorm2();
+    Scalar prattNorm   = sqrt(prattNorm2);
+    Scalar cfactor     = Scalar(.5) / prattNorm;
     ScalarArray dfield = Base::m_dUc;
     // Recall that tau is the field function at the evaluation point, we thus must take care about
     // its variation when differentiating in space:
-    if(Base::isSpaceDer())
-      dfield.template tail<DataPoint::Dim>() += Base::m_ul;
+    if (Base::isSpaceDer())
+        dfield.template tail<DataPoint::Dim>() += Base::m_ul;
 
     return (dfield * prattNorm - Base::m_uc * cfactor * Base::dprattNorm2()) / prattNorm2;
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::VectorArray
-GLSDer <DataPoint, _NFilter, DiffType, T>::deta() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::VectorArray GLSDer<DataPoint, _NFilter, DiffType, T>::deta() const
 {
-  return Base::dNormal();
+    return Base::dNormal();
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::ScalarArray
-GLSDer <DataPoint, _NFilter, DiffType, T>::dkappa() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::ScalarArray GLSDer<DataPoint, _NFilter, DiffType, T>::dkappa() const
 {
     PONCA_MULTIARCH_STD_MATH(sqrt);
 
@@ -58,43 +52,35 @@ GLSDer <DataPoint, _NFilter, DiffType, T>::dkappa() const
     return Scalar(2.) * (Base::m_dUq * prattNorm - Base::m_uq * cfactor * Base::dprattNorm2()) / prattNorm2;
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::ScalarArray
-GLSDer <DataPoint, _NFilter, DiffType, T>::dtau_normalized() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::ScalarArray GLSDer<DataPoint, _NFilter, DiffType,
+                                                                      T>::dtau_normalized() const
 {
     return dtau();
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::VectorArray
-GLSDer <DataPoint, _NFilter, DiffType, T>::deta_normalized() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::VectorArray GLSDer<DataPoint, _NFilter, DiffType,
+                                                                      T>::deta_normalized() const
 {
     return Base::getNeighborFilter().evalScale() * deta();
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::ScalarArray
-GLSDer <DataPoint, _NFilter, DiffType, T>::dkappa_normalized() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::ScalarArray GLSDer<DataPoint, _NFilter, DiffType,
+                                                                      T>::dkappa_normalized() const
 {
     return dkappa() * Base::getNeighborFilter().evalScale() * Base::getNeighborFilter().evalScale();
 }
 
-
-
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename GLSDer <DataPoint, _NFilter, DiffType, T>::Scalar
-GLSDer <DataPoint, _NFilter, DiffType, T>::geomVar(  Scalar wtau,
-                                                      Scalar weta,
-                                                      Scalar wkappa ) const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename GLSDer<DataPoint, _NFilter, DiffType, T>::Scalar GLSDer<DataPoint, _NFilter, DiffType, T>::geomVar(
+    Scalar wtau, Scalar weta, Scalar wkappa) const
 {
-    static_assert( bool(DiffType & FitScaleDer), "Scale derivatives are required to compute Geometric Variation" );
+    static_assert(bool(DiffType & FitScaleDer), "Scale derivatives are required to compute Geometric Variation");
     Scalar dtau   = dtau_normalized().col(0)(0);
     Scalar deta   = deta_normalized().col(0).norm();
     Scalar dkappa = dkappa_normalized().col(0)(0);
 
-    return wtau*dtau*dtau + weta*deta*deta + wkappa*dkappa*dkappa;
+    return wtau * dtau * dtau + weta * deta * deta + wkappa * dkappa * dkappa;
 }

--- a/Ponca/src/Fitting/heightField.h
+++ b/Ponca/src/Fitting/heightField.h
@@ -20,39 +20,53 @@ namespace Ponca
     This primitive provides:
     \verbatim PROVIDES_HEIGHTFIELD \endverbatim
     */
-    template < class DataPoint, class _NFilter, typename T >
+    template <class DataPoint, class _NFilter, typename T>
     class HeightField : public T
     {
         PONCA_FITTING_DECLARE_DEFAULT_TYPES
-        static_assert ( DataPoint::Dim == 3, "HeightField is only valid in 3D");
+        static_assert(DataPoint::Dim == 3, "HeightField is only valid in 3D");
+
     protected:
-        enum {
+        enum
+        {
             PROVIDES_HEIGHTFIELD /*!< \brief Provides generic heightfield API */
         };
 
         /// \brief get access to height from local coordinate vector
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& getHFromLocalCoordinates (const VectorType& _lq) const
-        { return *(_lq.data()); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& getHFromLocalCoordinates(const VectorType& _lq) const
+        {
+            return *(_lq.data());
+        }
 
         /// \brief get access to height from local coordinate vector
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar& getHFromLocalCoordinates (VectorType& _lq) const
-        { return *(_lq.data()); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar& getHFromLocalCoordinates(VectorType& _lq) const
+        {
+            return *(_lq.data());
+        }
 
         /// \brief get access to u from local coordinate vector
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& getUFromLocalCoordinates (const VectorType& _lq) const
-        { return *(_lq.data()+1); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& getUFromLocalCoordinates(const VectorType& _lq) const
+        {
+            return *(_lq.data() + 1);
+        }
 
         /// \brief get access to u from local coordinate vector
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar& getUFromLocalCoordinates (VectorType& _lq) const
-        { return *(_lq.data()+1); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar& getUFromLocalCoordinates(VectorType& _lq) const
+        {
+            return *(_lq.data() + 1);
+        }
 
         /// \brief get access to v from local coordinate vector
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& getVFromLocalCoordinates (const VectorType& _lq) const
-        { return *(_lq.data()+2); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& getVFromLocalCoordinates(const VectorType& _lq) const
+        {
+            return *(_lq.data() + 2);
+        }
 
         /// \brief get access to v from local coordinate vector
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar& getVFromLocalCoordinates (VectorType& _lq)
-        { return *(_lq.data()+2); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar& getVFromLocalCoordinates(VectorType& _lq)
+        {
+            return *(_lq.data() + 2);
+        }
     };
 
     /*!
@@ -63,27 +77,27 @@ namespace Ponca
     This primitive provides:
     \verbatim PROVIDES_QUADRIC_HEIGHTFIELD \endverbatim
     */
-    template < class DataPoint, class _NFilter, typename T >
+    template <class DataPoint, class _NFilter, typename T>
     class QuadraticHeightField : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-        using HeightFieldCoefficients = Eigen::Matrix<Scalar,6,1>;
-        static_assert ( DataPoint::Dim == 3, "QuadraticHeightField is only valid in 3D");
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        using HeightFieldCoefficients = Eigen::Matrix<Scalar, 6, 1>;
+        static_assert(DataPoint::Dim == 3, "QuadraticHeightField is only valid in 3D");
 
     protected:
-        enum {
+        enum
+        {
             Check = Base::PROVIDES_HEIGHTFIELD,
             PROVIDES_QUADRIC_HEIGHTFIELD /*!< \brief Provides quadric heightfield API */
         };
         /// \brief Quadric parameters, stored as \f$[h_uu, h_vv, h_uv, h_u, h_v, h_c]\f$
-        HeightFieldCoefficients  m_coeffs {HeightFieldCoefficients::Zero()};
+        HeightFieldCoefficients m_coeffs{HeightFieldCoefficients::Zero()};
 
     public:
-
         /*! \brief Default constructor */
         PONCA_MULTIARCH inline QuadraticHeightField() : Base() { init(); }
 
-        PONCA_EXPLICIT_CAST_OPERATORS(QuadraticHeightField,quadraticHeightField)
+        PONCA_EXPLICIT_CAST_OPERATORS(QuadraticHeightField, quadraticHeightField)
 
         /// \brief Set the scalar field values
         PONCA_MULTIARCH inline void setQuadric(const HeightFieldCoefficients& coeffs) { m_coeffs = coeffs; }
@@ -100,63 +114,82 @@ namespace Ponca
         /// \brief Tell if the plane as been correctly set.
         /// Used to set CONFLICT_ERROR_FOUND during fitting
         /// \return false when called straight after #init. Should be true after fitting
-        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const{
-            return ! m_coeffs.isApprox(HeightFieldCoefficients::Zero());
+        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const
+        {
+            return !m_coeffs.isApprox(HeightFieldCoefficients::Zero());
         }
 
-        PONCA_MULTIARCH [[nodiscard]] inline bool operator==(const QuadraticHeightField<DataPoint, _NFilter, T>& other) const{
+        PONCA_MULTIARCH [[nodiscard]] inline bool operator==(
+            const QuadraticHeightField<DataPoint, _NFilter, T>& other) const
+        {
             return m_coeffs.isApprox(other.m_params);
         }
 
         /*! \brief Comparison operator, convenience function */
-        PONCA_MULTIARCH [[nodiscard]] inline bool operator!=(const QuadraticHeightField<DataPoint, _NFilter, T>& other) const{
-            return ! ((*this) == other);
+        PONCA_MULTIARCH [[nodiscard]] inline bool operator!=(
+            const QuadraticHeightField<DataPoint, _NFilter, T>& other) const
+        {
+            return !((*this) == other);
         }
 
         //! \brief Height value at local uv
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar height(Scalar u, Scalar v) const {
-            return h_uu()*u*u + h_vv()*v*v + h_uv()*u*v + h_u()*u + h_v()*v + h_c();
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar height(Scalar u, Scalar v) const
+        {
+            return h_uu() * u * u + h_vv() * v * v + h_uv() * u * v + h_u() * u + h_v() * v + h_c();
         }
 
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_uu () const { return *(m_coeffs.data()); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_vv () const { return *(m_coeffs.data()+1); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_uv () const { return *(m_coeffs.data()+2); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_u  () const { return *(m_coeffs.data()+3); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_v  () const { return *(m_coeffs.data()+4); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_c  () const { return *(m_coeffs.data()+5); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_uu() const { return *(m_coeffs.data()); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_vv() const { return *(m_coeffs.data() + 1); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_uv() const { return *(m_coeffs.data() + 2); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_u() const { return *(m_coeffs.data() + 3); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_v() const { return *(m_coeffs.data() + 4); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_c() const { return *(m_coeffs.data() + 5); }
 
         /// \brief Partial derivative \f$ \frac{\delta h }{\delta u} (u,v) = 2h_{uu} u + h_{uv} v + h_u \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_du (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_uu() * u + h_uv()*v + h_u(); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_du(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_uu() * u + h_uv() * v + h_u();
+        }
 
         /// \brief Partial derivative \f$ \frac{\delta h }{\delta v} (u,v) = 2h_{vv} v + h_{uv} u + h_v \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_dv (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_vv() * v + h_uv()*u + h_v(); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_dv(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_vv() * v + h_uv() * u + h_v();
+        }
 
         /// \brief Second order partial derivative \f$ \frac{\delta h }{\delta u^2} (u,v) = 2h_{uu} \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duu (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_uu(); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duu(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_uu();
+        }
 
         /// \brief Second order partial derivative \f$ \frac{\delta h }{\delta v} (u,v) = 2h_{vv} \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_dvv (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_vv(); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_dvv(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_vv();
+        }
 
-        /// \brief Second order partial derivative \f$ \frac{\delta }{\delta v} (\frac{\delta h }{\delta u}) (u,v) = h_{uv} \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duv (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return h_uv(); }
+        /// \brief Second order partial derivative \f$ \frac{\delta }{\delta v} (\frac{\delta h }{\delta u}) (u,v) =
+        /// h_{uv} \f$
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duv(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return h_uv();
+        }
 
         //! \brief Local tangent vector in the direction of \f$u\f$
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentULocal (const VectorType& _localQ) const {
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentULocal(const VectorType& _localQ) const
+        {
             const Scalar tu = dh_du(Base::getUFromLocalCoordinates(_localQ), Base::getVFromLocalCoordinates(_localQ));
-            return VectorType (tu, Scalar(1), Scalar(0)).normalized();
+            return VectorType(tu, Scalar(1), Scalar(0)).normalized();
         }
 
         //! \brief Local tangent vector in the direction of \f$v\f$
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentVLocal (const VectorType& _localQ) const {
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentVLocal(const VectorType& _localQ) const
+        {
             const Scalar tv = dh_dv(Base::getUFromLocalCoordinates(_localQ), Base::getVFromLocalCoordinates(_localQ));
-            return VectorType (tv, Scalar(0), Scalar(1)).normalized();
+            return VectorType(tv, Scalar(0), Scalar(1)).normalized();
         }
-    }; //class QuadraticHeightField
+    }; // class QuadraticHeightField
     /*!
      \brief Quadratic height field defined as \f$h(u,v)=h_{uu}u^2 + h_{vv}v^2 + h_{uv}uv + h_c \f$
 
@@ -168,27 +201,27 @@ namespace Ponca
      This primitive provides:
      \verbatim PROVIDES_QUADRIC_HEIGHTFIELD \endverbatim
     */
-    template < class DataPoint, class _NFilter, typename T >
+    template <class DataPoint, class _NFilter, typename T>
     class RestrictedQuadraticHeightField : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-        using HeightFieldCoefficients = Eigen::Matrix<Scalar,4,1>;
-        static_assert ( DataPoint::Dim == 3, "QuadraticHeightField is only valid in 3D");
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        using HeightFieldCoefficients = Eigen::Matrix<Scalar, 4, 1>;
+        static_assert(DataPoint::Dim == 3, "QuadraticHeightField is only valid in 3D");
 
     protected:
-        enum {
+        enum
+        {
             Check = Base::PROVIDES_HEIGHTFIELD,
             PROVIDES_RESTRICTED_QUADRIC_HEIGHTFIELD /*!< \brief Provides quadric heightfield API */
         };
         /// \brief Quadric parameters, stored as \f$[h_uu, h_vv, h_uv]\f$
-        HeightFieldCoefficients  m_coeffs {HeightFieldCoefficients::Zero()};
+        HeightFieldCoefficients m_coeffs{HeightFieldCoefficients::Zero()};
 
     public:
-
         /*! \brief Default constructor */
         PONCA_MULTIARCH inline RestrictedQuadraticHeightField() : Base() { init(); }
 
-        PONCA_EXPLICIT_CAST_OPERATORS(RestrictedQuadraticHeightField,quadraticHeightField)
+        PONCA_EXPLICIT_CAST_OPERATORS(RestrictedQuadraticHeightField, quadraticHeightField)
 
         /// \brief Set the scalar field values
         PONCA_MULTIARCH inline void setQuadric(const HeightFieldCoefficients& coeffs) { m_coeffs = coeffs; }
@@ -205,61 +238,80 @@ namespace Ponca
         /// \brief Tell if the plane as been correctly set.
         /// Used to set CONFLICT_ERROR_FOUND during fitting
         /// \return false when called straight after #init. Should be true after fitting
-        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const{
-            return ! m_coeffs.isApprox(HeightFieldCoefficients::Zero());
+        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const
+        {
+            return !m_coeffs.isApprox(HeightFieldCoefficients::Zero());
         }
 
-        PONCA_MULTIARCH [[nodiscard]] inline bool operator==(const RestrictedQuadraticHeightField<DataPoint, _NFilter, T>& other) const{
+        PONCA_MULTIARCH [[nodiscard]] inline bool operator==(
+            const RestrictedQuadraticHeightField<DataPoint, _NFilter, T>& other) const
+        {
             return m_coeffs.isApprox(other.m_params);
         }
 
         /*! \brief Comparison operator, convenience function */
-        PONCA_MULTIARCH [[nodiscard]] inline bool operator!=(const RestrictedQuadraticHeightField<DataPoint, _NFilter, T>& other) const{
-            return ! ((*this) == other);
+        PONCA_MULTIARCH [[nodiscard]] inline bool operator!=(
+            const RestrictedQuadraticHeightField<DataPoint, _NFilter, T>& other) const
+        {
+            return !((*this) == other);
         }
 
         //! \brief Height value at local uv
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar height(Scalar u, Scalar v) const {
-            return h_uu()*u*u + h_vv()*v*v + h_uv()*u*v + h_c();
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar height(Scalar u, Scalar v) const
+        {
+            return h_uu() * u * u + h_vv() * v * v + h_uv() * u * v + h_c();
         }
 
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_uu () const { return *(m_coeffs.data()); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_vv () const { return *(m_coeffs.data()+1); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_uv () const { return *(m_coeffs.data()+2); }
-        PONCA_MULTIARCH [[nodiscard]] inline const Scalar & h_c ()  const { return *(m_coeffs.data()+3); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_uu() const { return *(m_coeffs.data()); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_vv() const { return *(m_coeffs.data() + 1); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_uv() const { return *(m_coeffs.data() + 2); }
+        PONCA_MULTIARCH [[nodiscard]] inline const Scalar& h_c() const { return *(m_coeffs.data() + 3); }
 
         /// \brief Partial derivative \f$ \frac{\delta h }{\delta u} (u,v) = 2h_{uu} u + h_{uv} v\f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_du (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_uu() * u + h_uv()*v; }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_du(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_uu() * u + h_uv() * v;
+        }
 
         /// \brief Partial derivative \f$ \frac{\delta h }{\delta v} (u,v) = 2h_{vv} v + h_{uv} u\f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_dv (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_vv() * v + h_uv()*u ; }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dh_dv(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_vv() * v + h_uv() * u;
+        }
 
         /// \brief Second order partial derivative \f$ \frac{\delta h }{\delta u^2} (u,v) = 2h_{uu} \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duu (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_uu(); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duu(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_uu();
+        }
 
         /// \brief Second order partial derivative \f$ \frac{\delta h }{\delta v} (u,v) = 2h_{vv} \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_dvv (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return Scalar(2)*h_vv(); }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_dvv(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return Scalar(2) * h_vv();
+        }
 
-        /// \brief Second order partial derivative \f$ \frac{\delta }{\delta v} (\frac{\delta h }{\delta u}) (u,v) = h_{uv} \f$
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duv (Scalar u = Scalar(0), Scalar v = Scalar(0)) const
-        { return h_uv(); }
+        /// \brief Second order partial derivative \f$ \frac{\delta }{\delta v} (\frac{\delta h }{\delta u}) (u,v) =
+        /// h_{uv} \f$
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar d2h_duv(Scalar u = Scalar(0), Scalar v = Scalar(0)) const
+        {
+            return h_uv();
+        }
 
         //! \brief Local tangent vector in the direction of \f$u\f$
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentULocal (const VectorType& _localQ) const {
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentULocal(const VectorType& _localQ) const
+        {
             const Scalar tu = dh_du(Base::getUFromLocalCoordinates(_localQ), Base::getVFromLocalCoordinates(_localQ));
-            return VectorType (tu, Scalar(1), Scalar(0)).normalized();
+            return VectorType(tu, Scalar(1), Scalar(0)).normalized();
         }
 
         //! \brief Local tangent vector in the direction of \f$v\f$
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentVLocal (const VectorType& _localQ) const {
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType heightTangentVLocal(const VectorType& _localQ) const
+        {
             const Scalar tv = dh_dv(Base::getUFromLocalCoordinates(_localQ), Base::getVFromLocalCoordinates(_localQ));
-            return VectorType (tv, Scalar(0), Scalar(1)).normalized();
+            return VectorType(tv, Scalar(0), Scalar(1)).normalized();
         }
-    }; //class RestrictedQuadraticHeightField
+    }; // class RestrictedQuadraticHeightField
 
-} //namespace Ponca
+} // namespace Ponca
 

--- a/Ponca/src/Fitting/linePrimitive.h
+++ b/Ponca/src/Fitting/linePrimitive.h
@@ -1,7 +1,7 @@
 
 /*
  Copyright (C) 2021 aniket agarwalla <aniketagarwalla37@gmail.com>
- 
+
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -16,124 +16,126 @@
 namespace Ponca
 {
 
-/*!
-    \brief A parametrized line is defined by an origin point \f$\mathbf{o}\f$ and a unit direction vector
-    \f$\overrightarrow{\mathbf{d}}\f$ such that the line corresponds to the set
-    \f$l(t)=\mathbf{o}+t\overrightarrow{\mathbf{d}}, t\in \mathbb{R}\f$.
-
-    This class inherits Eigen::ParametrizedLine.
-
-    This primitive requires the definition of n-d vectors
-    (VectorType) in Concept::PointConcept.
-
-    This primitive provides:
-    \verbatim PROVIDES_LINE \endverbatim
-*/
-
-template < class DataPoint, class _NFilter, typename T >
-class Line : public T,
-             public Eigen::ParametrizedLine<typename DataPoint::Scalar, DataPoint::Dim >
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-
-public:
-    /// \brief Specialization of Eigen::ParametrizedLine inherited by Ponca::Line
-    using EigenBase = Eigen::ParametrizedLine<typename DataPoint::Scalar, DataPoint::Dim >;
-
-protected:
-
-    enum
-    {
-        check = Base::PROVIDES_PRIMITIVE_BASE,  /*!< \brief Requires PrimitiveBase */
-        PROVIDES_LINE                           /*!< \brief Provides  Line */
-    };
-
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(Line,line)
-
     /*!
-     * \brief Set the scalar field values to 0 and reset the distance() and origin() status
+        \brief A parametrized line is defined by an origin point \f$\mathbf{o}\f$ and a unit direction vector
+        \f$\overrightarrow{\mathbf{d}}\f$ such that the line corresponds to the set
+        \f$l(t)=\mathbf{o}+t\overrightarrow{\mathbf{d}}, t\in \mathbb{R}\f$.
+
+        This class inherits Eigen::ParametrizedLine.
+
+        This primitive requires the definition of n-d vectors
+        (VectorType) in Concept::PointConcept.
+
+        This primitive provides:
+        \verbatim PROVIDES_LINE \endverbatim
     */
-    PONCA_MULTIARCH inline void init()
+
+    template <class DataPoint, class _NFilter, typename T>
+    class Line : public T, public Eigen::ParametrizedLine<typename DataPoint::Scalar, DataPoint::Dim>
     {
-        Base::init();
-        EigenBase::origin().setZero();
-        EigenBase::direction().setZero();
-    }
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
-    /// \brief Tell if the line as been correctly set.
-    /// Used to set CONFLICT_ERROR_FOUND during fitting
-    /// \return false when called straight after #init. Should be true after fitting
-    PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const{
-        static const typename EigenBase::VectorType zeros = EigenBase::VectorType::Zero();
-        return ! ( EigenBase::origin().isApprox(zeros) && EigenBase::direction().isApprox(zeros) ) ;
-    }
+    public:
+        /// \brief Specialization of Eigen::ParametrizedLine inherited by Ponca::Line
+        using EigenBase = Eigen::ParametrizedLine<typename DataPoint::Scalar, DataPoint::Dim>;
 
-    /*! \brief Comparison operator */
-    PONCA_MULTIARCH inline bool operator==(const Line<DataPoint, NeighborFilter, T>& other) const{
-        return EigenBase::isApprox(other);
-    }
+    protected:
+        enum
+        {
+            check = Base::PROVIDES_PRIMITIVE_BASE, /*!< \brief Requires PrimitiveBase */
+            PROVIDES_LINE                          /*!< \brief Provides  Line */
+        };
 
-    /*! \brief Comparison operator, convenience function */
-    PONCA_MULTIARCH inline bool operator!=(const Line<DataPoint, NeighborFilter, T>& other) const{
-        return ! ((*this) == other);
-    }
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(Line, line)
 
-    /*! \brief Init the line from a direction and a position
-       \param direction Orientation of the line, does not need to be normalized
-       \param origin Position of the line
-    */
-    PONCA_MULTIARCH inline void setLine (const VectorType& origin,
-                                         const VectorType& direction)
-    {
-        EigenBase* cc = static_cast<EigenBase*>(this);
-        *cc = EigenBase(origin, direction);
-    }
+        /*!
+         * \brief Set the scalar field values to 0 and reset the distance() and origin() status
+         */
+        PONCA_MULTIARCH inline void init()
+        {
+            Base::init();
+            EigenBase::origin().setZero();
+            EigenBase::direction().setZero();
+        }
 
-    /*!
-     \brief Express the line relatively to a new basis
-    */
-    PONCA_MULTIARCH inline void changeBasis(const VectorType& newbasis)
-    {
-        VectorType diff = Base::getNeighborFilter().evalPos() - newbasis;
-        Base::m_nFilter.changeNeighborhoodFrame(newbasis);
-        Base::init();
-        EigenBase::origin() += diff;
-    }
+        /// \brief Tell if the line as been correctly set.
+        /// Used to set CONFLICT_ERROR_FOUND during fitting
+        /// \return false when called straight after #init. Should be true after fitting
+        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const
+        {
+            static const typename EigenBase::VectorType zeros = EigenBase::VectorType::Zero();
+            return !(EigenBase::origin().isApprox(zeros) && EigenBase::direction().isApprox(zeros));
+        }
 
-    //! \brief Value of the scalar field at the evaluation point
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potential ( ) const
-    {
-        // The potential is the distance from a point to the line
-        return EigenBase::squaredDistance(VectorType::Zero());
-    }
+        /*! \brief Comparison operator */
+        PONCA_MULTIARCH inline bool operator==(const Line<DataPoint, NeighborFilter, T>& other) const
+        {
+            return EigenBase::isApprox(other);
+        }
 
-    /*!  \brief Value of the scalar field at the location \f$ \mathbf{q} \f$,
-     * defined as the squared distance between \f$ \mathbf{q} \f$ and the line
-     *  \see method `#isSigned` of the fit to check if the sign is reliable
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potential (const VectorType& _q) const
-    {
-        // Turn to centered basis
-        const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
-        // The potential is the distance from a point to the line
-        return potentialLocal(lq);
-    }
+        /*! \brief Comparison operator, convenience function */
+        PONCA_MULTIARCH inline bool operator!=(const Line<DataPoint, NeighborFilter, T>& other) const
+        {
+            return !((*this) == other);
+        }
 
-    //! \brief Project a point on the line
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType project (const VectorType& _q) const
-    {
-        // Project on the normal vector and add the offset value
-        return Base::getNeighborFilter().convertToGlobalBasis(EigenBase::projection(Base::getNeighborFilter().convertToLocalBasis(_q)));
-    }
-protected:
-    /// \copydoc Line::potential
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal (const VectorType& _lq) const {
-        // The potential is the distance from a point to the line
-        return EigenBase::squaredDistance(_lq);
-    }
-}; //class Line
+        /*! \brief Init the line from a direction and a position
+           \param direction Orientation of the line, does not need to be normalized
+           \param origin Position of the line
+        */
+        PONCA_MULTIARCH inline void setLine(const VectorType& origin, const VectorType& direction)
+        {
+            EigenBase* cc = static_cast<EigenBase*>(this);
+            *cc           = EigenBase(origin, direction);
+        }
 
+        /*!
+         \brief Express the line relatively to a new basis
+        */
+        PONCA_MULTIARCH inline void changeBasis(const VectorType& newbasis)
+        {
+            VectorType diff = Base::getNeighborFilter().evalPos() - newbasis;
+            Base::m_nFilter.changeNeighborhoodFrame(newbasis);
+            Base::init();
+            EigenBase::origin() += diff;
+        }
 
-}
+        //! \brief Value of the scalar field at the evaluation point
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential() const
+        {
+            // The potential is the distance from a point to the line
+            return EigenBase::squaredDistance(VectorType::Zero());
+        }
+
+        /*!  \brief Value of the scalar field at the location \f$ \mathbf{q} \f$,
+         * defined as the squared distance between \f$ \mathbf{q} \f$ and the line
+         *  \see method `#isSigned` of the fit to check if the sign is reliable
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential(const VectorType& _q) const
+        {
+            // Turn to centered basis
+            const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
+            // The potential is the distance from a point to the line
+            return potentialLocal(lq);
+        }
+
+        //! \brief Project a point on the line
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType project(const VectorType& _q) const
+        {
+            // Project on the normal vector and add the offset value
+            return Base::getNeighborFilter().convertToGlobalBasis(
+                EigenBase::projection(Base::getNeighborFilter().convertToLocalBasis(_q)));
+        }
+
+    protected:
+        /// \copydoc Line::potential
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal(const VectorType& _lq) const
+        {
+            // The potential is the distance from a point to the line
+            return EigenBase::squaredDistance(_lq);
+        }
+    }; // class Line
+
+} // namespace Ponca

--- a/Ponca/src/Fitting/mean.h
+++ b/Ponca/src/Fitting/mean.h
@@ -9,44 +9,50 @@
 #include "./defines.h"
 #include "./primitive.h"
 
-namespace Ponca {
+namespace Ponca
+{
 
-/*!
-    \brief Compute the barycenter of the input points
-    \inherit Concept::FittingProcedureConcept
+    /*!
+        \brief Compute the barycenter of the input points
+        \inherit Concept::FittingProcedureConcept
 
-    \warning The barycenter is not stored explicitly, but rather computed from the sum of the neighbors positions.
+        \warning The barycenter is not stored explicitly, but rather computed from the sum of the neighbors positions.
 
-    This primitive provides:
-    \verbatim PROVIDES_MEAN_POSITION \endverbatim
-*/
-    template<class DataPoint, class _NFilter, typename T>
-    class MeanPosition : public T {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        This primitive provides:
+        \verbatim PROVIDES_MEAN_POSITION \endverbatim
+    */
+    template <class DataPoint, class _NFilter, typename T>
+    class MeanPosition : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
     protected:
-        enum { PROVIDES_MEAN_POSITION };
-        VectorType m_sumP {VectorType::Zero()}; /*!< \brief Sum of the input points vectors */
+        enum
+        {
+            PROVIDES_MEAN_POSITION
+        };
+        VectorType m_sumP{VectorType::Zero()}; /*!< \brief Sum of the input points vectors */
 
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS(MeanPosition,meanPosition)
+        PONCA_EXPLICIT_CAST_OPERATORS(MeanPosition, meanPosition)
         PONCA_FITTING_DECLARE_INIT
         PONCA_FITTING_DECLARE_ADDNEIGHBOR
 
         /// \brief Barycenter of the input points expressed in the global frame
         ///
-        /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
-        ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in \f$\mathbf{x}\f$'s neighborhood
-        PONCA_MULTIARCH inline VectorType barycenter() const {
-            return Base::getNeighborFilter().convertToGlobalBasis( barycenterLocal() );
+        /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i
+        /// w_\mathbf{x}(\mathbf{p_i})} \f$,
+        ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in
+        ///  \f$\mathbf{x}\f$'s neighborhood
+        PONCA_MULTIARCH inline VectorType barycenter() const
+        {
+            return Base::getNeighborFilter().convertToGlobalBasis(barycenterLocal());
         }
 
         /*! \brief The distance between the barycenter and the basis center.
             \return 0 for invalid fits
         */
-        PONCA_MULTIARCH inline Scalar barycenterDistance() const {
-            return barycenterLocal().norm();
-        }
+        PONCA_MULTIARCH inline Scalar barycenterDistance() const { return barycenterLocal().norm(); }
 
     protected:
         /// \brief Barycenter of the input points expressed in the local frame
@@ -55,78 +61,85 @@ namespace Ponca {
         /// \warning Provided for internal use only: any access to the barycenter in other computing classes must be
         /// done using this function and not #barycenter()
         ///
-        /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
+        /// Defined as \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i
+        /// w_\mathbf{x}(\mathbf{p_i})} \f$,
         ///  where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in
         /// \f$\mathbf{x}\f$'s neighborhood
-        PONCA_MULTIARCH inline VectorType barycenterLocal() const {
-            return (m_sumP / Base::getWeightSum());
-        }
+        PONCA_MULTIARCH inline VectorType barycenterLocal() const { return (m_sumP / Base::getWeightSum()); }
 
-    }; //class MeanPosition
+    }; // class MeanPosition
 
-/*!
-    \brief Compute the mean normal of the input points
-    \inherit Concept::FittingProcedureConcept
+    /*!
+        \brief Compute the mean normal of the input points
+        \inherit Concept::FittingProcedureConcept
 
-    \warning The mean normal is not stored explicitly, but rather computed from the sum of the neighbors normals.
+        \warning The mean normal is not stored explicitly, but rather computed from the sum of the neighbors normals.
 
-    This primitive provides:
-    \verbatim PROVIDES_MEAN_NORMAL \endverbatim
+        This primitive provides:
+        \verbatim PROVIDES_MEAN_NORMAL \endverbatim
 
-    \see MeanNormalDer
-*/
-    template<class DataPoint, class _NFilter, typename T>
-    class MeanNormal : public T {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        \see MeanNormalDer
+    */
+    template <class DataPoint, class _NFilter, typename T>
+    class MeanNormal : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
     protected:
-        enum { PROVIDES_MEAN_NORMAL };
-        VectorType m_sumN {VectorType::Zero()};    /*!< \brief Sum of the normal vectors */
+        enum
+        {
+            PROVIDES_MEAN_NORMAL
+        };
+        VectorType m_sumN{VectorType::Zero()}; /*!< \brief Sum of the normal vectors */
 
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS(MeanNormal,meanNormal)
+        PONCA_EXPLICIT_CAST_OPERATORS(MeanNormal, meanNormal)
         PONCA_FITTING_DECLARE_INIT
         PONCA_FITTING_DECLARE_ADDNEIGHBOR
 
         /// \brief Mean of the normals of the input points
         ///
-        /// Defined as \f$ n(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
-        ///  where \f$\left[\mathbf{p_i}, \mathbf{n_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point and normal samples in \f$\mathbf{x}\f$'s neighborhood
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType meanNormalVector() const {
+        /// Defined as \f$ n(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i}}{\sum_i
+        /// w_\mathbf{x}(\mathbf{p_i})} \f$,
+        ///  where \f$\left[\mathbf{p_i}, \mathbf{n_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point
+        ///  and normal samples in \f$\mathbf{x}\f$'s neighborhood
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType meanNormalVector() const
+        {
             return (m_sumN / Base::getWeightSum());
         }
 
-    }; //class MeanNormal
+    }; // class MeanNormal
 
-/*!
-    \brief Compute the derivatives of the input points barycenter
-    \inherit Concept::FittingProcedureConcept
+    /*!
+        \brief Compute the derivatives of the input points barycenter
+        \inherit Concept::FittingProcedureConcept
 
-    This primitive requires:
-    \verbatim PROVIDES_PRIMITIVE_DERIVATIVE, PROVIDES_MEAN_POSITION\endverbatim
+        This primitive requires:
+        \verbatim PROVIDES_PRIMITIVE_DERIVATIVE, PROVIDES_MEAN_POSITION\endverbatim
 
-    This primitive provides:
-    \verbatim PROVIDES_MEAN_POSITION_DERIVATIVE \endverbatim
+        This primitive provides:
+        \verbatim PROVIDES_MEAN_POSITION_DERIVATIVE \endverbatim
 
-    \see MeanNormal
-*/
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
-    class MeanPositionDer : public T {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
+        \see MeanNormal
+    */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class MeanPositionDer : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
 
     protected:
-        enum {
-            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE &&
-                    Base::PROVIDES_MEAN_POSITION,
-            PROVIDES_MEAN_POSITION_DERIVATIVE,    /*!< \brief Provides derivative of the mean position*/
+        enum
+        {
+            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE && Base::PROVIDES_MEAN_POSITION,
+            PROVIDES_MEAN_POSITION_DERIVATIVE, /*!< \brief Provides derivative of the mean position*/
         };
 
         /*! \brief Derivatives of the input points vectors */
-        VectorArray m_dSumP {VectorArray::Zero()};
+        VectorArray m_dSumP{VectorArray::Zero()};
 
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS_DER(MeanPositionDer,meanPositionDer)
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(MeanPositionDer, meanPositionDer)
         PONCA_FITTING_DECLARE_INIT
         PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER
 
@@ -134,90 +147,103 @@ namespace Ponca {
         /// \see MeanPosition::barycenterLocal()
         ///
         /// ### Step-by-step derivation from the barycenter definition
-        /// Given the definition of the barycenter \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
-        /// where \f$\left[\mathbf{p_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in \f$\mathbf{x}\f$'s neighborhood.
+        /// Given the definition of the barycenter \f$ b(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i})
+        /// \mathbf{p_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$, where \f$\left[\mathbf{p_i} \in
+        /// \text{neighborhood}(\mathbf{x})\right]\f$ are all the point samples in \f$\mathbf{x}\f$'s neighborhood.
         ///
-        /// We denote \f$ t(\mathbf{x}) = \sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i} \f$ and \f$ s(\mathbf{x}) = \sum_i w_\mathbf{x}(\mathbf{p_i})\f$,
-        /// such that \f$ b(\mathbf{x}) = \frac{t(\mathbf{x})}{s(\mathbf{x})}\f$.
+        /// We denote \f$ t(\mathbf{x}) = \sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i} \f$ and \f$ s(\mathbf{x}) =
+        /// \sum_i w_\mathbf{x}(\mathbf{p_i})\f$, such that \f$ b(\mathbf{x}) = \frac{t(\mathbf{x})}{s(\mathbf{x})}\f$.
         ///
-        /// By definition, \f$ b'(\mathbf{x}) = \frac{s(\mathbf{x})t'(\mathbf{x}) - t(\mathbf{x})s'(\mathbf{x})}{s(\mathbf{x})^2}\f$.
-        /// We have \f$ s'(\mathbf{x}) = \sum_i w'_\mathbf{x}(\mathbf{p_i}) \f$.
+        /// By definition, \f$ b'(\mathbf{x}) = \frac{s(\mathbf{x})t'(\mathbf{x}) -
+        /// t(\mathbf{x})s'(\mathbf{x})}{s(\mathbf{x})^2}\f$. We have \f$ s'(\mathbf{x}) = \sum_i
+        /// w'_\mathbf{x}(\mathbf{p_i}) \f$.
         ///
-        /// We rewrite \f$ t(\mathbf{x}) = \sum u(\mathbf{x})v(\mathbf{x}) \f$, with \f$ u(\mathbf{x}) = w_\mathbf{x}(\mathbf{p_i}) \f$ and \f$ v(\mathbf{x}) = \mathbf{p_i} \f$.
+        /// We rewrite \f$ t(\mathbf{x}) = \sum u(\mathbf{x})v(\mathbf{x}) \f$, with \f$ u(\mathbf{x}) =
+        /// w_\mathbf{x}(\mathbf{p_i}) \f$ and \f$ v(\mathbf{x}) = \mathbf{p_i} \f$.
         ///
-        /// As the point cloud coordinates are constants, \f$v(\mathbf{x})\f$ is constant, its derivative is null, and so \f$  t'(\mathbf{x}) = \sum_i u'(\mathbf{x}) v(\mathbf{x}) = \sum_i w'_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i} \f$.
+        /// As the point cloud coordinates are constants, \f$v(\mathbf{x})\f$ is constant, its derivative is null, and
+        /// so \f$  t'(\mathbf{x}) = \sum_i u'(\mathbf{x}) v(\mathbf{x}) = \sum_i w'_\mathbf{x}(\mathbf{p_i})
+        /// \mathbf{p_i} \f$.
         ///
-        /// Which leads to \f$ b'(\mathbf{x}) = \frac{\sum_i w'_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i} - b(\mathbf{x})\sum w'(\mathbf{x})}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$
+        /// Which leads to \f$ b'(\mathbf{x}) = \frac{\sum_i w'_\mathbf{x}(\mathbf{p_i}) \mathbf{p_i} -
+        /// b(\mathbf{x})\sum w'(\mathbf{x})}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$
         ///
         /// \note This code is not directly tested, but rather indirectly by testing CovariancePlaneDer::dNormal()
         PONCA_MULTIARCH [[nodiscard]] VectorArray barycenterDerivatives() const
         {
-            return ( m_dSumP - Base::barycenterLocal() * Base::m_dSumW ) / Base::getWeightSum();
+            return (m_dSumP - Base::barycenterLocal() * Base::m_dSumW) / Base::getWeightSum();
         }
 
-    }; //class MeanPositionDer
+    }; // class MeanPositionDer
 
-/*!
-    \brief Compute the derivatives of the input points mean normal
-    \inherit Concept::FittingProcedureConcept
+    /*!
+        \brief Compute the derivatives of the input points mean normal
+        \inherit Concept::FittingProcedureConcept
 
-    This primitive requires:
-    \verbatim PROVIDES_PRIMITIVE_DERIVATIVE, PROVIDES_MEAN_NORMAL\endverbatim
+        This primitive requires:
+        \verbatim PROVIDES_PRIMITIVE_DERIVATIVE, PROVIDES_MEAN_NORMAL\endverbatim
 
-    This primitive provides:
-    \verbatim PROVIDES_MEAN_NORMAL_DERIVATIVE \endverbatim
+        This primitive provides:
+        \verbatim PROVIDES_MEAN_NORMAL_DERIVATIVE \endverbatim
 
-    \see MeanNormal
-*/
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
-    class MeanNormalDer : public T {
+        \see MeanNormal
+    */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class MeanNormalDer : public T
+    {
         PONCA_FITTING_DECLARE_DEFAULT_TYPES
         PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
 
     protected:
-        enum {
-            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE && 
-                    Base::PROVIDES_MEAN_NORMAL,
-            PROVIDES_MEAN_NORMAL_DERIVATIVE,  /*!< \brief Provides derivative of the mean normal*/
+        enum
+        {
+            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE && Base::PROVIDES_MEAN_NORMAL,
+            PROVIDES_MEAN_NORMAL_DERIVATIVE, /*!< \brief Provides derivative of the mean normal*/
         };
 
         /*! \brief Derivatives of the input normals of the input points vectors*/
-        VectorArray m_dSumN {VectorArray::Zero()};
+        VectorArray m_dSumN{VectorArray::Zero()};
 
     public:
-
-        PONCA_EXPLICIT_CAST_OPERATORS_DER(MeanNormalDer,meanNormalDer)
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(MeanNormalDer, meanNormalDer)
         PONCA_FITTING_DECLARE_INIT
         PONCA_FITTING_DECLARE_ADDNEIGHBOR_DER
 
-    /// \brief Compute the derivative of the mean normal vector of the input points. 
-    /// 
-    /// ### Step-by-step derivation of the mean normal : 
-    ///  Given the definition of the mean normal \f$ n(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$, 
-    /// where \f$\left[\mathbf{p_i}, \mathbf{n_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point and normal samples in \f$\mathbf{x}\f$'s neighborhood.
-    ///
-    /// We denote \f$ t(\mathbf{x}) = \sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i} \f$ and \f$ s(\mathbf{x}) = \sum_i w_\mathbf{x}(\mathbf{p_i})\f$, 
-    /// such that \f$ n(\mathbf{x}) = \frac{t(\mathbf{x})}{s(\mathbf{x})}\f$.
-    ///
-    /// By definition, \f$ n'(\mathbf{x}) = \frac{s(\mathbf{x})t'(\mathbf{x}) - t(\mathbf{x})s'(\mathbf{x})}{s(\mathbf{x})^2}\f$.
-    ///
-    /// Assuming the weight of each normal is dependent on the position, we have \f$ s'(\mathbf{x}) = \sum_i w'_\mathbf{x}(\mathbf{p_i}) \f$.
-    ///
-    /// We rewrite \f$ t(\mathbf{x}) = \sum u(\mathbf{x})v(\mathbf{x}) \f$, with \f$ u(\mathbf{x}) = w_\mathbf{x}(\mathbf{p_i}) \f$ and \f$ v(\mathbf{x}) = \mathbf{n_i} \f$.
-    ///
-    /// Assuming the normal vectors themselves do not change with position, \f$v(\mathbf{x})\f$ is constant, its derivative is null, 
-    /// and so \f$ t'(\mathbf{x}) = \sum_i u'(\mathbf{x}) v(\mathbf{x}) = \sum_i w'_\mathbf{x}(\mathbf{n_i}) \mathbf{n_i} \f$.
-    ///
-    /// Which leads to \f$ n'(\mathbf{x}) = \frac{\sum_i w'_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i} - n(\mathbf{x})\sum_i w'_\mathbf{x}(\mathbf{p_i})}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$.
-    /// \note This code is not directly tested. 
+        /// \brief Compute the derivative of the mean normal vector of the input points.
+        ///
+        /// ### Step-by-step derivation of the mean normal :
+        ///  Given the definition of the mean normal \f$ n(\mathbf{x}) = \frac{\sum_i w_\mathbf{x}(\mathbf{p_i})
+        ///  \mathbf{n_i}}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$,
+        /// where \f$\left[\mathbf{p_i}, \mathbf{n_i} \in \text{neighborhood}(\mathbf{x})\right]\f$ are all the point
+        /// and normal samples in \f$\mathbf{x}\f$'s neighborhood.
+        ///
+        /// We denote \f$ t(\mathbf{x}) = \sum_i w_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i} \f$ and \f$ s(\mathbf{x}) =
+        /// \sum_i w_\mathbf{x}(\mathbf{p_i})\f$, such that \f$ n(\mathbf{x}) = \frac{t(\mathbf{x})}{s(\mathbf{x})}\f$.
+        ///
+        /// By definition, \f$ n'(\mathbf{x}) = \frac{s(\mathbf{x})t'(\mathbf{x}) -
+        /// t(\mathbf{x})s'(\mathbf{x})}{s(\mathbf{x})^2}\f$.
+        ///
+        /// Assuming the weight of each normal is dependent on the position, we have \f$ s'(\mathbf{x}) = \sum_i
+        /// w'_\mathbf{x}(\mathbf{p_i}) \f$.
+        ///
+        /// We rewrite \f$ t(\mathbf{x}) = \sum u(\mathbf{x})v(\mathbf{x}) \f$, with \f$ u(\mathbf{x}) =
+        /// w_\mathbf{x}(\mathbf{p_i}) \f$ and \f$ v(\mathbf{x}) = \mathbf{n_i} \f$.
+        ///
+        /// Assuming the normal vectors themselves do not change with position, \f$v(\mathbf{x})\f$ is constant, its
+        /// derivative is null, and so \f$ t'(\mathbf{x}) = \sum_i u'(\mathbf{x}) v(\mathbf{x}) = \sum_i
+        /// w'_\mathbf{x}(\mathbf{n_i}) \mathbf{n_i} \f$.
+        ///
+        /// Which leads to \f$ n'(\mathbf{x}) = \frac{\sum_i w'_\mathbf{x}(\mathbf{p_i}) \mathbf{n_i} -
+        /// n(\mathbf{x})\sum_i w'_\mathbf{x}(\mathbf{p_i})}{\sum_i w_\mathbf{x}(\mathbf{p_i})} \f$.
+        /// \note This code is not directly tested.
 
-    PONCA_MULTIARCH [[nodiscard]] VectorArray dMeanNormal() const
-    { 
-        return ( m_dSumN - Base::meanNormalVector() * Base::m_dSumW ) / Base::getWeightSum(); 
-    }
+        PONCA_MULTIARCH [[nodiscard]] VectorArray dMeanNormal() const
+        {
+            return (m_dSumN - Base::meanNormalVector() * Base::m_dSumW) / Base::getWeightSum();
+        }
 
-    }; //class MeanNormalDer
+    }; // class MeanNormalDer
 
 #include "mean.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/mean.hpp
+++ b/Ponca/src/Fitting/mean.hpp
@@ -7,61 +7,57 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-template<class DataPoint, class _NFilter, typename T>
-void
-MeanPosition<DataPoint, _NFilter, T>::init() {
+template <class DataPoint, class _NFilter, typename T>
+void MeanPosition<DataPoint, _NFilter, T>::init()
+{
     Base::init();
     m_sumP = VectorType::Zero();
 }
 
-template<class DataPoint, class _NFilter, typename T>
-bool
-MeanPosition<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                        const VectorType &localQ,
-                                                        const DataPoint &attributes) {
-    if( Base::addLocalNeighbor(w, localQ, attributes) ) {
+template <class DataPoint, class _NFilter, typename T>
+bool MeanPosition<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                            const DataPoint& attributes)
+{
+    if (Base::addLocalNeighbor(w, localQ, attributes))
+    {
         m_sumP += w * localQ;
         return true;
     }
     return false;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-void
-MeanNormal<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void MeanNormal<DataPoint, _NFilter, T>::init()
 {
     Base::init();
     m_sumN = VectorType::Zero();
 }
 
-
-template<class DataPoint, class _NFilter, typename T>
-bool
-MeanNormal<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                      const VectorType &localQ,
-                                                      const DataPoint &attributes) {
-    if( Base::addLocalNeighbor(w, localQ, attributes) ) {
+template <class DataPoint, class _NFilter, typename T>
+bool MeanNormal<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                          const DataPoint& attributes)
+{
+    if (Base::addLocalNeighbor(w, localQ, attributes))
+    {
         m_sumN += w * attributes.normal();
         return true;
     }
     return false;
 }
 
-template<class DataPoint, class _NFilter, int DiffType, typename T>
-void
-MeanPositionDer<DataPoint, _NFilter, DiffType, T>::init() {
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+void MeanPositionDer<DataPoint, _NFilter, DiffType, T>::init()
+{
     Base::init();
     m_dSumP.setZero();
 }
 
-
-template<class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-MeanPositionDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
-                                                                 const VectorType &localQ,
-                                                                 const DataPoint &attributes,
-                                                                 ScalarArray &dw) {
-    if (Base::addLocalNeighbor(w, localQ, attributes, dw)) {
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+bool MeanPositionDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                         const DataPoint& attributes, ScalarArray& dw)
+{
+    if (Base::addLocalNeighbor(w, localQ, attributes, dw))
+    {
         m_dSumP += localQ * dw;
         return true;
     }
@@ -69,21 +65,19 @@ MeanPositionDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
     return false;
 }
 
-
-template<class DataPoint, class _NFilter, int DiffType, typename T>
-void
-MeanNormalDer<DataPoint, _NFilter, DiffType, T>::init() {
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+void MeanNormalDer<DataPoint, _NFilter, DiffType, T>::init()
+{
     Base::init();
     m_dSumN.setZero();
 }
 
-template<class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-MeanNormalDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
-                                                                 const VectorType &localQ,
-                                                                 const DataPoint &attributes,
-                                                                 ScalarArray &dw) {
-    if (Base::addLocalNeighbor(w, localQ, attributes, dw)) {
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+bool MeanNormalDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                       const DataPoint& attributes, ScalarArray& dw)
+{
+    if (Base::addLocalNeighbor(w, localQ, attributes, dw))
+    {
         m_dSumN += attributes.normal() * dw;
         return true;
     }

--- a/Ponca/src/Fitting/meanPlaneFit.h
+++ b/Ponca/src/Fitting/meanPlaneFit.h
@@ -14,49 +14,51 @@
 namespace Ponca
 {
 
-/*!
-    \brief Plane fitting procedure computing the mean position and orientation
-    from oriented points
+    /*!
+        \brief Plane fitting procedure computing the mean position and orientation
+        from oriented points
 
-    \inherit Concept::FittingProcedureConcept
+        \inherit Concept::FittingProcedureConcept
 
-    \see Plane
+        \see Plane
 
-    \todo Add local frame computation to enable PROVIDES_TANGENT_PLANE_BASIS
-*/
-template < class DataPoint, class _NFilter, typename T >
-class MeanPlaneFitImpl : public T
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-PONCA_FITTING_DECLARE_MATRIX_TYPE
-
-protected:
-    enum { Check = Base::PROVIDES_MEAN_POSITION && Base::PROVIDES_MEAN_NORMAL && Base::PROVIDES_PLANE };
-
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(MeanPlaneFitImpl,meanPlaneFit)
-
-    PONCA_FITTING_APIDOC_FINALIZE
-    PONCA_MULTIARCH inline FIT_RESULT finalize()
+        \todo Add local frame computation to enable PROVIDES_TANGENT_PLANE_BASIS
+    */
+    template <class DataPoint, class _NFilter, typename T>
+    class MeanPlaneFitImpl : public T
     {
-        // handle specific configurations
-        if(Base::finalize() == STABLE)
-        {
-            if (Base::plane().isValid()) Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-            Base::setPlane(Base::m_sumN / Base::getWeightSum(), Base::barycenterLocal());
-        }
-        return Base::m_eCurrentState;
-    }
-    PONCA_FITTING_IS_SIGNED(true)
-}; //class MeanPlaneFitImpl
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_MATRIX_TYPE
 
-/// \brief Helper alias for Plane fitting on points using MeanPlaneFitImpl
-//! [MeanPlaneFit Definition]
-    template < class DataPoint, class _NFilter, typename T>
-    using MeanPlaneFit =
-    MeanPlaneFitImpl<DataPoint, _NFilter,
-        MeanNormal<DataPoint, _NFilter,
-            MeanPosition<DataPoint, _NFilter,
-                Plane<DataPoint, _NFilter, T>>>>;
-//! [MeanPlaneFit Definition]
-} //namespace Ponca
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_MEAN_POSITION && Base::PROVIDES_MEAN_NORMAL && Base::PROVIDES_PLANE
+        };
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(MeanPlaneFitImpl, meanPlaneFit)
+
+        PONCA_FITTING_APIDOC_FINALIZE
+        PONCA_MULTIARCH inline FIT_RESULT finalize()
+        {
+            // handle specific configurations
+            if (Base::finalize() == STABLE)
+            {
+                if (Base::plane().isValid())
+                    Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
+                Base::setPlane(Base::m_sumN / Base::getWeightSum(), Base::barycenterLocal());
+            }
+            return Base::m_eCurrentState;
+        }
+        PONCA_FITTING_IS_SIGNED(true)
+    }; // class MeanPlaneFitImpl
+
+    /// \brief Helper alias for Plane fitting on points using MeanPlaneFitImpl
+    //! [MeanPlaneFit Definition]
+    template <class DataPoint, class _NFilter, typename T>
+    using MeanPlaneFit = MeanPlaneFitImpl<
+        DataPoint, _NFilter,
+        MeanNormal<DataPoint, _NFilter, MeanPosition<DataPoint, _NFilter, Plane<DataPoint, _NFilter, T>>>>;
+    //! [MeanPlaneFit Definition]
+} // namespace Ponca

--- a/Ponca/src/Fitting/mlsSphereFitDer.h
+++ b/Ponca/src/Fitting/mlsSphereFitDer.h
@@ -11,99 +11,100 @@
 namespace Ponca
 {
 
-/*!
- * \brief Extension performing derivation of the mls surface
- * \inherit Concept::FittingExtensionConcept
- *
- * The differentiation is determined by a previous basket elements that must
- * provides first order derivatives of the algebraic sphere parameters.
- */
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-class MlsSphereFitDer : public T
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
-
-protected:
-    enum
-    {
-        Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE & Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
-        PROVIDES_NORMAL_DERIVATIVE
-    };
-
-    enum
-    {
-        Dim     = DataPoint::Dim,       //!< Dimension of the ambient space
-        DerDim  = Base::NbDerivatives   //!< Number of dimensions used for the differentiation
-    };
-
-public:
     /*!
-        \brief Static squared matrix of scalars with a size adapted to the
-        differentiation type.
-
-        The size is adapted to the differentiation type (scale and/or space)
-        only. Such Matrix is typically used to represent Hessian matrix of
-        multivariate single-valued functions such as \f$ u_c \f$ and \f$ u_q \f$
-        of an AlgebraicSphere obtained from a fitting procedure.
-
-        \todo check with MatrixType, VectorArray and ScalarArray
+     * \brief Extension performing derivation of the mls surface
+     * \inherit Concept::FittingExtensionConcept
+     *
+     * The differentiation is determined by a previous basket elements that must
+     * provides first order derivatives of the algebraic sphere parameters.
      */
-    typedef Eigen::Matrix< Scalar, DerDim, DerDim > Matrix;
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class MlsSphereFitDer : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
 
-    /*!
-        \brief Static matrix of scalars with a size adapted to the
-        differentiation type and the dimension of the ambient space.
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE & Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
+            PROVIDES_NORMAL_DERIVATIVE
+        };
 
-        The size is adapted to the differentiation type (scale and/or space) and
-        the dimension of the ambient space. Such Matrix is typically used to
-        represent Hessian matrices of multivariate multi-valued functions such
-        as \f$ u_l \f$ of an AlgebraicSphere obtained from a fitting procedure.
+        enum
+        {
+            Dim    = DataPoint::Dim,     //!< Dimension of the ambient space
+            DerDim = Base::NbDerivatives //!< Number of dimensions used for the differentiation
+        };
 
-        A MatrixArray is an array of Matrix (that mimics a 3D matrix) where the
-        number of Matrix is equal to the dimension of the ambient space.
-        The i-th Matrix can be accessed by the following block operation:
-        \code
-            MatrixArray a;
-            int i;
-            //...
-            Matrix m_i = a.template block<DerDim, DerDim>(0, i*DerDim);
-        \endcode
-     */
-    typedef Eigen::Matrix< Scalar, DerDim, Dim*DerDim > MatrixArray;
+    public:
+        /*!
+            \brief Static squared matrix of scalars with a size adapted to the
+            differentiation type.
 
-protected:
-    // computation data
-    Matrix m_d2SumDotPN,  /*!< \brief Sum of the dot product between relative positions and normals with second-order weight derivatives */
-           m_d2SumDotPP,  /*!< \brief Sum of the squared relative positions with second-order weight derivatives */
-           m_d2SumW;      /*!< \brief Sum of queries weight with second-order weight derivatives */
+            The size is adapted to the differentiation type (scale and/or space)
+            only. Such Matrix is typically used to represent Hessian matrix of
+            multivariate single-valued functions such as \f$ u_c \f$ and \f$ u_q \f$
+            of an AlgebraicSphere obtained from a fitting procedure.
 
-    MatrixArray m_d2SumP, /*!< \brief Sum of relative positions with second-order weight derivatives */
-                m_d2SumN; /*!< \brief Sum of normal vectors with second-order weight derivatives */
+            \todo check with MatrixType, VectorArray and ScalarArray
+         */
+        typedef Eigen::Matrix<Scalar, DerDim, DerDim> Matrix;
 
-public:
-    // results
-    Matrix m_d2Uc,      /*!< \brief Second derivative of the hyper-sphere constant term  */
-           m_d2Uq;      /*!< \brief Second derivative of the hyper-sphere quadratic term */
-    MatrixArray m_d2Ul; /*!< \brief Second derivative of the hyper-sphere linear term    */
+        /*!
+            \brief Static matrix of scalars with a size adapted to the
+            differentiation type and the dimension of the ambient space.
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS_DER(MlsSphereFitDer,mlsSphereFitDer)
+            The size is adapted to the differentiation type (scale and/or space) and
+            the dimension of the ambient space. Such Matrix is typically used to
+            represent Hessian matrices of multivariate multi-valued functions such
+            as \f$ u_l \f$ of an AlgebraicSphere obtained from a fitting procedure.
 
-    PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
+            A MatrixArray is an array of Matrix (that mimics a 3D matrix) where the
+            number of Matrix is equal to the dimension of the ambient space.
+            The i-th Matrix can be accessed by the following block operation:
+            \code
+                MatrixArray a;
+                int i;
+                //...
+                Matrix m_i = a.template block<DerDim, DerDim>(0, i*DerDim);
+            \endcode
+         */
+        typedef Eigen::Matrix<Scalar, DerDim, Dim * DerDim> MatrixArray;
 
-    //! \brief Returns the derivatives of the scalar field at the evaluation point
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dPotential() const;
+    protected:
+        // computation data
+        Matrix m_d2SumDotPN, /*!< \brief Sum of the dot product between relative positions and normals with second-order
+                                weight derivatives */
+            m_d2SumDotPP,    /*!< \brief Sum of the squared relative positions with second-order weight derivatives */
+            m_d2SumW;        /*!< \brief Sum of queries weight with second-order weight derivatives */
 
-    /*! \brief Value of the normal of the primitive at the evaluation point */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient() const;
+        MatrixArray m_d2SumP, /*!< \brief Sum of relative positions with second-order weight derivatives */
+            m_d2SumN;         /*!< \brief Sum of normal vectors with second-order weight derivatives */
 
-    /*! \brief Returns the second derivatives of the scalar field at the evaluation point */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorArray dNormal() const;
+    public:
+        // results
+        Matrix m_d2Uc,      /*!< \brief Second derivative of the hyper-sphere constant term  */
+            m_d2Uq;         /*!< \brief Second derivative of the hyper-sphere quadratic term */
+        MatrixArray m_d2Ul; /*!< \brief Second derivative of the hyper-sphere linear term    */
 
-}; //class MlsSphereFitDer
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(MlsSphereFitDer, mlsSphereFitDer)
+
+        PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
+
+        //! \brief Returns the derivatives of the scalar field at the evaluation point
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dPotential() const;
+
+        /*! \brief Value of the normal of the primitive at the evaluation point */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient() const;
+
+        /*! \brief Returns the second derivatives of the scalar field at the evaluation point */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorArray dNormal() const;
+
+    }; // class MlsSphereFitDer
 
 #include "mlsSphereFitDer.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/mlsSphereFitDer.hpp
+++ b/Ponca/src/Fitting/mlsSphereFitDer.hpp
@@ -4,15 +4,12 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-void
-MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::init()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+void MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::init()
 {
     Base::init();
 
-    m_d2Uc = Matrix::Zero(),
-    m_d2Uq = Matrix::Zero();
+    m_d2Uc = Matrix::Zero(), m_d2Uq = Matrix::Zero();
     m_d2Ul = MatrixArray::Zero();
 
     m_d2SumDotPN = Matrix::Zero();
@@ -23,37 +20,37 @@ MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::init()
     m_d2SumN = MatrixArray::Zero();
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
-                                                              const VectorType &localQ,
-                                                              const DataPoint &attributes,
-                                                              ScalarArray &dw)
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+bool MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                         const DataPoint& attributes, ScalarArray& dw)
 {
-    if( Base::addLocalNeighbor(w, localQ, attributes, dw) ) {
+    if (Base::addLocalNeighbor(w, localQ, attributes, dw))
+    {
         // compute weight derivatives
         Matrix d2w = Matrix::Zero();
 
         if (Base::isScaleDer())
-            d2w(0,0) = Base::getNeighborFilter().scaled2w(attributes.pos(), attributes);
+            d2w(0, 0) = Base::getNeighborFilter().scaled2w(attributes.pos(), attributes);
 
         if (Base::isSpaceDer())
-            d2w.template bottomRightCorner<Dim,Dim>() = Base::getNeighborFilter().spaced2w(attributes.pos(), attributes);
+            d2w.template bottomRightCorner<Dim, Dim>() =
+                Base::getNeighborFilter().spaced2w(attributes.pos(), attributes);
 
         if (Base::isScaleDer() && Base::isSpaceDer())
         {
-            d2w.template bottomLeftCorner<Dim,1>() = Base::getNeighborFilter().scaleSpaced2w(attributes.pos(),attributes);
-            d2w.template topRightCorner<1,Dim>() = d2w.template bottomLeftCorner<Dim,1>().transpose();
+            d2w.template bottomLeftCorner<Dim, 1>() =
+                Base::getNeighborFilter().scaleSpaced2w(attributes.pos(), attributes);
+            d2w.template topRightCorner<1, Dim>() = d2w.template bottomLeftCorner<Dim, 1>().transpose();
         }
 
         m_d2SumDotPN += d2w * attributes.normal().dot(localQ);
         m_d2SumDotPP += d2w * localQ.squaredNorm();
-        m_d2SumW     += d2w;
+        m_d2SumW += d2w;
 
-        for(int i=0; i<Dim; ++i)
+        for (int i = 0; i < Dim; ++i)
         {
-            m_d2SumP.template block<DerDim,DerDim>(0,i*DerDim) += d2w * localQ[i];
-            m_d2SumN.template block<DerDim,DerDim>(0,i*DerDim) += d2w * attributes.normal()[i];
+            m_d2SumP.template block<DerDim, DerDim>(0, i * DerDim) += d2w * localQ[i];
+            m_d2SumN.template block<DerDim, DerDim>(0, i * DerDim) += d2w * attributes.normal()[i];
         }
 
         return true;
@@ -61,9 +58,8 @@ MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
     return false;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-FIT_RESULT
-MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::finalize()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+FIT_RESULT MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::finalize()
 {
     Base::finalize();
 
@@ -75,89 +71,89 @@ MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::finalize()
         Matrix sumdSumPdSumP  = Matrix::Zero();
         Matrix sumd2SumPdSumP = Matrix::Zero();
 
-        for(int i=0; i<Dim; ++i)
+        for (int i = 0; i < Dim; ++i)
         {
-            sumdSumPdSumN  += Base::m_dSumN.row(i).transpose()*Base::m_dSumP.row(i);
-            sumd2SumPdSumN += m_d2SumP.template block<DerDim,DerDim>(0,i*DerDim)*Base::m_sumN(i);
-            sumd2SumNdSumP += m_d2SumN.template block<DerDim,DerDim>(0,i*DerDim)*Base::m_sumP(i);
-            sumdSumPdSumP  += Base::m_dSumP.row(i).transpose()*Base::m_dSumP.row(i);
-            sumd2SumPdSumP += m_d2SumP.template block<DerDim,DerDim>(0,i*DerDim)*Base::m_sumP(i);
+            sumdSumPdSumN += Base::m_dSumN.row(i).transpose() * Base::m_dSumP.row(i);
+            sumd2SumPdSumN += m_d2SumP.template block<DerDim, DerDim>(0, i * DerDim) * Base::m_sumN(i);
+            sumd2SumNdSumP += m_d2SumN.template block<DerDim, DerDim>(0, i * DerDim) * Base::m_sumP(i);
+            sumdSumPdSumP += Base::m_dSumP.row(i).transpose() * Base::m_dSumP.row(i);
+            sumd2SumPdSumP += m_d2SumP.template block<DerDim, DerDim>(0, i * DerDim) * Base::m_sumP(i);
         }
 
-        Scalar invSumW = Scalar(1.)/Base::getWeightSum();
+        Scalar invSumW = Scalar(1.) / Base::getWeightSum();
 
-        Matrix d2Nume = m_d2SumDotPN
-            - invSumW*invSumW*invSumW*invSumW*(
-                    Base::getWeightSum()*Base::getWeightSum()*(  Base::getWeightSum()*(sumdSumPdSumN+sumdSumPdSumN.transpose()+sumd2SumPdSumN+sumd2SumNdSumP)
-                                               + Base::m_dSumW.transpose()*(Base::m_sumN.transpose()*Base::m_dSumP + Base::m_sumP.transpose()*Base::m_dSumN)
-                                               - (Base::m_sumP.transpose()*Base::m_sumN)*m_d2SumW.transpose()
-                                               - (Base::m_dSumN.transpose()*Base::m_sumP + Base::m_dSumP.transpose()*Base::m_sumN)*Base::m_dSumW)
-                    - Scalar(2.)*Base::getWeightSum()*Base::m_dSumW.transpose()*(Base::getWeightSum()*(Base::m_sumN.transpose()*Base::m_dSumP + Base::m_sumP.transpose()*Base::m_dSumN)
-                                                                         - (Base::m_sumP.transpose()*Base::m_sumN)*Base::m_dSumW));
+        Matrix d2Nume =
+            m_d2SumDotPN -
+            invSumW * invSumW * invSumW * invSumW *
+                (Base::getWeightSum() * Base::getWeightSum() *
+                     (Base::getWeightSum() *
+                          (sumdSumPdSumN + sumdSumPdSumN.transpose() + sumd2SumPdSumN + sumd2SumNdSumP) +
+                      Base::m_dSumW.transpose() *
+                          (Base::m_sumN.transpose() * Base::m_dSumP + Base::m_sumP.transpose() * Base::m_dSumN) -
+                      (Base::m_sumP.transpose() * Base::m_sumN) * m_d2SumW.transpose() -
+                      (Base::m_dSumN.transpose() * Base::m_sumP + Base::m_dSumP.transpose() * Base::m_sumN) *
+                          Base::m_dSumW) -
+                 Scalar(2.) * Base::getWeightSum() * Base::m_dSumW.transpose() *
+                     (Base::getWeightSum() *
+                          (Base::m_sumN.transpose() * Base::m_dSumP + Base::m_sumP.transpose() * Base::m_dSumN) -
+                      (Base::m_sumP.transpose() * Base::m_sumN) * Base::m_dSumW));
 
-        Matrix d2Deno = m_d2SumDotPP
-            - invSumW*invSumW*invSumW*invSumW*(
-                Base::getWeightSum()*Base::getWeightSum()*(  Scalar(2.)*Base::getWeightSum()*(sumdSumPdSumP+sumd2SumPdSumP)
-                                           + Scalar(2.)*Base::m_dSumW.transpose()*(Base::m_sumP.transpose()*Base::m_dSumP)
-                                           - (Base::m_sumP.transpose()*Base::m_sumP)*m_d2SumW.transpose()
-                                           - Scalar(2.)*(Base::m_dSumP.transpose()*Base::m_sumP)*Base::m_dSumW)
-                - Scalar(2.)*Base::getWeightSum()*Base::m_dSumW.transpose()*(Scalar(2.)*Base::getWeightSum()*Base::m_sumP.transpose()*Base::m_dSumP
-                                                                     - (Base::m_sumP.transpose()*Base::m_sumP)*Base::m_dSumW));
+        Matrix d2Deno = m_d2SumDotPP -
+                        invSumW * invSumW * invSumW * invSumW *
+                            (Base::getWeightSum() * Base::getWeightSum() *
+                                 (Scalar(2.) * Base::getWeightSum() * (sumdSumPdSumP + sumd2SumPdSumP) +
+                                  Scalar(2.) * Base::m_dSumW.transpose() * (Base::m_sumP.transpose() * Base::m_dSumP) -
+                                  (Base::m_sumP.transpose() * Base::m_sumP) * m_d2SumW.transpose() -
+                                  Scalar(2.) * (Base::m_dSumP.transpose() * Base::m_sumP) * Base::m_dSumW) -
+                             Scalar(2.) * Base::getWeightSum() * Base::m_dSumW.transpose() *
+                                 (Scalar(2.) * Base::getWeightSum() * Base::m_sumP.transpose() * Base::m_dSumP -
+                                  (Base::m_sumP.transpose() * Base::m_sumP) * Base::m_dSumW));
 
-        Scalar deno2 = Base::m_deno*Base::m_deno;
+        Scalar deno2 = Base::m_deno * Base::m_deno;
 
-        m_d2Uq = Scalar(.5)/(deno2*deno2)*(deno2*(  Base::m_dDeno.transpose()*Base::m_dNume
-                                                  + Base::m_deno*d2Nume
-                                                  - Base::m_dNume.transpose()*Base::m_dDeno
-                                                  - Base::m_nume*d2Deno)
-                                           - Scalar(2.)*Base::m_deno*Base::m_dDeno.transpose()*(Base::m_deno*Base::m_dNume - Base::m_nume*Base::m_dDeno));
+        m_d2Uq = Scalar(.5) / (deno2 * deno2) *
+                 (deno2 * (Base::m_dDeno.transpose() * Base::m_dNume + Base::m_deno * d2Nume -
+                           Base::m_dNume.transpose() * Base::m_dDeno - Base::m_nume * d2Deno) -
+                  Scalar(2.) * Base::m_deno * Base::m_dDeno.transpose() *
+                      (Base::m_deno * Base::m_dNume - Base::m_nume * Base::m_dDeno));
 
-        for(int i=0; i<Dim; ++i)
+        for (int i = 0; i < Dim; ++i)
         {
-            m_d2Ul.template block<DerDim,DerDim>(0,i*DerDim) = invSumW*(
-                  m_d2SumN.template block<DerDim,DerDim>(0,i*DerDim)
-                - Scalar(2.)*(  m_d2Uq*Base::m_sumP[i]
-                              + Base::m_dSumP.row(i).transpose()*Base::m_dUq
-                              + Base::m_uq*m_d2SumP.template block<DerDim,DerDim>(0,i*DerDim)
-                              + Base::m_dUq.transpose()*Base::m_dSumP.row(i))
-                - Base::m_ul[i]*m_d2SumW
-                - Base::m_dUl.row(i).transpose()*Base::m_dSumW
-                - Base::m_dSumW.transpose()*Base::m_dUl.row(i));
+            m_d2Ul.template block<DerDim, DerDim>(0, i * DerDim) =
+                invSumW * (m_d2SumN.template block<DerDim, DerDim>(0, i * DerDim) -
+                           Scalar(2.) * (m_d2Uq * Base::m_sumP[i] + Base::m_dSumP.row(i).transpose() * Base::m_dUq +
+                                         Base::m_uq * m_d2SumP.template block<DerDim, DerDim>(0, i * DerDim) +
+                                         Base::m_dUq.transpose() * Base::m_dSumP.row(i)) -
+                           Base::m_ul[i] * m_d2SumW - Base::m_dUl.row(i).transpose() * Base::m_dSumW -
+                           Base::m_dSumW.transpose() * Base::m_dUl.row(i));
         }
-        
+
         Matrix sumdUldSumP = Matrix::Zero();
         Matrix sumUld2SumP = Matrix::Zero();
         Matrix sumd2UlsumP = Matrix::Zero();
         Matrix sumdSumPdUl = Matrix::Zero();
 
-        for(int i=0; i<Dim; ++i)
+        for (int i = 0; i < Dim; ++i)
         {
-            sumdUldSumP += Base::m_dUl.row(i).transpose()*Base::m_dSumP.row(i);
-            sumUld2SumP += Base::m_ul[i]*m_d2SumP.template block<DerDim,DerDim>(0,i*DerDim);
-            sumd2UlsumP += m_d2Ul.template block<DerDim,DerDim>(0,i*DerDim)*Base::m_sumP[i];
-            sumdSumPdUl += Base::m_dSumP.row(i).transpose()*Base::m_dUl.row(i);
+            sumdUldSumP += Base::m_dUl.row(i).transpose() * Base::m_dSumP.row(i);
+            sumUld2SumP += Base::m_ul[i] * m_d2SumP.template block<DerDim, DerDim>(0, i * DerDim);
+            sumd2UlsumP += m_d2Ul.template block<DerDim, DerDim>(0, i * DerDim) * Base::m_sumP[i];
+            sumdSumPdUl += Base::m_dSumP.row(i).transpose() * Base::m_dUl.row(i);
         }
 
-        m_d2Uc = -invSumW*(
-              sumdUldSumP
-            + sumUld2SumP
-            + sumd2UlsumP
-            + sumdSumPdUl
-            + Base::m_dUq.transpose()*Base::m_dSumDotPP
-            + Base::m_uq*m_d2SumDotPP
-            + Base::m_dSumDotPP.transpose()*Base::m_dUq
-            + m_d2Uq*Base::m_sumDotPP
-            + Base::m_uc*m_d2SumW
-            + Base::m_dUc.transpose()*Base::m_dSumW
-            + Base::m_dSumW.transpose()*Base::m_dUc);
+        m_d2Uc =
+            -invSumW *
+            (sumdUldSumP + sumUld2SumP + sumd2UlsumP + sumdSumPdUl + Base::m_dUq.transpose() * Base::m_dSumDotPP +
+             Base::m_uq * m_d2SumDotPP + Base::m_dSumDotPP.transpose() * Base::m_dUq + m_d2Uq * Base::m_sumDotPP +
+             Base::m_uc * m_d2SumW + Base::m_dUc.transpose() * Base::m_dSumW + Base::m_dSumW.transpose() * Base::m_dUc);
     }
 
     return Base::m_eCurrentState;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::ScalarArray
-MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::dPotential() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::ScalarArray MlsSphereFitDer<DataPoint, _NFilter, DiffType,
+                                                                                        T>::dPotential() const
 {
     // Compute the 1st order derivative of the scalar field s = uc + x^T ul + x^T x uq
     // In a centered basis (x=0), we obtain:
@@ -165,24 +161,24 @@ MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::dPotential() const
     //   the spatial derivative: d_x(s)(t,0) = d_x(uc)(t,0) + ul(t,0)
     ScalarArray result = Base::m_dUc;
 
-    if(Base::isSpaceDer())
+    if (Base::isSpaceDer())
         result.template tail<Dim>() += Base::m_ul;
 
     return result;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::VectorType
-MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::primitiveGradient() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::VectorType MlsSphereFitDer<DataPoint, _NFilter, DiffType,
+                                                                                       T>::primitiveGradient() const
 {
     // Compute the 1st order derivative of the scalar field and normalize it
     VectorType grad = Base::m_dUc.template tail<Dim>().transpose() + Base::m_ul;
     return grad.normalized();
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::VectorArray
-MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::dNormal() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::VectorArray MlsSphereFitDer<DataPoint, _NFilter, DiffType,
+                                                                                        T>::dNormal() const
 {
     // Compute the 1st order derivative of the normal, which is the normalized gradient N = d_x(s) / |d_x(s)|
     // We obtain:
@@ -196,16 +192,16 @@ MlsSphereFitDer<DataPoint, _NFilter, DiffType, T>::dNormal() const
     VectorType grad = Base::m_dUc.template tail<Dim>().transpose() + Base::m_ul;
     Scalar gradNorm = grad.norm();
 
-    if(Base::isScaleDer())
-        result.col(0) = m_d2Uc.template topRightCorner<1,Dim>().transpose() + Base::m_dUl.col(0);
+    if (Base::isScaleDer())
+        result.col(0) = m_d2Uc.template topRightCorner<1, Dim>().transpose() + Base::m_dUl.col(0);
 
-    if(Base::isSpaceDer())
+    if (Base::isSpaceDer())
     {
-        result.template rightCols<Dim>() = m_d2Uc.template bottomRightCorner<Dim,Dim>().transpose()
-                                           + Base::m_dUl.template rightCols<Dim>().transpose()
-                                           + Base::m_dUl.template rightCols<Dim>();
-        result.template rightCols<Dim>().diagonal().array() += Scalar(2.)*Base::m_uq;
+        result.template rightCols<Dim>() = m_d2Uc.template bottomRightCorner<Dim, Dim>().transpose() +
+                                           Base::m_dUl.template rightCols<Dim>().transpose() +
+                                           Base::m_dUl.template rightCols<Dim>();
+        result.template rightCols<Dim>().diagonal().array() += Scalar(2.) * Base::m_uq;
     }
 
-    return result/gradNorm - grad*grad.transpose()/(gradNorm*gradNorm)*result;
+    return result / gradNorm - grad * grad.transpose() / (gradNorm * gradNorm) * result;
 }

--- a/Ponca/src/Fitting/mongePatch.h
+++ b/Ponca/src/Fitting/mongePatch.h
@@ -17,204 +17,215 @@
 
 namespace Ponca
 {
-/*!
-    \brief Monge Patch primitive, defined as \f$ \mathbf{x}(u,v)= (u,v,h(u,v)) \f$,
-     with \f$h(u,v)\f$ defined by a Base class.
+    /*!
+        \brief Monge Patch primitive, defined as \f$ \mathbf{x}(u,v)= (u,v,h(u,v)) \f$,
+         with \f$h(u,v)\f$ defined by a Base class.
 
-    \see MongePatchQuadraticFitImpl and MongePatchRestrictedQuadraticFitImpl
+        \see MongePatchQuadraticFitImpl and MongePatchRestrictedQuadraticFitImpl
 
-    \warning Internally, the patch is represented as (h(u,v), u, v) because
-    CovariancePlaneFitImpl::worldToTangentPlane() wraps up coordinates in this order (height, u and v).
+        \warning Internally, the patch is represented as (h(u,v), u, v) because
+        CovariancePlaneFitImpl::worldToTangentPlane() wraps up coordinates in this order (height, u and v).
 
-    This primitive provides:
-    \verbatim PROVIDES_MONGE_PATCH, PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS, PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS \endverbatim
+        This primitive provides:
+        \verbatim PROVIDES_MONGE_PATCH, PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS,
+       PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS \endverbatim
 
-    This primitive requires:
-    \verbatim PROVIDES_PLANE, PROVIDES_TANGENT_PLANE_BASIS, PROVIDES_HEIGHTFIELD \endverbatim
-    */
-    template < class DataPoint, class _NFilter, typename T >
+        This primitive requires:
+        \verbatim PROVIDES_PLANE, PROVIDES_TANGENT_PLANE_BASIS, PROVIDES_HEIGHTFIELD \endverbatim
+        */
+    template <class DataPoint, class _NFilter, typename T>
     class MongePatch : public T
     {
         PONCA_FITTING_DECLARE_DEFAULT_TYPES
-        static_assert ( DataPoint::Dim == 3, "MongePatch is only valid in 3D");
+        static_assert(DataPoint::Dim == 3, "MongePatch is only valid in 3D");
 
     protected:
-        enum {
-            Check = Base::PROVIDES_PLANE &&
-                    Base::PROVIDES_TANGENT_PLANE_BASIS &&
-                    Base::PROVIDES_HEIGHTFIELD,      /*!< \brief Requires a heightfield function */
-                    PROVIDES_MONGE_PATCH,            /*!< \brief Provides MongePatch API */
-                    PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS, /*!< \brief Provides first fundamental form */
-                    PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS  /*!< \brief Provides second fundamental form */
+        enum
+        {
+            Check = Base::PROVIDES_PLANE && Base::PROVIDES_TANGENT_PLANE_BASIS &&
+                    Base::PROVIDES_HEIGHTFIELD,         /*!< \brief Requires a heightfield function */
+            PROVIDES_MONGE_PATCH,                       /*!< \brief Provides MongePatch API */
+            PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS, /*!< \brief Provides first fundamental form */
+            PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS /*!< \brief Provides second fundamental form */
         };
 
     public:
-
         /*! \brief Default constructor */
         PONCA_MULTIARCH inline MongePatch() : Base() { Base::init(); }
 
-        PONCA_EXPLICIT_CAST_OPERATORS(MongePatch,mongePatchPrimitive)
+        PONCA_EXPLICIT_CAST_OPERATORS(MongePatch, mongePatchPrimitive)
 
         //! \brief Value of the scalar field at the evaluation point
         //! \see method `#isSigned` of the fit to check if the sign is reliable
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential ( ) const
-        {
-            return Base::height(Scalar(0),Scalar(0));
-        }
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential() const { return Base::height(Scalar(0), Scalar(0)); }
 
         //! \brief Value of the scalar field at a given point
         //! \see method `#isSigned` of the plane fit to check if the sign is reliable
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential(const VectorType& _q) const {
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential(const VectorType& _q) const
+        {
             const VectorType x = Base::worldToTangentPlane(_q);
-            return Base::height(Base::getUFromLocalCoordinates(x),Base::getVFromLocalCoordinates(x)) - Base::getHFromLocalCoordinates(x);
+            return Base::height(Base::getUFromLocalCoordinates(x), Base::getVFromLocalCoordinates(x)) -
+                   Base::getHFromLocalCoordinates(x);
         }
 
         //! \brief Orthogonal projection on the patch
         ///
         /// Given a point p and its local representation q, project the point such that \f$h(q.x(),q.y())-q.z()=0\f$
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType project (const VectorType& _q) const
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType project(const VectorType& _q) const
         {
             VectorType x = Base::worldToTangentPlane(_q);
-            Base::getHFromLocalCoordinates(x) = Base::height(Base::getUFromLocalCoordinates(x),Base::getVFromLocalCoordinates(x));
+            Base::getHFromLocalCoordinates(x) =
+                Base::height(Base::getUFromLocalCoordinates(x), Base::getVFromLocalCoordinates(x));
             return Base::tangentPlaneToWorld(x);
         }
 
         //! \brief Scalar field gradient direction at the basis center
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient () const
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient() const
         {
             return Base::tangentPlaneToWorld(primitiveGradientLocal(), false);
         }
 
         //! \brief Scalar field gradient direction at \f$ \mathbf{q}\f$
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient (const VectorType& _q) const
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient(const VectorType& _q) const
         {
             return Base::tangentPlaneToWorld(primitiveGradientLocal(Base::worldToTangentPlane(_q)), false);
         }
 
         //! \brief Scalar field gradient direction, both input and output vectors are expressed in the local basis
-        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal (const VectorType& _localQ = VectorType::Zero()) const
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal(
+            const VectorType& _localQ = VectorType::Zero()) const
         {
-            VectorType  uVect = Base::heightTangentULocal(_localQ);
-            VectorType  vVect = Base::heightTangentVLocal(_localQ);
-            VectorType  cross = uVect.cross(vVect);
-            VectorType  crossN = uVect.normalized().cross(vVect.normalized());
+            VectorType uVect  = Base::heightTangentULocal(_localQ);
+            VectorType vVect  = Base::heightTangentVLocal(_localQ);
+            VectorType cross  = uVect.cross(vVect);
+            VectorType crossN = uVect.normalized().cross(vVect.normalized());
             return Base::heightTangentULocal(_localQ).cross(Base::heightTangentVLocal(_localQ));
         }
 
-        PONCA_MULTIARCH inline void firstFundamentalFormComponents (Scalar &E, Scalar &F, Scalar &G) const
+        PONCA_MULTIARCH inline void firstFundamentalFormComponents(Scalar& E, Scalar& F, Scalar& G) const
         {
             PONCA_MULTIARCH_STD_MATH(sqrt);
-            const VectorType fu {Base::dh_du(), Scalar(1), Scalar(0)};
-            const VectorType fv {Base::dh_dv(), Scalar(0), Scalar(1)};
+            const VectorType fu{Base::dh_du(), Scalar(1), Scalar(0)};
+            const VectorType fv{Base::dh_dv(), Scalar(0), Scalar(1)};
             E = fu.dot(fu);
             F = fu.dot(fv);
             G = fv.dot(fv);
         }
 
-        PONCA_MULTIARCH inline void secondFundamentalFormComponents (Scalar &L, Scalar &M, Scalar &N) const
+        PONCA_MULTIARCH inline void secondFundamentalFormComponents(Scalar& L, Scalar& M, Scalar& N) const
         {
             PONCA_MULTIARCH_STD_MATH(sqrt);
-            const VectorType fuu {Base::d2h_duu(), Scalar(0), Scalar(0)};
-            const VectorType fuv {Base::d2h_duv(), Scalar(0), Scalar(0)};
-            const VectorType fvv {Base::d2h_dvv(), Scalar(0), Scalar(0)};
+            const VectorType fuu{Base::d2h_duu(), Scalar(0), Scalar(0)};
+            const VectorType fuv{Base::d2h_duv(), Scalar(0), Scalar(0)};
+            const VectorType fvv{Base::d2h_dvv(), Scalar(0), Scalar(0)};
             const VectorType fn = primitiveGradientLocal();
 
             L = fuu.dot(fn);
-            M = fuv.dot(fn);;
-            N = fvv.dot(fn);;
+            M = fuv.dot(fn);
+            ;
+            N = fvv.dot(fn);
+            ;
         }
-    }; //class MongePatchPrimitive
+    }; // class MongePatchPrimitive
 
-/*!
- * \brief Extension to compute the best fit quadric on 3d points expressed as \f$f(u,v)=h\f$
- *
- * \see MongePatchPrimitive
- * \note This procedure requires at least two passes, the first one for plane fitting,
- * the second one for quadric fitting.
- * \warning This class is valid only in 3D.
- */
-    template < class DataPoint, class _NFilter, typename T>
+    /*!
+     * \brief Extension to compute the best fit quadric on 3d points expressed as \f$f(u,v)=h\f$
+     *
+     * \see MongePatchPrimitive
+     * \note This procedure requires at least two passes, the first one for plane fitting,
+     * the second one for quadric fitting.
+     * \warning This class is valid only in 3D.
+     */
+    template <class DataPoint, class _NFilter, typename T>
     class MongePatchQuadraticFitImpl : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
     protected:
-        enum {
-            Check = Base::PROVIDES_QUADRIC_HEIGHTFIELD &&
-                    Base::PROVIDES_MONGE_PATCH
+        enum
+        {
+            Check = Base::PROVIDES_QUADRIC_HEIGHTFIELD && Base::PROVIDES_MONGE_PATCH
         };
 
     public:
         // we need to use dynamic matric to use ThinU, ThinV for solving
-        using SampleMatrix                     = Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic>;
+        using SampleMatrix                     = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
         using QuadraticHeightFieldCoefficients = typename Base::HeightFieldCoefficients;
 
-//protected:
-    public: //temporary DO NOT MERGE THIS
-        SampleMatrix                     m_A; /*!< \brief Quadric input samples */
-        QuadraticHeightFieldCoefficients m_b {QuadraticHeightFieldCoefficients::Zero()}; /*!< \brief Observations */
+        // protected:
+    public:               // temporary DO NOT MERGE THIS
+        SampleMatrix m_A; /*!< \brief Quadric input samples */
+        QuadraticHeightFieldCoefficients m_b{QuadraticHeightFieldCoefficients::Zero()}; /*!< \brief Observations */
 
-        bool m_planeIsReady {false};
+        bool m_planeIsReady{false};
+
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS(MongePatchQuadraticFitImpl,mongePatchQuadraticFit)
+        PONCA_EXPLICIT_CAST_OPERATORS(MongePatchQuadraticFitImpl, mongePatchQuadraticFit)
         PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
     }; // MongePatchQuadraticFitImpl
-/*!
- * \brief Extension to compute the best fit restricted quadric on 3d points expressed as \f$f(u,v)=h\f$
- *
- * \see MongePatchPrimitive
- * \note This procedure requires at least two passes, the first one for plane fitting,
- * the second one for quadric fitting.
- * \warning This class is valid only in 3D.
- */
-    template < class DataPoint, class _NFilter, typename T>
+    /*!
+     * \brief Extension to compute the best fit restricted quadric on 3d points expressed as \f$f(u,v)=h\f$
+     *
+     * \see MongePatchPrimitive
+     * \note This procedure requires at least two passes, the first one for plane fitting,
+     * the second one for quadric fitting.
+     * \warning This class is valid only in 3D.
+     */
+    template <class DataPoint, class _NFilter, typename T>
     class MongePatchRestrictedQuadraticFitImpl : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
     protected:
-        enum {
-            Check = Base::PROVIDES_RESTRICTED_QUADRIC_HEIGHTFIELD &&
-                    Base::PROVIDES_MONGE_PATCH
+        enum
+        {
+            Check = Base::PROVIDES_RESTRICTED_QUADRIC_HEIGHTFIELD && Base::PROVIDES_MONGE_PATCH
         };
 
     public:
         // we need to use dynamic matric to use ThinU, ThinV for solving
-        using SampleMatrix                     = Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic>;
+        using SampleMatrix                     = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
         using QuadraticHeightFieldCoefficients = typename Base::HeightFieldCoefficients;
 
-protected:
-        SampleMatrix                     m_A; /*!< \brief Quadric input samples */
-        QuadraticHeightFieldCoefficients m_b {QuadraticHeightFieldCoefficients::Zero()}; /*!< \brief Observations */
+    protected:
+        SampleMatrix m_A; /*!< \brief Quadric input samples */
+        QuadraticHeightFieldCoefficients m_b{QuadraticHeightFieldCoefficients::Zero()}; /*!< \brief Observations */
 
-        bool m_planeIsReady {false};
+        bool m_planeIsReady{false};
+
     public:
-        PONCA_EXPLICIT_CAST_OPERATORS(MongePatchRestrictedQuadraticFitImpl,mongePatchQuadraticFit)
+        PONCA_EXPLICIT_CAST_OPERATORS(MongePatchRestrictedQuadraticFitImpl, mongePatchQuadraticFit)
         PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
     }; // MongePatchRestrictedQuadraticFitImpl
 
-template < class DataPoint, class _NFilter, typename T>
-using MongePatchQuadraticFit =
-        WeingartenCurvatureEstimator<DataPoint, _NFilter,
-            CurvatureEstimator<DataPoint, _NFilter,
-                FundamentalFormWeingartenEstimator<DataPoint, _NFilter,
-                    MongePatchQuadraticFitImpl<DataPoint, _NFilter,
-                        MongePatch<DataPoint, _NFilter,
-                            QuadraticHeightField<DataPoint, _NFilter,
-                                HeightField<DataPoint, _NFilter,
-                                    CovariancePlaneFit<DataPoint, _NFilter,T>>>>>>>>;
+    template <class DataPoint, class _NFilter, typename T>
+    using MongePatchQuadraticFit = WeingartenCurvatureEstimator<
+        DataPoint, _NFilter,
+        CurvatureEstimator<
+            DataPoint, _NFilter,
+            FundamentalFormWeingartenEstimator<
+                DataPoint, _NFilter,
+                MongePatchQuadraticFitImpl<
+                    DataPoint, _NFilter,
+                    MongePatch<DataPoint, _NFilter,
+                               QuadraticHeightField<
+                                   DataPoint, _NFilter,
+                                   HeightField<DataPoint, _NFilter, CovariancePlaneFit<DataPoint, _NFilter, T>>>>>>>>;
 
-template < class DataPoint, class _NFilter, typename T>
-using MongePatchRestrictedQuadraticFit =
-        WeingartenCurvatureEstimator<DataPoint, _NFilter,
-            CurvatureEstimator<DataPoint, _NFilter,
-                FundamentalFormWeingartenEstimator<DataPoint, _NFilter,
-                    MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter,
-                        MongePatch<DataPoint, _NFilter,
-                            RestrictedQuadraticHeightField<DataPoint, _NFilter,
-                                HeightField<DataPoint, _NFilter,
-                                    CovariancePlaneFit<DataPoint, _NFilter,T>>>>>>>>;
+    template <class DataPoint, class _NFilter, typename T>
+    using MongePatchRestrictedQuadraticFit = WeingartenCurvatureEstimator<
+        DataPoint, _NFilter,
+        CurvatureEstimator<
+            DataPoint, _NFilter,
+            FundamentalFormWeingartenEstimator<
+                DataPoint, _NFilter,
+                MongePatchRestrictedQuadraticFitImpl<
+                    DataPoint, _NFilter,
+                    MongePatch<DataPoint, _NFilter,
+                               RestrictedQuadraticHeightField<
+                                   DataPoint, _NFilter,
+                                   HeightField<DataPoint, _NFilter, CovariancePlaneFit<DataPoint, _NFilter, T>>>>>>>>;
 
 #include "mongePatch.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/mongePatch.hpp
+++ b/Ponca/src/Fitting/mongePatch.hpp
@@ -4,25 +4,22 @@
 
 #include "mongePatch.h"
 
-template < class DataPoint, class _NFilter, typename T>
-void
-MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::init()
 {
     Base::init();
 
-    m_A = SampleMatrix(6,6);
+    m_A = SampleMatrix(6, 6);
     m_A.setZero();
     m_b.setZero();
     m_planeIsReady = false;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-bool
-MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                      const VectorType &localQ,
-                                                      const DataPoint &attributes)
+template <class DataPoint, class _NFilter, typename T>
+bool MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                          const DataPoint& attributes)
 {
-    if(! m_planeIsReady)
+    if (!m_planeIsReady)
     {
         return Base::addLocalNeighbor(w, localQ, attributes);
     }
@@ -30,29 +27,30 @@ MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
     {
         // express neighbor in local coordinate frame
         const VectorType local = Base::worldToTangentPlane(attributes.pos());
-        const Scalar& h = Base::getHFromLocalCoordinates(local);
-        const Scalar& u = Base::getUFromLocalCoordinates(local);
-        const Scalar& v = Base::getVFromLocalCoordinates(local);
+        const Scalar& h        = Base::getHFromLocalCoordinates(local);
+        const Scalar& u        = Base::getUFromLocalCoordinates(local);
+        const Scalar& v        = Base::getVFromLocalCoordinates(local);
 
-        Eigen::Matrix<Scalar, 6, 1 > p;
-        p << u*u, v*v, u*v, u, v, 1;
-        m_A    += w*p*p.transpose();
-        m_b    += w*h*p;
+        Eigen::Matrix<Scalar, 6, 1> p;
+        p << u * u, v * v, u * v, u, v, 1;
+        m_A += w * p * p.transpose();
+        m_b += w * h * p;
 
         return true;
     }
     return false;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::finalize()
 {
     // end of the fitting process, check plane is ready
-    if (! m_planeIsReady) {
+    if (!m_planeIsReady)
+    {
         FIT_RESULT res = Base::finalize();
 
-        if(res == STABLE) {  // plane is ready
+        if (res == STABLE)
+        { // plane is ready
             m_planeIsReady = true;
 
             return Base::m_eCurrentState = NEED_OTHER_PASS;
@@ -60,37 +58,33 @@ MongePatchQuadraticFitImpl<DataPoint, _NFilter, T>::finalize ()
         return res;
     }
     // end of the monge patch fitting process
-    else {
+    else
+    {
         // we use BDCSVD as the matrix size is 36
         // http://eigen.tuxfamily.org/dox/classEigen_1_1BDCSVD.html
-        Base::quadraticHeightField().setQuadric
-        (m_A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV | Eigen::NoQRPreconditioner).solve(m_b) );
+        Base::quadraticHeightField().setQuadric(
+            m_A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV | Eigen::NoQRPreconditioner).solve(m_b));
 
         return Base::m_eCurrentState = STABLE;
     }
 }
 
-
-
-template < class DataPoint, class _NFilter, typename T>
-void
-MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::init()
 {
     Base::init();
 
-    m_A = SampleMatrix(4,4);
+    m_A = SampleMatrix(4, 4);
     m_A.setZero();
     m_b.setZero();
     m_planeIsReady = false;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-bool
-MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                                     const VectorType &localQ,
-                                                                     const DataPoint &attributes)
+template <class DataPoint, class _NFilter, typename T>
+bool MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                                    const DataPoint& attributes)
 {
-    if(! m_planeIsReady)
+    if (!m_planeIsReady)
     {
         return Base::addLocalNeighbor(w, localQ, attributes);
     }
@@ -98,40 +92,42 @@ MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(S
     {
         // express neighbor in local coordinate frame
         const VectorType local = Base::worldToTangentPlane(attributes.pos());
-        const Scalar& h = Base::getHFromLocalCoordinates(local);
-        const Scalar& u = Base::getUFromLocalCoordinates(local);
-        const Scalar& v = Base::getVFromLocalCoordinates(local);
+        const Scalar& h        = Base::getHFromLocalCoordinates(local);
+        const Scalar& u        = Base::getUFromLocalCoordinates(local);
+        const Scalar& v        = Base::getVFromLocalCoordinates(local);
 
-        Eigen::Matrix<Scalar, 4, 1 > p;
-        p << u*u, v*v, u*v, 1;
-        m_A    += w*p*p.transpose();
-        m_b    += w*h*p;
+        Eigen::Matrix<Scalar, 4, 1> p;
+        p << u * u, v * v, u * v, 1;
+        m_A += w * p * p.transpose();
+        m_b += w * h * p;
 
         return true;
     }
     return false;
 }
 
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT MongePatchRestrictedQuadraticFitImpl<DataPoint, _NFilter, T>::finalize()
 {
     // end of the fitting process, check plane is ready
-    if (! m_planeIsReady) {
+    if (!m_planeIsReady)
+    {
         FIT_RESULT res = Base::finalize();
 
-        if(res == STABLE) {  // plane is ready
+        if (res == STABLE)
+        { // plane is ready
             m_planeIsReady = true;
 
             return Base::m_eCurrentState = NEED_OTHER_PASS;
         }
         return res;
     }
-        // end of the monge patch fitting process
-    else {
+    // end of the monge patch fitting process
+    else
+    {
         // we use SVD as the matrix size is 4x4, and skip preconditioner as it is squared
-        Base::quadraticHeightField().setQuadric
-        (m_A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV | Eigen::NoQRPreconditioner).solve(m_b));
+        Base::quadraticHeightField().setQuadric(
+            m_A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV | Eigen::NoQRPreconditioner).solve(m_b));
 
         return Base::m_eCurrentState = STABLE;
     }

--- a/Ponca/src/Fitting/orientedSphereFit.h
+++ b/Ponca/src/Fitting/orientedSphereFit.h
@@ -7,142 +7,136 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #pragma once
 
 #include "./algebraicSphere.h"
-#include "./mean.h"          // used to define OrientedSphereFit
+#include "./mean.h" // used to define OrientedSphereFit
 
 namespace Ponca
 {
 
-/*!
-    \brief Algebraic Sphere fitting procedure on oriented point sets
-
-    Method published in \cite Guennebaud:2007:APSS.
-
-    \inherit Concept::FittingProcedureConcept
-
-    \see AlgebraicSphere
-*/
-template < class DataPoint, class _NFilter, typename T >
-class OrientedSphereFitImpl : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-
-protected:
-    enum
-    {
-        Check = Base::PROVIDES_ALGEBRAIC_SPHERE &&
-                Base::PROVIDES_MEAN_NORMAL &&
-                Base::PROVIDES_MEAN_POSITION
-    };
-
-    // computation data
-    Scalar  m_sumDotPN {0}, /*!< \brief Sum of the dot product between relative positions and normals */
-            m_sumDotPP {0}, /*!< \brief Sum of the squared relative positions */
-            m_nume     {0}, /*!< \brief Numerator of the quadratic parameter (excluding the 0.5 coefficient)   */
-            m_deno     {0}; /*!< \brief Denominator of the quadratic parameter (excluding the 0.5 coefficient) */
-
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(OrientedSphereFitImpl,orientedSphereFit)
-    PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
-    PONCA_FITTING_IS_SIGNED(true)
-}; //class OrientedSphereFitImpl
-
-/// \brief Helper alias for Oriented Sphere fitting on 3D points using OrientedSphereFitImpl
-//! [OrientedSphereFit Definition]
-template < class DataPoint, class _NFilter, typename T>
-using OrientedSphereFit =
-OrientedSphereFitImpl<DataPoint, _NFilter,
-        MeanPosition<DataPoint, _NFilter,
-            MeanNormal<DataPoint, _NFilter,
-                AlgebraicSphere<DataPoint, _NFilter, T>>>>;
-//! [OrientedSphereFit Definition]
-
-/*!
-    \brief Internal generic class performing the Fit derivation
-*/
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-class OrientedSphereDerImpl : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
-
-protected:
-    enum
-    {
-        Check = Base::PROVIDES_ALGEBRAIC_SPHERE &
-                Base::PROVIDES_MEAN_POSITION_DERIVATIVE &
-                Base::PROVIDES_PRIMITIVE_DERIVATIVE,
-        PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
-        PROVIDES_NORMAL_DERIVATIVE
-    };
-
-    // computation data
-    VectorArray m_dSumN {VectorArray::Zero()};     /*!< \brief Sum of the normal vectors with weight derivatives */
-    ScalarArray m_dSumDotPN {ScalarArray::Zero()}, /*!< \brief Sum of the dot product between relative positions and normals with weight derivatives */
-                m_dSumDotPP {ScalarArray::Zero()}, /*!< \brief Sum of the squared relative positions with weight derivatives */
-                m_dNume {ScalarArray::Zero()},     /*!< \brief Derivatives of the numerator of the quadratic parameter   */
-                m_dDeno {ScalarArray::Zero()};     /*!< \brief Derivatives of the denominator of the quadratic parameter */
-
-public:
-    // results
-    ScalarArray m_dUc {ScalarArray::Zero()}, /*!< \brief Derivatives of the hyper-sphere constant term  */
-                m_dUq {ScalarArray::Zero()}; /*!< \brief Derivatives of the hyper-sphere quadratic term */
-    VectorArray m_dUl {VectorArray::Zero()}; /*!< \brief Derivatives of the hyper-sphere linear term    */
-
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS_DER(OrientedSphereDerImpl,orientedSphereDer)
-
-    PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
-
-    /*! \brief Returns the derivatives of the scalar field at the evaluation point */
-    PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dPotential() const;
-
-    /*! \brief Returns the derivatives of the primitive normal */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorArray dNormal() const;
-
-    /*! \brief compute  the square of the Pratt norm derivative */
-    PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dprattNorm2() const
-    {
-        return   Scalar(2.) * Base::m_ul.transpose() * m_dUl
-            - Scalar(4.) * Base::m_uq * m_dUc
-            - Scalar(4.) * Base::m_uc * m_dUq;
-    }
-
-    /*! \brief compute the square of the Pratt norm derivative for dimension _d */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar dprattNorm2(unsigned int _d) const
-    {
-        return   Scalar(2.) * m_dUl.col(_d).dot(Base::m_ul)
-            - Scalar(4.) * m_dUc.col(_d)[0]*Base::m_uq
-            - Scalar(4.) * m_dUq.col(_d)[0]*Base::m_uc;
-    }
-
-    /*! \brief compute the Pratt norm derivative for the dimension _d */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar dprattNorm(unsigned int _d) const
-    {
-        PONCA_MULTIARCH_STD_MATH(sqrt);
-        return sqrt(dprattNorm2(_d));
-    }
-
-    /*! \brief compute the Pratt norm derivative */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar dprattNorm() const
-    {
-        PONCA_MULTIARCH_STD_MATH(sqrt);
-        return dprattNorm2().array().sqrt();
-    }
-    //! Normalize the scalar field by the Pratt norm
     /*!
-        \warning Requires that isNormalized() return false
-        \return false when the original sphere has already been normalized.
+        \brief Algebraic Sphere fitting procedure on oriented point sets
+
+        Method published in \cite Guennebaud:2007:APSS.
+
+        \inherit Concept::FittingProcedureConcept
+
+        \see AlgebraicSphere
     */
-    PONCA_MULTIARCH [[nodiscard]] inline bool applyPrattNorm();
+    template <class DataPoint, class _NFilter, typename T>
+    class OrientedSphereFitImpl : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
-}; //class OrientedSphereDerImpl
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE && Base::PROVIDES_MEAN_NORMAL && Base::PROVIDES_MEAN_POSITION
+        };
 
-/// \brief Helper alias for Oriented Sphere fitting on 3D points using OrientedSphereDerImpl
-    template < class DataPoint, class _NFilter, int DiffType, typename T>
+        // computation data
+        Scalar m_sumDotPN{0}, /*!< \brief Sum of the dot product between relative positions and normals */
+            m_sumDotPP{0},    /*!< \brief Sum of the squared relative positions */
+            m_nume{0},        /*!< \brief Numerator of the quadratic parameter (excluding the 0.5 coefficient)   */
+            m_deno{0};        /*!< \brief Denominator of the quadratic parameter (excluding the 0.5 coefficient) */
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(OrientedSphereFitImpl, orientedSphereFit)
+        PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
+        PONCA_FITTING_IS_SIGNED(true)
+    }; // class OrientedSphereFitImpl
+
+    /// \brief Helper alias for Oriented Sphere fitting on 3D points using OrientedSphereFitImpl
+    //! [OrientedSphereFit Definition]
+    template <class DataPoint, class _NFilter, typename T>
+    using OrientedSphereFit = OrientedSphereFitImpl<
+        DataPoint, _NFilter,
+        MeanPosition<DataPoint, _NFilter, MeanNormal<DataPoint, _NFilter, AlgebraicSphere<DataPoint, _NFilter, T>>>>;
+    //! [OrientedSphereFit Definition]
+
+    /*!
+        \brief Internal generic class performing the Fit derivation
+    */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class OrientedSphereDerImpl : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
+
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE & Base::PROVIDES_MEAN_POSITION_DERIVATIVE &
+                    Base::PROVIDES_PRIMITIVE_DERIVATIVE,
+            PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
+            PROVIDES_NORMAL_DERIVATIVE
+        };
+
+        // computation data
+        VectorArray m_dSumN{VectorArray::Zero()};     /*!< \brief Sum of the normal vectors with weight derivatives */
+        ScalarArray m_dSumDotPN{ScalarArray::Zero()}, /*!< \brief Sum of the dot product between relative positions and
+                                                         normals with weight derivatives */
+            m_dSumDotPP{
+                ScalarArray::Zero()},     /*!< \brief Sum of the squared relative positions with weight derivatives */
+            m_dNume{ScalarArray::Zero()}, /*!< \brief Derivatives of the numerator of the quadratic parameter   */
+            m_dDeno{ScalarArray::Zero()}; /*!< \brief Derivatives of the denominator of the quadratic parameter */
+
+    public:
+        // results
+        ScalarArray m_dUc{ScalarArray::Zero()}, /*!< \brief Derivatives of the hyper-sphere constant term  */
+            m_dUq{ScalarArray::Zero()};         /*!< \brief Derivatives of the hyper-sphere quadratic term */
+        VectorArray m_dUl{VectorArray::Zero()}; /*!< \brief Derivatives of the hyper-sphere linear term    */
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(OrientedSphereDerImpl, orientedSphereDer)
+
+        PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
+
+        /*! \brief Returns the derivatives of the scalar field at the evaluation point */
+        PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dPotential() const;
+
+        /*! \brief Returns the derivatives of the primitive normal */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorArray dNormal() const;
+
+        /*! \brief compute  the square of the Pratt norm derivative */
+        PONCA_MULTIARCH [[nodiscard]] inline ScalarArray dprattNorm2() const
+        {
+            return Scalar(2.) * Base::m_ul.transpose() * m_dUl - Scalar(4.) * Base::m_uq * m_dUc -
+                   Scalar(4.) * Base::m_uc * m_dUq;
+        }
+
+        /*! \brief compute the square of the Pratt norm derivative for dimension _d */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dprattNorm2(unsigned int _d) const
+        {
+            return Scalar(2.) * m_dUl.col(_d).dot(Base::m_ul) - Scalar(4.) * m_dUc.col(_d)[0] * Base::m_uq -
+                   Scalar(4.) * m_dUq.col(_d)[0] * Base::m_uc;
+        }
+
+        /*! \brief compute the Pratt norm derivative for the dimension _d */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dprattNorm(unsigned int _d) const
+        {
+            PONCA_MULTIARCH_STD_MATH(sqrt);
+            return sqrt(dprattNorm2(_d));
+        }
+
+        /*! \brief compute the Pratt norm derivative */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar dprattNorm() const
+        {
+            PONCA_MULTIARCH_STD_MATH(sqrt);
+            return dprattNorm2().array().sqrt();
+        }
+        //! Normalize the scalar field by the Pratt norm
+        /*!
+            \warning Requires that isNormalized() return false
+            \return false when the original sphere has already been normalized.
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline bool applyPrattNorm();
+
+    }; // class OrientedSphereDerImpl
+
+    /// \brief Helper alias for Oriented Sphere fitting on 3D points using OrientedSphereDerImpl
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     using OrientedSphereDer =
-        OrientedSphereDerImpl<DataPoint, _NFilter, DiffType,
-            MeanPositionDer<DataPoint, _NFilter, DiffType, T>>;
+        OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, MeanPositionDer<DataPoint, _NFilter, DiffType, T>>;
 
 #include "orientedSphereFit.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/orientedSphereFit.hpp
+++ b/Ponca/src/Fitting/orientedSphereFit.hpp
@@ -4,10 +4,8 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
-template < class DataPoint, class _NFilter, typename T>
-void
-OrientedSphereFitImpl<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void OrientedSphereFitImpl<DataPoint, _NFilter, T>::init()
 {
     Base::init();
 
@@ -18,12 +16,12 @@ OrientedSphereFitImpl<DataPoint, _NFilter, T>::init()
     m_deno     = Scalar(0.0);
 }
 
-template<class DataPoint, class _NFilter, typename T>
-bool
-OrientedSphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                        const VectorType &localQ,
-                                                        const DataPoint &attributes) {
-    if( Base::addLocalNeighbor(w, localQ, attributes) ) {
+template <class DataPoint, class _NFilter, typename T>
+bool OrientedSphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                     const DataPoint& attributes)
+{
+    if (Base::addLocalNeighbor(w, localQ, attributes))
+    {
         m_sumDotPN += w * attributes.normal().dot(localQ);
         m_sumDotPP += w * localQ.squaredNorm();
         return true;
@@ -31,43 +29,41 @@ OrientedSphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
     return false;
 }
 
-
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-OrientedSphereFitImpl<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT OrientedSphereFitImpl<DataPoint, _NFilter, T>::finalize()
 {
     PONCA_MULTIARCH_STD_MATH(sqrt);
     PONCA_MULTIARCH_STD_MATH(max);
     PONCA_MULTIARCH_STD_MATH(abs);
 
     // Compute status
-    if(Base::finalize() != STABLE)
+    if (Base::finalize() != STABLE)
         return Base::m_eCurrentState;
-    if(Base::getNumNeighbors() < DataPoint::Dim)
+    if (Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::getNumNeighbors() < 2*DataPoint::Dim ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 2 * DataPoint::Dim ? UNSTABLE : STABLE;
 
     // 1. finalize sphere fitting
     Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision();
 
-    Scalar invSumW = Scalar(1.)/Base::getWeightSum();
+    Scalar invSumW = Scalar(1.) / Base::getWeightSum();
 
-    m_nume = (m_sumDotPN - invSumW * Base::m_sumP.dot(Base::m_sumN));
+    m_nume      = (m_sumDotPN - invSumW * Base::m_sumP.dot(Base::m_sumN));
     Scalar den1 = invSumW * Base::m_sumP.dot(Base::m_sumP);
-    m_deno = m_sumDotPP - den1;
+    m_deno      = m_sumDotPP - den1;
 
     // Deal with degenerate cases
-    if(abs(m_deno) <= epsilon * max(m_sumDotPP, den1))
+    if (abs(m_deno) <= epsilon * max(m_sumDotPP, den1))
     {
         if (Base::m_ul.isZero(0))
             return Base::m_eCurrentState = UNDEFINED;
         // Plane
         Scalar s   = Scalar(1.) / Base::m_ul.norm();
-        Base::m_ul = s*Base::m_ul;
-        Base::m_uc = s*Base::m_uc;
+        Base::m_ul = s * Base::m_ul;
+        Base::m_uc = s * Base::m_uc;
         Base::m_uq = Scalar(0.);
     }
     else
@@ -83,9 +79,8 @@ OrientedSphereFitImpl<DataPoint, _NFilter, T>::finalize ()
     return Base::m_eCurrentState;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-void
-OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::init()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+void OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::init()
 {
     Base::init();
 
@@ -101,16 +96,15 @@ OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::init()
     m_dUl.setZero();
 }
 
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+bool OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                               const DataPoint& attributes,
+                                                                               ScalarArray& dw)
+{
+    if (Base::addLocalNeighbor(w, localQ, attributes, dw))
+    {
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w,
-                                                                           const VectorType &localQ,
-                                                                           const DataPoint &attributes,
-                                                                           ScalarArray &dw) {
-    if( Base::addLocalNeighbor(w, localQ, attributes, dw) ) {
-
-        m_dSumN     += attributes.normal() * dw;
+        m_dSumN += attributes.normal() * dw;
         m_dSumDotPN += dw * attributes.normal().dot(localQ);
         m_dSumDotPP += dw * localQ.squaredNorm();
 
@@ -119,10 +113,8 @@ OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar
     return false;
 }
 
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-FIT_RESULT
-OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+FIT_RESULT OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
 {
     PONCA_MULTIARCH_STD_MATH(sqrt);
 
@@ -130,79 +122,78 @@ OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
     // Test if base finalize end on a viable case (stable / unstable)
     if (this->isReady())
     {
-        Scalar invSumW = Scalar(1.)/Base::getWeightSum();
+        Scalar invSumW = Scalar(1.) / Base::getWeightSum();
 
-        Scalar nume  = Base::m_sumDotPN - invSumW*Base::m_sumP.dot(Base::m_sumN);
-        Scalar deno  = Base::m_sumDotPP - invSumW*Base::m_sumP.dot(Base::m_sumP);
+        Scalar nume = Base::m_sumDotPN - invSumW * Base::m_sumP.dot(Base::m_sumN);
+        Scalar deno = Base::m_sumDotPP - invSumW * Base::m_sumP.dot(Base::m_sumP);
 
         // FIXME, the following product "Base::m_sumN.transpose() * m_dSumP" is prone to numerical cancellation
-        // issues for spacial derivatives because, (d sum w_i P_i)/(d x) is supposed to be tangent to the surface whereas
-        // "sum w_i N_i" is normal to the surface...
-        m_dNume = m_dSumDotPN
-            - invSumW*invSumW * ( Base::getWeightSum() * ( Base::m_sumN.transpose() * Base::m_dSumP + Base::m_sumP.transpose() * m_dSumN )
-            - Base::m_dSumW*Base::m_sumP.dot(Base::m_sumN) );
+        // issues for spacial derivatives because, (d sum w_i P_i)/(d x) is supposed to be tangent to the surface
+        // whereas "sum w_i N_i" is normal to the surface...
+        m_dNume = m_dSumDotPN - invSumW * invSumW *
+                                    (Base::getWeightSum() * (Base::m_sumN.transpose() * Base::m_dSumP +
+                                                             Base::m_sumP.transpose() * m_dSumN) -
+                                     Base::m_dSumW * Base::m_sumP.dot(Base::m_sumN));
 
-        m_dDeno = m_dSumDotPP
-            - invSumW*invSumW*(   Scalar(2.) * Base::getWeightSum() * Base::m_sumP.transpose() * Base::m_dSumP
-            - Base::m_dSumW*Base::m_sumP.dot(Base::m_sumP) );
+        m_dDeno = m_dSumDotPP - invSumW * invSumW *
+                                    (Scalar(2.) * Base::getWeightSum() * Base::m_sumP.transpose() * Base::m_dSumP -
+                                     Base::m_dSumW * Base::m_sumP.dot(Base::m_sumP));
 
-        m_dUq =  Scalar(.5) * (deno * m_dNume - m_dDeno * nume)/(deno*deno);
+        m_dUq = Scalar(.5) * (deno * m_dNume - m_dDeno * nume) / (deno * deno);
 
-        // FIXME: this line is prone to numerical cancellation issues because dSumN and u_l*dSumW are close to each other.
-        // If using two passes, one could directly compute sum( dw_i + (n_i - ul) ) to avoid this issue.
-        m_dUl =  invSumW * ( m_dSumN - Base::m_ul*Base::m_dSumW - Scalar(2.)*(Base::m_dSumP * Base::m_uq + Base::m_sumP * m_dUq) );
-        m_dUc = -invSumW*( Base::m_sumP.transpose() * m_dUl
-            + Base::m_sumDotPP * m_dUq
-            + Base::m_ul.transpose() * Base::m_dSumP
-            + Base::m_uq * m_dSumDotPP
-            + Base::m_dSumW * Base::m_uc);
+        // FIXME: this line is prone to numerical cancellation issues because dSumN and u_l*dSumW are close to each
+        // other. If using two passes, one could directly compute sum( dw_i + (n_i - ul) ) to avoid this issue.
+        m_dUl = invSumW * (m_dSumN - Base::m_ul * Base::m_dSumW -
+                           Scalar(2.) * (Base::m_dSumP * Base::m_uq + Base::m_sumP * m_dUq));
+        m_dUc =
+            -invSumW * (Base::m_sumP.transpose() * m_dUl + Base::m_sumDotPP * m_dUq +
+                        Base::m_ul.transpose() * Base::m_dSumP + Base::m_uq * m_dSumDotPP + Base::m_dSumW * Base::m_uc);
     }
 
     return Base::m_eCurrentState;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename OrientedSphereDerImpl <DataPoint, _NFilter, DiffType, T>::VectorArray
-OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::dNormal() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::VectorArray OrientedSphereDerImpl<
+    DataPoint, _NFilter, DiffType, T>::dNormal() const
 {
-  // Computes the derivatives of the normal of the sphere at the evaluation point.
-  // Therefore, we must take into account the variation of the evaluation point when differentiating wrt space
-  // i.e., normal(x) = grad / |grad|, with grad(x) = ul + 2 uq * x, and diff_x(grad) = dul + 2 uq I
-  VectorArray dgrad = m_dUl;
-  if(Base::isSpaceDer())
-    dgrad.template rightCols<DataPoint::Dim>().diagonal().array() += Scalar(2)*Base::m_uq;
-  Scalar norm  = Base::m_ul.norm();
-  Scalar norm3 = norm*norm*norm;
-  return dgrad / norm - Base::m_ul * (Base::m_ul.transpose() * dgrad) / norm3;
+    // Computes the derivatives of the normal of the sphere at the evaluation point.
+    // Therefore, we must take into account the variation of the evaluation point when differentiating wrt space
+    // i.e., normal(x) = grad / |grad|, with grad(x) = ul + 2 uq * x, and diff_x(grad) = dul + 2 uq I
+    VectorArray dgrad = m_dUl;
+    if (Base::isSpaceDer())
+        dgrad.template rightCols<DataPoint::Dim>().diagonal().array() += Scalar(2) * Base::m_uq;
+    Scalar norm  = Base::m_ul.norm();
+    Scalar norm3 = norm * norm * norm;
+    return dgrad / norm - Base::m_ul * (Base::m_ul.transpose() * dgrad) / norm3;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename OrientedSphereDerImpl <DataPoint, _NFilter, DiffType, T>::ScalarArray
-OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::dPotential() const
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+typename OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::ScalarArray OrientedSphereDerImpl<
+    DataPoint, _NFilter, DiffType, T>::dPotential() const
 {
-  ScalarArray dfield = m_dUc;
-  if(Base::isSpaceDer())
-    dfield.template tail<DataPoint::Dim>() += Base::m_ul;
-  return dfield;
+    ScalarArray dfield = m_dUc;
+    if (Base::isSpaceDer())
+        dfield.template tail<DataPoint::Dim>() += Base::m_ul;
+    return dfield;
 }
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::applyPrattNorm()
+template <class DataPoint, class _NFilter, int DiffType, typename T>
+bool OrientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::applyPrattNorm()
 {
-    if(Base::isNormalized())
-        return false; //need original parameters without Pratt Normalization
+    if (Base::isNormalized())
+        return false; // need original parameters without Pratt Normalization
 
     PONCA_MULTIARCH_STD_MATH(sqrt);
-    Scalar pn2    = Base::prattNorm2();
-    Scalar pn     = sqrt(pn2);
+    Scalar pn2 = Base::prattNorm2();
+    Scalar pn  = sqrt(pn2);
 
     ScalarArray dpn2   = dprattNorm2();
     ScalarArray factor = Scalar(0.5) * dpn2 / pn;
 
-    m_dUc = ( m_dUc * pn - Base::m_uc * factor ) / pn2;
-    m_dUl = ( m_dUl * pn - Base::m_ul * factor ) / pn2;
-    m_dUq = ( m_dUq * pn - Base::m_uq * factor ) / pn2;
+    m_dUc = (m_dUc * pn - Base::m_uc * factor) / pn2;
+    m_dUl = (m_dUl * pn - Base::m_ul * factor) / pn2;
+    m_dUq = (m_dUq * pn - Base::m_uq * factor) / pn2;
 
     Base::applyPrattNorm();
     return true;

--- a/Ponca/src/Fitting/plane.h
+++ b/Ponca/src/Fitting/plane.h
@@ -14,139 +14,147 @@
 namespace Ponca
 {
 
-/*!
-    \brief Implicit hyperplane defined by an homogeneous vector \f$\mathbf{p}\f$.
-
-    In n-dimensionnal space, the plane is defined as
-    the \f$0\f$-isosurface of the scalar field
-
-    \f$ s_\mathbf{u}(\mathbf{x}) =
-    \left[ \mathbf{x}^T \; 1 \;\right]^T \cdot \mathbf{p} \f$.
-
-    This class inherits Eigen::Hyperplane.
-
-    This primitive requires the definition of n-dimensionnal vectors
-    (VectorType) in Concept::PointConcept.
-
-    This primitive provides:
-    \verbatim PROVIDES_PLANE \endverbatim
-*/
-template < class DataPoint, class _NFilter, typename T >
-class Plane : public T,
-              public Eigen::Hyperplane<typename DataPoint::Scalar, DataPoint::Dim >
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-
-public:
-    /// \brief Specialization of Eigen::Hyperplane inherited by Ponca::Plane
-    using EigenBase = Eigen::Hyperplane<typename DataPoint::Scalar, DataPoint::Dim >;
-
-protected:
-    enum { check = Base::PROVIDES_PRIMITIVE_BASE, PROVIDES_PLANE };
-
-public:
-
-    /*! \brief Default constructor */
-    PONCA_MULTIARCH inline Plane() : Base(), EigenBase() { init(); }
-
-    PONCA_EXPLICIT_CAST_OPERATORS(Plane,compactPlane) //< \fixme To be removed, kept for compatibility only
-    PONCA_EXPLICIT_CAST_OPERATORS(Plane,plane)
-
-    /// \brief Set the scalar field values to 0
-    PONCA_MULTIARCH inline void init()
-    {
-        Base::init();
-        EigenBase::coeffs().setZero();
-    }
-
-    /// \brief Tell if the plane as been correctly set.
-    /// Used to set CONFLICT_ERROR_FOUND during fitting
-    /// \return false when called straight after #init. Should be true after fitting
-    PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const{
-        return ! EigenBase::coeffs().isApprox(EigenBase::Coefficients::Zero());
-    }
-
-    PONCA_MULTIARCH inline bool operator==(const Plane<DataPoint, NeighborFilter, T>& other) const{
-        return EigenBase::isApprox(other);
-    }
-
-    /*! \brief Comparison operator, convenience function */
-    PONCA_MULTIARCH inline bool operator!=(const Plane<DataPoint, NeighborFilter, T>& other) const{
-        return ! ((*this) == other);
-    }
-
-    /* \brief Init the plane from a direction and a position
-       \param _dir Orientation of the plane, does not need to be normalized
-       \param _pos Position of the plane
-    */
-    PONCA_MULTIARCH inline void setPlane (const VectorType& _dir,
-                                    const VectorType& _pos)
-    {
-        auto cc = static_cast<EigenBase*>(this);
-        *cc = EigenBase(_dir.normalized(), _pos);
-    }
-
     /*!
-     \brief Express the scalar field relatively to a new basis
+        \brief Implicit hyperplane defined by an homogeneous vector \f$\mathbf{p}\f$.
 
-     The plane in dimension \f$d\f$ is parametrized in the original basis.
-     Moving the basis only affects the constant term:
-    \f$c' = c - \mathbf{u}_l^T.\mathbf{\Delta}\f$ with \f$\Delta=old-new\f$.
+        In n-dimensionnal space, the plane is defined as
+        the \f$0\f$-isosurface of the scalar field
+
+        \f$ s_\mathbf{u}(\mathbf{x}) =
+        \left[ \mathbf{x}^T \; 1 \;\right]^T \cdot \mathbf{p} \f$.
+
+        This class inherits Eigen::Hyperplane.
+
+        This primitive requires the definition of n-dimensionnal vectors
+        (VectorType) in Concept::PointConcept.
+
+        This primitive provides:
+        \verbatim PROVIDES_PLANE \endverbatim
     */
-    PONCA_MULTIARCH inline void changeBasis(const VectorType& newbasis)
+    template <class DataPoint, class _NFilter, typename T>
+    class Plane : public T, public Eigen::Hyperplane<typename DataPoint::Scalar, DataPoint::Dim>
     {
-        VectorType diff = Base::getNeighborFilter().evalPos() - newbasis;
-        Base::m_nFilter.changeNeighborhoodFrame(newbasis);
-        Base::init();
-        EigenBase::offset() -= EigenBase::normal().dot(diff);
-    }
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
-    //! \brief Value of the scalar field at the evaluation point
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potential ( ) const
-    {
-        return EigenBase::signedDistance(VectorType::Zero());
-    }
+    public:
+        /// \brief Specialization of Eigen::Hyperplane inherited by Ponca::Plane
+        using EigenBase = Eigen::Hyperplane<typename DataPoint::Scalar, DataPoint::Dim>;
 
-    //! \brief Value of the scalar field at the location \f$ \mathbf{q} \f$
-    //! \see method `#isSigned` of the fit to check if the sign is reliable
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potential (const VectorType& _q) const
-    {
-        // turn to centered basis
-        const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
-        return potentialLocal( lq );
-    }
+    protected:
+        enum
+        {
+            check = Base::PROVIDES_PRIMITIVE_BASE,
+            PROVIDES_PLANE
+        };
 
-    //! \brief Project a point on the plane
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType project (const VectorType& _q) const
-    {
-        // Project on the normal vector and add the offset value
-        return Base::getNeighborFilter().convertToGlobalBasis(EigenBase::projection(Base::getNeighborFilter().convertToLocalBasis(_q)));
-    }
+    public:
+        /*! \brief Default constructor */
+        PONCA_MULTIARCH inline Plane() : Base(), EigenBase() { init(); }
 
-    //! \brief Scalar field gradient direction at the evaluation point
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient () const
-    {
-        // Uniform gradient defined only by the orientation of the plane
-        return EigenBase::normal();
-    }
+        PONCA_EXPLICIT_CAST_OPERATORS(Plane, compactPlane) //< \fixme To be removed, kept for compatibility only
+        PONCA_EXPLICIT_CAST_OPERATORS(Plane, plane)
 
-    //! \brief Scalar field gradient direction at \f$ \mathbf{q}\f$
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient (const VectorType& /*_q*/) const
-    {
-        // Uniform gradient defined only by the orientation of the plane
-        return EigenBase::normal();
-    }
-protected:
-    /// \copydoc Plane::potential
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal (const VectorType& _lq) const {
-        // The potential is the distance from the point to the plane
-        return EigenBase::signedDistance(_lq);
-    }
-    /// \copydoc Plane::primitiveGradient
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal (const VectorType&  /*_lq*/) const {
-        return EigenBase::normal();
-    }
-}; //class Plane
+        /// \brief Set the scalar field values to 0
+        PONCA_MULTIARCH inline void init()
+        {
+            Base::init();
+            EigenBase::coeffs().setZero();
+        }
 
-}
+        /// \brief Tell if the plane as been correctly set.
+        /// Used to set CONFLICT_ERROR_FOUND during fitting
+        /// \return false when called straight after #init. Should be true after fitting
+        PONCA_MULTIARCH [[nodiscard]] inline bool isValid() const
+        {
+            return !EigenBase::coeffs().isApprox(EigenBase::Coefficients::Zero());
+        }
+
+        PONCA_MULTIARCH inline bool operator==(const Plane<DataPoint, NeighborFilter, T>& other) const
+        {
+            return EigenBase::isApprox(other);
+        }
+
+        /*! \brief Comparison operator, convenience function */
+        PONCA_MULTIARCH inline bool operator!=(const Plane<DataPoint, NeighborFilter, T>& other) const
+        {
+            return !((*this) == other);
+        }
+
+        /* \brief Init the plane from a direction and a position
+           \param _dir Orientation of the plane, does not need to be normalized
+           \param _pos Position of the plane
+        */
+        PONCA_MULTIARCH inline void setPlane(const VectorType& _dir, const VectorType& _pos)
+        {
+            auto cc = static_cast<EigenBase*>(this);
+            *cc     = EigenBase(_dir.normalized(), _pos);
+        }
+
+        /*!
+         \brief Express the scalar field relatively to a new basis
+
+         The plane in dimension \f$d\f$ is parametrized in the original basis.
+         Moving the basis only affects the constant term:
+        \f$c' = c - \mathbf{u}_l^T.\mathbf{\Delta}\f$ with \f$\Delta=old-new\f$.
+        */
+        PONCA_MULTIARCH inline void changeBasis(const VectorType& newbasis)
+        {
+            VectorType diff = Base::getNeighborFilter().evalPos() - newbasis;
+            Base::m_nFilter.changeNeighborhoodFrame(newbasis);
+            Base::init();
+            EigenBase::offset() -= EigenBase::normal().dot(diff);
+        }
+
+        //! \brief Value of the scalar field at the evaluation point
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential() const
+        {
+            return EigenBase::signedDistance(VectorType::Zero());
+        }
+
+        //! \brief Value of the scalar field at the location \f$ \mathbf{q} \f$
+        //! \see method `#isSigned` of the fit to check if the sign is reliable
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potential(const VectorType& _q) const
+        {
+            // turn to centered basis
+            const VectorType lq = Base::getNeighborFilter().convertToLocalBasis(_q);
+            return potentialLocal(lq);
+        }
+
+        //! \brief Project a point on the plane
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType project(const VectorType& _q) const
+        {
+            // Project on the normal vector and add the offset value
+            return Base::getNeighborFilter().convertToGlobalBasis(
+                EigenBase::projection(Base::getNeighborFilter().convertToLocalBasis(_q)));
+        }
+
+        //! \brief Scalar field gradient direction at the evaluation point
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient() const
+        {
+            // Uniform gradient defined only by the orientation of the plane
+            return EigenBase::normal();
+        }
+
+        //! \brief Scalar field gradient direction at \f$ \mathbf{q}\f$
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradient(const VectorType& /*_q*/) const
+        {
+            // Uniform gradient defined only by the orientation of the plane
+            return EigenBase::normal();
+        }
+
+    protected:
+        /// \copydoc Plane::potential
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar potentialLocal(const VectorType& _lq) const
+        {
+            // The potential is the distance from the point to the plane
+            return EigenBase::signedDistance(_lq);
+        }
+        /// \copydoc Plane::primitiveGradient
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType primitiveGradientLocal(const VectorType& /*_lq*/) const
+        {
+            return EigenBase::normal();
+        }
+    }; // class Plane
+
+} // namespace Ponca

--- a/Ponca/src/Fitting/primitive.h
+++ b/Ponca/src/Fitting/primitive.h
@@ -15,214 +15,207 @@
 namespace Ponca
 {
 
-/*!
-    \brief Primitive base class.
+    /*!
+        \brief Primitive base class.
 
-    This class stores and provides public access to the fitting state, and must
-    be inherited by classes implementing new primitives.
+        This class stores and provides public access to the fitting state, and must
+        be inherited by classes implementing new primitives.
 
-    \note This class should not be inherited explicitly: this is done by the
-    #Basket class.
-*/
-template < class DataPoint, class _NFilter, typename T = void  >
-class PrimitiveBase
-{
-protected:
-    enum {
-        PROVIDES_PRIMITIVE_BASE,    /*!< \brief Provides base API for primitives*/
-    };
-
-public:
-    using Scalar         = typename DataPoint::Scalar;     /*!< \brief Inherited scalar type*/
-    using VectorType     = typename DataPoint::VectorType; /*!< \brief Inherited vector type*/
-    using NeighborFilter = _NFilter;                       /*!< \brief Filter applied on each neighbor*/
-
-private:
-    //! \brief Number of neighbors
-    int m_nbNeighbors {0};
-
-    //! \brief Sum of the neighbors weights
-    Scalar m_sumW {0};
-
-protected:
-    //! \brief Neighborhood filter
-    NeighborFilter   m_nFilter;
-
-    //! \brief Represent the current state of the fit (finalize function
-    //! update the state)
-    FIT_RESULT m_eCurrentState {UNDEFINED};
-
-public:
-    /**************************************************************************/
-    /* Initialization                                                         */
-    /**************************************************************************/
-    PONCA_FITTING_APIDOC_SETWFUNC
-    PONCA_MULTIARCH inline void setNeighborFilter (const NeighborFilter& _nFilter) {
-        m_nFilter  = _nFilter;
-    }
-
-    PONCA_FITTING_APIDOC_INIT
-    PONCA_MULTIARCH inline void init()
+        \note This class should not be inherited explicitly: this is done by the
+        #Basket class.
+    */
+    template <class DataPoint, class _NFilter, typename T = void>
+    class PrimitiveBase
     {
-        m_eCurrentState = UNDEFINED;
-        startNewPass();
-    }
+    protected:
+        enum
+        {
+            PROVIDES_PRIMITIVE_BASE, /*!< \brief Provides base API for primitives*/
+        };
 
-    /*! \brief Is the primitive well fitted and ready to use (finalize has been
-    called) ?
-    \warning The fit can be unstable (having neighbors between 3 and 6) */
-    PONCA_MULTIARCH [[nodiscard]] inline bool isReady() const
-    {
-        return (m_eCurrentState == STABLE) || (m_eCurrentState == UNSTABLE);
-    }
+    public:
+        using Scalar         = typename DataPoint::Scalar;     /*!< \brief Inherited scalar type*/
+        using VectorType     = typename DataPoint::VectorType; /*!< \brief Inherited vector type*/
+        using NeighborFilter = _NFilter;                       /*!< \brief Filter applied on each neighbor*/
 
-    /*! \brief Is the fitted primitive ready to use (finalize has been called and the result is stable) */
-    PONCA_MULTIARCH [[nodiscard]] inline bool isStable() const { return m_eCurrentState == STABLE; }
+    private:
+        //! \brief Number of neighbors
+        int m_nbNeighbors{0};
 
-    /*! \brief Is another pass required for fitting (finalize has been called and the result is #NEED_OTHER_PASS)
-     * \see startNewPass */
-    PONCA_MULTIARCH [[nodiscard]] inline bool needAnotherPass() const { return m_eCurrentState == NEED_OTHER_PASS; }
+        //! \brief Sum of the neighbors weights
+        Scalar m_sumW{0};
 
-    /*! \brief Get number of points added in the neighborhood (with non negative weight)  */
-    PONCA_MULTIARCH [[nodiscard]] inline int getNumNeighbors() const { return m_nbNeighbors; }
+    protected:
+        //! \brief Neighborhood filter
+        NeighborFilter m_nFilter;
 
-    /*! \brief Get the sum of the weights */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar getWeightSum() const { return m_sumW; }
+        //! \brief Represent the current state of the fit (finalize function
+        //! update the state)
+        FIT_RESULT m_eCurrentState{UNDEFINED};
 
-    /*! \brief To be called when starting a new processing pass, ie. when `getCurrentState()==#NEED_ANOTHER_PASS` */
-    PONCA_MULTIARCH inline void startNewPass() {
-        m_nbNeighbors = 0;
-        m_sumW = Scalar(0);
-    }
+    public:
+        /**************************************************************************/
+        /* Initialization                                                         */
+        /**************************************************************************/
+        PONCA_FITTING_APIDOC_SETWFUNC
+        PONCA_MULTIARCH inline void setNeighborFilter(const NeighborFilter& _nFilter) { m_nFilter = _nFilter; }
 
-    /*! \brief Read access to the NeighborFilter \see setNeighborFilter */
-    PONCA_MULTIARCH inline const NeighborFilter& getNeighborFilter() const
-    {
-        return m_nFilter;
-    }
-
-public:
-    /*! \return the current test of the fit */
-    PONCA_MULTIARCH [[nodiscard]] inline FIT_RESULT getCurrentState() const
-    {
-        return m_eCurrentState;
-    }
-
-    PONCA_FITTING_APIDOC_ADDNEIGHBOR
-    PONCA_MULTIARCH [[nodiscard]] inline bool addLocalNeighbor(Scalar w, const VectorType &, const DataPoint &) {
-        m_sumW += w;
-        ++(m_nbNeighbors);
-        return true;
-    }
-
-    PONCA_FITTING_APIDOC_FINALIZE
-    PONCA_MULTIARCH inline FIT_RESULT finalize(){
-        // handle specific configurations
-        if (m_sumW == Scalar(0.) || m_nbNeighbors < 1) {
-            return m_eCurrentState = UNDEFINED;
+        PONCA_FITTING_APIDOC_INIT
+        PONCA_MULTIARCH inline void init()
+        {
+            m_eCurrentState = UNDEFINED;
+            startNewPass();
         }
-        return m_eCurrentState = STABLE;
-    }
 
-}; //class Primitive
+        /*! \brief Is the primitive well fitted and ready to use (finalize has been
+        called) ?
+        \warning The fit can be unstable (having neighbors between 3 and 6) */
+        PONCA_MULTIARCH [[nodiscard]] inline bool isReady() const
+        {
+            return (m_eCurrentState == STABLE) || (m_eCurrentState == UNSTABLE);
+        }
 
+        /*! \brief Is the fitted primitive ready to use (finalize has been called and the result is stable) */
+        PONCA_MULTIARCH [[nodiscard]] inline bool isStable() const { return m_eCurrentState == STABLE; }
 
+        /*! \brief Is another pass required for fitting (finalize has been called and the result is #NEED_OTHER_PASS)
+         * \see startNewPass */
+        PONCA_MULTIARCH [[nodiscard]] inline bool needAnotherPass() const { return m_eCurrentState == NEED_OTHER_PASS; }
 
+        /*! \brief Get number of points added in the neighborhood (with non negative weight)  */
+        PONCA_MULTIARCH [[nodiscard]] inline int getNumNeighbors() const { return m_nbNeighbors; }
 
+        /*! \brief Get the sum of the weights */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar getWeightSum() const { return m_sumW; }
 
-/**
-    \brief Generic class performing the Fit derivation
-    \inherit Concept::FittingExtensionConcept
+        /*! \brief To be called when starting a new processing pass, ie. when `getCurrentState()==#NEED_ANOTHER_PASS` */
+        PONCA_MULTIARCH inline void startNewPass()
+        {
+            m_nbNeighbors = 0;
+            m_sumW        = Scalar(0);
+        }
 
-    The differentiation can be done automatically in scale and/or space, by
-    combining the enum values FitScaleDer and FitSpaceDer in the template
-    parameter Type.
+        /*! \brief Read access to the NeighborFilter \see setNeighborFilter */
+        PONCA_MULTIARCH inline const NeighborFilter& getNeighborFilter() const { return m_nFilter; }
 
-    The differentiated values are stored in static arrays. The size of the
-    arrays is computed with respect to the derivation type (scale and/or space)
-    and the number of the dimension of the ambiant space.
-    By convention, the scale derivatives are stored at index 0 when Type
-    contains at least FitScaleDer. The size of these arrays can be known using
-    derDimension(), and the differentiation type by isScaleDer() and
-    isSpaceDer().
+    public:
+        /*! \return the current test of the fit */
+        PONCA_MULTIARCH [[nodiscard]] inline FIT_RESULT getCurrentState() const { return m_eCurrentState; }
 
-    Thanks to the BasketDiff definition, we know that PrimitiveDer has Primitive
-    as base class (through the Basket). As a result, this class first asks to
-    compute the Fit, and if it works properly, compute the weight derivatives.
- */
-template < class DataPoint, class _NFilter, int Type, typename T>
-class PrimitiveDer : public T
-{
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_MATRIX_TYPE
-protected:
-    enum {
-        Check = Base::PROVIDES_PRIMITIVE_BASE,    /*!< \brief Provides base API for primitives*/
-        PROVIDES_PRIMITIVE_DERIVATIVE
-    };
-
-protected:
-    static constexpr  int NbDerivatives   = ((Type & FitScaleDer) ? 1 : 0 ) + ((Type & FitSpaceDer) ? DataPoint::Dim : 0);
-    static constexpr  int DerStorageOrder = (Type & FitSpaceDer) ? Eigen::RowMajor : Eigen::ColMajor;
-
-public:
-
-    /*! \brief Static array of scalars with a size adapted to the differentiation type */
-    typedef Eigen::Matrix<Scalar, DataPoint::Dim, NbDerivatives, DerStorageOrder> VectorArray;
-
-    /*! \brief Static array of scalars with a size adapted to the differentiation type */
-    typedef Eigen::Matrix<Scalar, 1, NbDerivatives> ScalarArray;
-
-protected:
-    // computation data
-    ScalarArray m_dSumW;      /*!< \brief Sum of weight derivatives */
-
-public:
-
-    /************************************************************************/
-    /* Initialization                                                       */
-    /************************************************************************/
-    /*! \see Concept::FittingProcedureConcept::init() */
-    PONCA_MULTIARCH inline void init()
-    { Base::init(); m_dSumW.setZero(); }
-
-    /************************************************************************/
-    /* Processing                                                           */
-    /************************************************************************/
-    /*! \see Concept::FittingProcedureConcept::addLocalNeighbor()
-     * \todo update doc (takes derivatives) */
-    PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w,
-                                                 const VectorType &localQ,
-                                                 const DataPoint &attributes,
-                                                 ScalarArray &dw)
-    {
-        if( Base::addLocalNeighbor(w, localQ, attributes) ) { // call the Primitive Fit (without dw)
-            int spaceId = (Type & FitScaleDer) ? 1 : 0;
-            // compute weight
-            if (Type & FitScaleDer)
-                dw[0] = Base::getNeighborFilter().scaledw(attributes.pos(), attributes);
-
-            if (Type & FitSpaceDer)
-                dw.template segment<int(DataPoint::Dim)>(spaceId) = -Base::getNeighborFilter().spacedw(attributes.pos(), attributes).transpose();
-
-            m_dSumW += dw;
+        PONCA_FITTING_APIDOC_ADDNEIGHBOR
+        PONCA_MULTIARCH [[nodiscard]] inline bool addLocalNeighbor(Scalar w, const VectorType&, const DataPoint&)
+        {
+            m_sumW += w;
+            ++(m_nbNeighbors);
             return true;
         }
-        return false;
-    }
 
-    /**************************************************************************/
-    /* Use results                                                            */
-    /**************************************************************************/
-    /*! \brief State specified at compilation time to compute derivatives in scale */
-    PONCA_MULTIARCH [[nodiscard]] static inline constexpr bool isScaleDer() {return bool(Type & FitScaleDer);}
-    /*! \brief State specified at compilation time to compute derivatives in space */
-    PONCA_MULTIARCH [[nodiscard]] static inline constexpr bool isSpaceDer() {return bool(Type & FitSpaceDer);}
-    /*! \brief Number of dimensions used for the differentiation */
-    PONCA_MULTIARCH [[nodiscard]] static inline constexpr unsigned int derDimension() { return NbDerivatives;}
+        PONCA_FITTING_APIDOC_FINALIZE
+        PONCA_MULTIARCH inline FIT_RESULT finalize()
+        {
+            // handle specific configurations
+            if (m_sumW == Scalar(0.) || m_nbNeighbors < 1)
+            {
+                return m_eCurrentState = UNDEFINED;
+            }
+            return m_eCurrentState = STABLE;
+        }
 
-};
+    }; // class Primitive
 
+    /**
+        \brief Generic class performing the Fit derivation
+        \inherit Concept::FittingExtensionConcept
 
+        The differentiation can be done automatically in scale and/or space, by
+        combining the enum values FitScaleDer and FitSpaceDer in the template
+        parameter Type.
 
-}
+        The differentiated values are stored in static arrays. The size of the
+        arrays is computed with respect to the derivation type (scale and/or space)
+        and the number of the dimension of the ambiant space.
+        By convention, the scale derivatives are stored at index 0 when Type
+        contains at least FitScaleDer. The size of these arrays can be known using
+        derDimension(), and the differentiation type by isScaleDer() and
+        isSpaceDer().
+
+        Thanks to the BasketDiff definition, we know that PrimitiveDer has Primitive
+        as base class (through the Basket). As a result, this class first asks to
+        compute the Fit, and if it works properly, compute the weight derivatives.
+     */
+    template <class DataPoint, class _NFilter, int Type, typename T>
+    class PrimitiveDer : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_MATRIX_TYPE
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_PRIMITIVE_BASE, /*!< \brief Provides base API for primitives*/
+            PROVIDES_PRIMITIVE_DERIVATIVE
+        };
+
+    protected:
+        static constexpr int NbDerivatives =
+            ((Type & FitScaleDer) ? 1 : 0) + ((Type & FitSpaceDer) ? DataPoint::Dim : 0);
+        static constexpr int DerStorageOrder = (Type & FitSpaceDer) ? Eigen::RowMajor : Eigen::ColMajor;
+
+    public:
+        /*! \brief Static array of scalars with a size adapted to the differentiation type */
+        typedef Eigen::Matrix<Scalar, DataPoint::Dim, NbDerivatives, DerStorageOrder> VectorArray;
+
+        /*! \brief Static array of scalars with a size adapted to the differentiation type */
+        typedef Eigen::Matrix<Scalar, 1, NbDerivatives> ScalarArray;
+
+    protected:
+        // computation data
+        ScalarArray m_dSumW; /*!< \brief Sum of weight derivatives */
+
+    public:
+        /************************************************************************/
+        /* Initialization                                                       */
+        /************************************************************************/
+        /*! \see Concept::FittingProcedureConcept::init() */
+        PONCA_MULTIARCH inline void init()
+        {
+            Base::init();
+            m_dSumW.setZero();
+        }
+
+        /************************************************************************/
+        /* Processing                                                           */
+        /************************************************************************/
+        /*! \see Concept::FittingProcedureConcept::addLocalNeighbor()
+         * \todo update doc (takes derivatives) */
+        PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType& localQ, const DataPoint& attributes,
+                                                     ScalarArray& dw)
+        {
+            if (Base::addLocalNeighbor(w, localQ, attributes))
+            { // call the Primitive Fit (without dw)
+                int spaceId = (Type & FitScaleDer) ? 1 : 0;
+                // compute weight
+                if (Type & FitScaleDer)
+                    dw[0] = Base::getNeighborFilter().scaledw(attributes.pos(), attributes);
+
+                if (Type & FitSpaceDer)
+                    dw.template segment<int(DataPoint::Dim)>(spaceId) =
+                        -Base::getNeighborFilter().spacedw(attributes.pos(), attributes).transpose();
+
+                m_dSumW += dw;
+                return true;
+            }
+            return false;
+        }
+
+        /**************************************************************************/
+        /* Use results                                                            */
+        /**************************************************************************/
+        /*! \brief State specified at compilation time to compute derivatives in scale */
+        PONCA_MULTIARCH [[nodiscard]] static inline constexpr bool isScaleDer() { return bool(Type & FitScaleDer); }
+        /*! \brief State specified at compilation time to compute derivatives in space */
+        PONCA_MULTIARCH [[nodiscard]] static inline constexpr bool isSpaceDer() { return bool(Type & FitSpaceDer); }
+        /*! \brief Number of dimensions used for the differentiation */
+        PONCA_MULTIARCH [[nodiscard]] static inline constexpr unsigned int derDimension() { return NbDerivatives; }
+    };
+
+} // namespace Ponca

--- a/Ponca/src/Fitting/sphereFit.h
+++ b/Ponca/src/Fitting/sphereFit.h
@@ -8,90 +8,88 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "./algebraicSphere.h"
 
-
 namespace Ponca
 {
 
-/*!
-    \brief Algebraic Sphere fitting procedure on point set without normals
+    /*!
+        \brief Algebraic Sphere fitting procedure on point set without normals
 
-    This method published in \cite Guennebaud:2007:APSS minimizes
-    \f[
-        \mathcal{L}(\mathbf{u}) = \frac{1}{2} \sum_i w_i f_{\mathbf{u}}(\mathbf{x}_i)^2 = \frac{1}{2} \mathbf{u}^T A \mathbf{u}
-    \f]
-    with \f$ A = \sum_i w_i \tilde{\mathbf{x}_i}  \tilde{\mathbf{x}_i}^T\f$ and \f$ f_{\mathbf{u}} \f$ the algebraic sphere defined by
-    \f[
-        f_{\mathbf{u}}(\mathbf{x}) =
-        u_c + \mathbf{u}_l.\mathbf{x} + u_q \mathbf{x}.\mathbf{x} =
-        \begin{bmatrix}
-        1 & \mathbf{x}^T & \mathbf{x}.\mathbf{x}
-        \end{bmatrix}
-        \begin{bmatrix}
-        u_c \\ u_l \\ u_q
-        \end{bmatrix}
-        = \tilde{\mathbf{x}}^T \mathbf{u},
-    \f]
-    under the constraint (unitary gradient onto the surface)
-    \f[
-        \|\mathbf{u}_l\|^2 - 4 u_c u_q = \mathbf{u}^T C \mathbf{u} = 1
-    \f]
-    where
-    \f[
-        C =
-        \begin{bmatrix}
-            0 &   &         &   & -2 \\
-              & 1 &         &   &    \\
-              &   &  \ddots &   &    \\
-              &   &         & 1 &    \\
-           -2 &   &         &   &  0
-        \end{bmatrix}
-    \f]
-    which amounts to solve the generalized eigenvalue problem \f$ A\mathbf{u} = \lambda C \mathbf{u} \f$.
+        This method published in \cite Guennebaud:2007:APSS minimizes
+        \f[
+            \mathcal{L}(\mathbf{u}) = \frac{1}{2} \sum_i w_i f_{\mathbf{u}}(\mathbf{x}_i)^2 = \frac{1}{2} \mathbf{u}^T A
+       \mathbf{u}
+        \f]
+        with \f$ A = \sum_i w_i \tilde{\mathbf{x}_i}  \tilde{\mathbf{x}_i}^T\f$ and \f$ f_{\mathbf{u}} \f$ the algebraic
+       sphere defined by
+        \f[
+            f_{\mathbf{u}}(\mathbf{x}) =
+            u_c + \mathbf{u}_l.\mathbf{x} + u_q \mathbf{x}.\mathbf{x} =
+            \begin{bmatrix}
+            1 & \mathbf{x}^T & \mathbf{x}.\mathbf{x}
+            \end{bmatrix}
+            \begin{bmatrix}
+            u_c \\ u_l \\ u_q
+            \end{bmatrix}
+            = \tilde{\mathbf{x}}^T \mathbf{u},
+        \f]
+        under the constraint (unitary gradient onto the surface)
+        \f[
+            \|\mathbf{u}_l\|^2 - 4 u_c u_q = \mathbf{u}^T C \mathbf{u} = 1
+        \f]
+        where
+        \f[
+            C =
+            \begin{bmatrix}
+                0 &   &         &   & -2 \\
+                  & 1 &         &   &    \\
+                  &   &  \ddots &   &    \\
+                  &   &         & 1 &    \\
+               -2 &   &         &   &  0
+            \end{bmatrix}
+        \f]
+        which amounts to solve the generalized eigenvalue problem \f$ A\mathbf{u} = \lambda C \mathbf{u} \f$.
 
-    \inherit Concept::FittingProcedureConcept
+        \inherit Concept::FittingProcedureConcept
 
-    \see AlgebraicSphere
-*/
-template < class DataPoint, class _NFilter, typename T >
-class SphereFitImpl : public T
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-
-protected:
-    enum
+        \see AlgebraicSphere
+    */
+    template <class DataPoint, class _NFilter, typename T>
+    class SphereFitImpl : public T
     {
-        Check = Base::PROVIDES_ALGEBRAIC_SPHERE
-    };
-protected:
-    typedef Eigen::Matrix<Scalar, DataPoint::Dim+2, 1>      VectorA;
-    typedef Eigen::Matrix<Scalar, DataPoint::Dim+2, DataPoint::Dim+2>  MatrixA;
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
-public:
-    using Solver = Eigen::EigenSolver<MatrixA>;
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE
+        };
 
-protected:
-    // computation data
-    MatrixA  m_matA {MatrixA::Zero()};  /*!< \brief Covariance matrix of [1, p, p^2] */
+    protected:
+        typedef Eigen::Matrix<Scalar, DataPoint::Dim + 2, 1> VectorA;
+        typedef Eigen::Matrix<Scalar, DataPoint::Dim + 2, DataPoint::Dim + 2> MatrixA;
 
-    Solver m_solver;
+    public:
+        using Solver = Eigen::EigenSolver<MatrixA>;
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(SphereFitImpl,sphereFit)
-    PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
-    PONCA_FITTING_IS_SIGNED(false)
+    protected:
+        // computation data
+        MatrixA m_matA{MatrixA::Zero()}; /*!< \brief Covariance matrix of [1, p, p^2] */
 
-    PONCA_MULTIARCH inline const Solver& solver() const { return m_solver; }
+        Solver m_solver;
 
-}; //class SphereFit
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(SphereFitImpl, sphereFit)
+        PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
+        PONCA_FITTING_IS_SIGNED(false)
 
-/// \brief Helper alias for Sphere fitting on 3D points using SphereFitImpl
-template < class DataPoint, class _NFilter, typename T>
-using SphereFit =
-    SphereFitImpl<DataPoint, _NFilter,
-        AlgebraicSphere<DataPoint, _NFilter, T>>;
+        PONCA_MULTIARCH inline const Solver& solver() const { return m_solver; }
 
+    }; // class SphereFit
 
+    /// \brief Helper alias for Sphere fitting on 3D points using SphereFitImpl
+    template <class DataPoint, class _NFilter, typename T>
+    using SphereFit = SphereFitImpl<DataPoint, _NFilter, AlgebraicSphere<DataPoint, _NFilter, T>>;
 
 #include "sphereFit.hpp"
 
-} //namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/sphereFit.hpp
+++ b/Ponca/src/Fitting/sphereFit.hpp
@@ -4,65 +4,60 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
-template < class DataPoint, class _NFilter, typename T>
-void
-SphereFitImpl<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void SphereFitImpl<DataPoint, _NFilter, T>::init()
 {
     Base::init();
     m_matA.setZero();
 }
 
-template < class DataPoint, class _NFilter, typename T>
-bool
-SphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                     const VectorType &localQ,
-                                                     const DataPoint &attributes)
+template <class DataPoint, class _NFilter, typename T>
+bool SphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                             const DataPoint& attributes)
 {
-    if( Base::addLocalNeighbor(w, localQ, attributes) ) {
+    if (Base::addLocalNeighbor(w, localQ, attributes))
+    {
         VectorA a;
 #ifdef __CUDACC__
-        a(0) = 1;
+        a(0)                                  = 1;
         a.template segment<DataPoint::Dim>(1) = localQ;
-        a(DataPoint::Dim+1) = localQ.squaredNorm();
+        a(DataPoint::Dim + 1)                 = localQ.squaredNorm();
 #else
         a << 1, localQ, localQ.squaredNorm();
 #endif
-        m_matA     += w * a * a.transpose();
+        m_matA += w * a * a.transpose();
         return true;
     }
 
     return false;
 }
 
-
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-SphereFitImpl<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT SphereFitImpl<DataPoint, _NFilter, T>::finalize()
 {
     // Compute status
-    if(Base::finalize() != STABLE)
+    if (Base::finalize() != STABLE)
         return Base::m_eCurrentState;
-    if(Base::getNumNeighbors() < DataPoint::Dim)
+    if (Base::getNumNeighbors() < DataPoint::Dim)
         return Base::m_eCurrentState = UNDEFINED;
     if (Base::algebraicSphere().isValid())
         Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
     else
-        Base::m_eCurrentState = Base::getNumNeighbors() < 2*DataPoint::Dim ? UNSTABLE : STABLE;
+        Base::m_eCurrentState = Base::getNumNeighbors() < 2 * DataPoint::Dim ? UNSTABLE : STABLE;
 
     MatrixA matC;
     matC.setIdentity();
-    matC.template topRightCorner<1,1>()    << -2;
-    matC.template bottomLeftCorner<1,1>()  << -2;
-    matC.template topLeftCorner<1,1>()     << 0;
-    matC.template bottomRightCorner<1,1>() << 0;
+    matC.template topRightCorner<1, 1>() << -2;
+    matC.template bottomLeftCorner<1, 1>() << -2;
+    matC.template topLeftCorner<1, 1>() << 0;
+    matC.template bottomRightCorner<1, 1>() << 0;
 
     MatrixA invCpratt;
     invCpratt.setIdentity();
-    invCpratt.template topRightCorner<1,1>()    << -0.5;
-    invCpratt.template bottomLeftCorner<1,1>()  << -0.5;
-    invCpratt.template topLeftCorner<1,1>()     << 0;
-    invCpratt.template bottomRightCorner<1,1>() << 0;
+    invCpratt.template topRightCorner<1, 1>() << -0.5;
+    invCpratt.template bottomLeftCorner<1, 1>() << -0.5;
+    invCpratt.template topLeftCorner<1, 1>() << 0;
+    invCpratt.template bottomRightCorner<1, 1>() << 0;
 
     // Remarks:
     //   A and C are symmetric so all eigenvalues and eigenvectors are real
@@ -76,19 +71,19 @@ SphereFitImpl<DataPoint, _NFilter, T>::finalize ()
     m_solver.compute(invCpratt * m_matA);
 #endif
     VectorA eivals = m_solver.eigenvalues().real();
-    int minId = -1;
-    for(int i=0 ; i<DataPoint::Dim+2 ; ++i)
+    int minId      = -1;
+    for (int i = 0; i < DataPoint::Dim + 2; ++i)
     {
-    Scalar ev = eivals(i);
-    if((ev>0) && (minId==-1 || ev<eivals(minId)))
-    minId = i;
+        Scalar ev = eivals(i);
+        if ((ev > 0) && (minId == -1 || ev < eivals(minId)))
+            minId = i;
     }
 
-    //mLambda = eivals(minId);
+    // mLambda = eivals(minId);
     VectorA vecU = m_solver.eigenvectors().col(minId).real();
-    Base::m_uq = vecU[1+DataPoint::Dim];
-    Base::m_ul = vecU.template segment<DataPoint::Dim>(1);
-    Base::m_uc = vecU[0];
+    Base::m_uq   = vecU[1 + DataPoint::Dim];
+    Base::m_ul   = vecU.template segment<DataPoint::Dim>(1);
+    Base::m_uc   = vecU[0];
 
     Base::m_isNormalized = false;
 

--- a/Ponca/src/Fitting/unorientedSphereFit.h
+++ b/Ponca/src/Fitting/unorientedSphereFit.h
@@ -9,122 +9,121 @@
 #pragma once
 
 #include "./algebraicSphere.h"
-#include "./mean.h"          // used to define UnorientedSphereFit
+#include "./mean.h" // used to define UnorientedSphereFit
 
 #include <Eigen/Dense>
 
 namespace Ponca
 {
-/*!
-    \brief Algebraic Sphere fitting procedure on point sets with non-oriented normals
+    /*!
+        \brief Algebraic Sphere fitting procedure on point sets with non-oriented normals
 
-    This method published in \cite Chen:2013:NOMG maximizes the sum of squared dot product between the input normal vectors and the gradient of the algebraic sphere.
-    The maximization is done under the constraint that the norm of the gradient is unitary on average.
-    In practice, it amounts to solve the generalized eigenvalue problem
-    \f[
-        A \mathbf{u} = \lambda Q \mathbf{u}
-    \f]
-    where
-    \f[
-        \mathbf{u} = \begin{bmatrix} u_l \\ u_q \end{bmatrix}
-    \f]
-    \f[
-        A = \sum_i w_i \begin{bmatrix} \mathbf{n}_i \\ \mathbf{n}_i^T\mathbf{p}_i \end{bmatrix}\begin{bmatrix} \mathbf{n}_i^T & \mathbf{n}_i^T\mathbf{p}_i \end{bmatrix}
-    \f]
-    \f[
-        Q = \frac{1}{\sum_i w_i} \begin{bmatrix} I & \sum_i w_i \mathbf{p}_i \\ \sum_i w_i \mathbf{p}_i^T & \sum_i w_i \mathbf{p}_i^T\mathbf{p}_i \end{bmatrix}
-    \f]
-    The constant coefficient \f$u_c\f$ is computed as in \ref OrientedSphereFitImpl by minimizing the sum of squared potential evaluated at the points \f$\mathbf{p}_i\f$.
-    This fitting method corresponds to the case where the scalar field is \f$ f^* \f$ in the Section 3.3 of \cite Chen:2013:NOMG.
+        This method published in \cite Chen:2013:NOMG maximizes the sum of squared dot product between the input normal
+       vectors and the gradient of the algebraic sphere. The maximization is done under the constraint that the norm of
+       the gradient is unitary on average. In practice, it amounts to solve the generalized eigenvalue problem
+        \f[
+            A \mathbf{u} = \lambda Q \mathbf{u}
+        \f]
+        where
+        \f[
+            \mathbf{u} = \begin{bmatrix} u_l \\ u_q \end{bmatrix}
+        \f]
+        \f[
+            A = \sum_i w_i \begin{bmatrix} \mathbf{n}_i \\ \mathbf{n}_i^T\mathbf{p}_i \end{bmatrix}\begin{bmatrix}
+       \mathbf{n}_i^T & \mathbf{n}_i^T\mathbf{p}_i \end{bmatrix}
+        \f]
+        \f[
+            Q = \frac{1}{\sum_i w_i} \begin{bmatrix} I & \sum_i w_i \mathbf{p}_i \\ \sum_i w_i \mathbf{p}_i^T & \sum_i
+       w_i \mathbf{p}_i^T\mathbf{p}_i \end{bmatrix}
+        \f]
+        The constant coefficient \f$u_c\f$ is computed as in \ref OrientedSphereFitImpl by minimizing the sum of squared
+       potential evaluated at the points \f$\mathbf{p}_i\f$. This fitting method corresponds to the case where the
+       scalar field is \f$ f^* \f$ in the Section 3.3 of \cite Chen:2013:NOMG.
 
-    \inherit Concept::FittingProcedureConcept
+        \inherit Concept::FittingProcedureConcept
 
-    \see class AlgebraicSphere, class OrientedSphereFit
-*/
-template < class DataPoint, class _NFilter, typename T >
-class UnorientedSphereFitImpl : public T
-{
-PONCA_FITTING_DECLARE_DEFAULT_TYPES
-
-protected:
-    enum { Check = Base::PROVIDES_ALGEBRAIC_SPHERE && Base::PROVIDES_MEAN_POSITION };
-
-    typedef Eigen::Matrix<Scalar, DataPoint::Dim+1, 1>      VectorB;
-    typedef Eigen::Matrix<Scalar, DataPoint::Dim+1, DataPoint::Dim+1>  MatrixBB;
-    
-public:
-    using Solver = Eigen::EigenSolver<MatrixBB>;
-
-    MatrixBB    m_matA {MatrixBB::Zero()}; /*!< \brief The accumulated covariance matrix */
-    MatrixBB    m_matQ {MatrixBB::Zero()}; /*!< \brief The constraint matrix */
-    Scalar      m_sumDotPP {0};            /*!< \brief Sum of the squared relative positions */
-
-    Solver m_solver;
-    
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS(UnorientedSphereFitImpl,unorientedSphereFit)
-    PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
-    PONCA_FITTING_IS_SIGNED(false)
-
-}; // class UnorientedSphereFitImpl
-
-/// \brief Helper alias for Oriented Sphere fitting on 3D points using UnorientedSphereFitImpl
-template < class DataPoint, class _NFilter, typename T>
-using UnorientedSphereFit =
-UnorientedSphereFitImpl<DataPoint, _NFilter,
-        MeanPosition<DataPoint, _NFilter,
-                AlgebraicSphere<DataPoint, _NFilter, T>>>;
-
-
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-class UnorientedSphereDerImpl : public T
-{
-protected:
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
-    PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
-
-    using VectorB = typename Base::VectorB;
-    using MatrixBB = typename Base::MatrixBB;
-
-protected:
-    enum
+        \see class AlgebraicSphere, class OrientedSphereFit
+    */
+    template <class DataPoint, class _NFilter, typename T>
+    class UnorientedSphereFitImpl : public T
     {
-        Check = Base::PROVIDES_ALGEBRAIC_SPHERE &
-                Base::PROVIDES_MEAN_POSITION_DERIVATIVE &
-                Base::PROVIDES_PRIMITIVE_DERIVATIVE,
-        PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
-        PROVIDES_NORMAL_DERIVATIVE
-    };
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
 
-protected:
-    // computation data
-    MatrixBB m_dmatA[Base::NbDerivatives];
-    ScalarArray m_dSumDotPP {ScalarArray::Zero()};
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE && Base::PROVIDES_MEAN_POSITION
+        };
 
-public:
-    // results
-    ScalarArray m_dUc {ScalarArray::Zero()};
-    VectorArray m_dUl {VectorArray::Zero()};
-    ScalarArray m_dUq {ScalarArray::Zero()};
+        typedef Eigen::Matrix<Scalar, DataPoint::Dim + 1, 1> VectorB;
+        typedef Eigen::Matrix<Scalar, DataPoint::Dim + 1, DataPoint::Dim + 1> MatrixBB;
 
-public:
-    PONCA_EXPLICIT_CAST_OPERATORS_DER(UnorientedSphereDerImpl,unorientedSphereDer)
+    public:
+        using Solver = Eigen::EigenSolver<MatrixBB>;
 
-    PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
+        MatrixBB m_matA{MatrixBB::Zero()}; /*!< \brief The accumulated covariance matrix */
+        MatrixBB m_matQ{MatrixBB::Zero()}; /*!< \brief The constraint matrix */
+        Scalar m_sumDotPP{0};              /*!< \brief Sum of the squared relative positions */
 
-    PONCA_MULTIARCH inline ScalarArray dPotential() const;
-    PONCA_MULTIARCH inline VectorArray dNormal() const;
+        Solver m_solver;
 
-}; //class UnorientedSphereDerImpl
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS(UnorientedSphereFitImpl, unorientedSphereFit)
+        PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
+        PONCA_FITTING_IS_SIGNED(false)
 
+    }; // class UnorientedSphereFitImpl
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-using UnorientedSphereDer =
-    UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType,
-        MeanPositionDer<DataPoint, _NFilter, DiffType, T>>;
+    /// \brief Helper alias for Oriented Sphere fitting on 3D points using UnorientedSphereFitImpl
+    template <class DataPoint, class _NFilter, typename T>
+    using UnorientedSphereFit =
+        UnorientedSphereFitImpl<DataPoint, _NFilter,
+                                MeanPosition<DataPoint, _NFilter, AlgebraicSphere<DataPoint, _NFilter, T>>>;
 
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    class UnorientedSphereDerImpl : public T
+    {
+    protected:
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
 
-} //namespace Ponca
+        using VectorB  = typename Base::VectorB;
+        using MatrixBB = typename Base::MatrixBB;
+
+    protected:
+        enum
+        {
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE & Base::PROVIDES_MEAN_POSITION_DERIVATIVE &
+                    Base::PROVIDES_PRIMITIVE_DERIVATIVE,
+            PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
+            PROVIDES_NORMAL_DERIVATIVE
+        };
+
+    protected:
+        // computation data
+        MatrixBB m_dmatA[Base::NbDerivatives];
+        ScalarArray m_dSumDotPP{ScalarArray::Zero()};
+
+    public:
+        // results
+        ScalarArray m_dUc{ScalarArray::Zero()};
+        VectorArray m_dUl{VectorArray::Zero()};
+        ScalarArray m_dUq{ScalarArray::Zero()};
+
+    public:
+        PONCA_EXPLICIT_CAST_OPERATORS_DER(UnorientedSphereDerImpl, unorientedSphereDer)
+
+        PONCA_FITTING_DECLARE_INIT_ADDDER_FINALIZE
+
+        PONCA_MULTIARCH inline ScalarArray dPotential() const;
+        PONCA_MULTIARCH inline VectorArray dNormal() const;
+
+    }; // class UnorientedSphereDerImpl
+
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    using UnorientedSphereDer =
+        UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, MeanPositionDer<DataPoint, _NFilter, DiffType, T>>;
+
+} // namespace Ponca
 
 #include "unorientedSphereFit.hpp"

--- a/Ponca/src/Fitting/unorientedSphereFit.hpp
+++ b/Ponca/src/Fitting/unorientedSphereFit.hpp
@@ -7,223 +7,212 @@
 namespace Ponca
 {
 
-template < class DataPoint, class _NFilter, typename T>
-void
-UnorientedSphereFitImpl<DataPoint, _NFilter, T>::init()
-{
-    Base::init();
-    m_matA.setZero();
-    m_matQ.setZero();
-    m_sumDotPP = Scalar(0.0);
-}
-
-template<class DataPoint, class _NFilter, typename T>
-bool
-UnorientedSphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                        const VectorType &localQ,
-                                                        const DataPoint &attributes) {
-    if( Base::addLocalNeighbor(w, localQ, attributes) )
+    template <class DataPoint, class _NFilter, typename T>
+    void UnorientedSphereFitImpl<DataPoint, _NFilter, T>::init()
     {
-        VectorB basis;
-        basis << attributes.normal(), attributes.normal().dot(localQ);
-
-        m_matA     += w * basis * basis.transpose();
-        m_sumDotPP += w * localQ.squaredNorm();
-
-        return true;
+        Base::init();
+        m_matA.setZero();
+        m_matQ.setZero();
+        m_sumDotPP = Scalar(0.0);
     }
 
-    return false;
-}
-
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-UnorientedSphereFitImpl<DataPoint, _NFilter, T>::finalize ()
-{
-    PONCA_MULTIARCH_STD_MATH(sqrt);
-    constexpr int Dim = DataPoint::Dim;
-
-    // Compute status
-    if(Base::finalize() != STABLE)
-        return Base::m_eCurrentState;
-    if(Base::getNumNeighbors() < DataPoint::Dim)
-        return Base::m_eCurrentState = UNDEFINED;
-    if (Base::algebraicSphere().isValid())
-        Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
-    else
-        Base::m_eCurrentState = Base::getNumNeighbors() < 2*DataPoint::Dim ? UNSTABLE : STABLE;
-
-    // 1. finalize sphere fitting
-    Scalar invSumW = Scalar(1.) / Base::getWeightSum();
-
-    m_matQ.template topLeftCorner<Dim,Dim>().setIdentity();
-    m_matQ.col(Dim).template head<Dim>() = Base::m_sumP * invSumW;
-    m_matQ.row(Dim).template head<Dim>() = Base::m_sumP * invSumW;
-    m_matQ(Dim,Dim) = m_sumDotPP * invSumW;
-
-    MatrixBB M = m_matQ.inverse() * m_matA;
-    m_solver.compute(M);
-    VectorB eivals = m_solver.eigenvalues().real();
-    int maxId = 0;
-    eivals.maxCoeff(&maxId);
-
-    VectorB eivec = m_solver.eigenvectors().col(maxId).real();
-
-    // integrate
-    Base::m_ul = eivec.template head<Dim>();
-    Base::m_uq = Scalar(0.5) * eivec(Dim);
-    Base::m_uc = -invSumW * (Base::m_ul.dot(Base::m_sumP) + m_sumDotPP * Base::m_uq);
-
-    Base::m_isNormalized = false;
-
-    return Base::m_eCurrentState;
-}
-
-
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-void
-UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::init()
-{
-    Base::init();
-    for(int dim = 0; dim < Base::NbDerivatives; ++dim)
-        m_dmatA[dim] = MatrixBB::Zero();
-    m_dSumDotPP = ScalarArray::Zero();
-    m_dUc = ScalarArray::Zero();
-    m_dUl = VectorArray::Zero();
-    m_dUq = ScalarArray::Zero();
-}
-
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-bool
-UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(
-    Scalar w,
-    const VectorType &localQ,
-    const DataPoint &attributes,
-    ScalarArray& dw)
-{
-    if( Base::addLocalNeighbor(w, localQ, attributes, dw) )
+    template <class DataPoint, class _NFilter, typename T>
+    bool UnorientedSphereFitImpl<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                           const DataPoint& attributes)
     {
-        VectorB basis;
-        basis << attributes.normal(), attributes.normal().dot(localQ);
-        const MatrixBB prod = basis * basis.transpose();
-
-        m_dSumDotPP += dw * localQ.squaredNorm();
-
-        for(int dim = 0; dim < Base::NbDerivatives; ++dim)
+        if (Base::addLocalNeighbor(w, localQ, attributes))
         {
-            m_dmatA[dim] += dw[dim] * prod;
+            VectorB basis;
+            basis << attributes.normal(), attributes.normal().dot(localQ);
+
+            m_matA += w * basis * basis.transpose();
+            m_sumDotPP += w * localQ.squaredNorm();
+
+            return true;
         }
 
-        return true;
+        return false;
     }
-    return false;
-}
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-FIT_RESULT
-UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
-{
-    constexpr int Dim = DataPoint::Dim;
-    constexpr Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision();
-
-    Base::finalize();
-    if(this->isReady())
+    template <class DataPoint, class _NFilter, typename T>
+    FIT_RESULT UnorientedSphereFitImpl<DataPoint, _NFilter, T>::finalize()
     {
-        int i = 0;
-        Base::m_solver.eigenvalues().real().maxCoeff(&i);
-        const Scalar eigenval_i = Base::m_solver.eigenvalues().real()[i];
-        const VectorB eigenvec_i = Base::m_solver.eigenvectors().real().col(i);
+        PONCA_MULTIARCH_STD_MATH(sqrt);
+        constexpr int Dim = DataPoint::Dim;
 
-        const Scalar invSumW = Scalar(1) / Base::getWeightSum();
+        // Compute status
+        if (Base::finalize() != STABLE)
+            return Base::m_eCurrentState;
+        if (Base::getNumNeighbors() < DataPoint::Dim)
+            return Base::m_eCurrentState = UNDEFINED;
+        if (Base::algebraicSphere().isValid())
+            Base::m_eCurrentState = CONFLICT_ERROR_FOUND;
+        else
+            Base::m_eCurrentState = Base::getNumNeighbors() < 2 * DataPoint::Dim ? UNSTABLE : STABLE;
 
-        // the derivative of (A vi = li Q vi), where A and Q are symmetric real, is
-        //
-        //     dA vi + A dvi = dli Q vi + li dQ vi + li Q dvi
-        //
-        // left-multiply by vj (i!=j, associated to eigenvalue lj)
-        //
-        //     vj . dA vi + vj . A dvi = dli vj . Q vi + li vj . dQ vi + li vj . Q dvi
-        //                  ^^^^^^           ^^^^^^^^^
-        //                  = lj vj . Q         = 0
-        //
-        // which simplified to
-        //
-        //     (Q vj) . dvi = 1/(li - lj) vj . dQ vi
-        //
-        // therefore
-        //
-        //     dvi = sum_j (1/(li - lj) vj . dQ vi) Q vj
-        //         = Q sum_j (1/(li - lj) vj . ((dA - li dQ) vi)) vj
-        //
-        for(int dim = 0; dim < Base::NbDerivatives; ++dim)
+        // 1. finalize sphere fitting
+        Scalar invSumW = Scalar(1.) / Base::getWeightSum();
+
+        m_matQ.template topLeftCorner<Dim, Dim>().setIdentity();
+        m_matQ.col(Dim).template head<Dim>() = Base::m_sumP * invSumW;
+        m_matQ.row(Dim).template head<Dim>() = Base::m_sumP * invSumW;
+        m_matQ(Dim, Dim)                     = m_sumDotPP * invSumW;
+
+        MatrixBB M = m_matQ.inverse() * m_matA;
+        m_solver.compute(M);
+        VectorB eivals = m_solver.eigenvalues().real();
+        int maxId      = 0;
+        eivals.maxCoeff(&maxId);
+
+        VectorB eivec = m_solver.eigenvectors().col(maxId).real();
+
+        // integrate
+        Base::m_ul = eivec.template head<Dim>();
+        Base::m_uq = Scalar(0.5) * eivec(Dim);
+        Base::m_uc = -invSumW * (Base::m_ul.dot(Base::m_sumP) + m_sumDotPP * Base::m_uq);
+
+        Base::m_isNormalized = false;
+
+        return Base::m_eCurrentState;
+    }
+
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    void UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::init()
+    {
+        Base::init();
+        for (int dim = 0; dim < Base::NbDerivatives; ++dim)
+            m_dmatA[dim] = MatrixBB::Zero();
+        m_dSumDotPP = ScalarArray::Zero();
+        m_dUc       = ScalarArray::Zero();
+        m_dUl       = VectorArray::Zero();
+        m_dUq       = ScalarArray::Zero();
+    }
+
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    bool UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                                     const DataPoint& attributes,
+                                                                                     ScalarArray& dw)
+    {
+        if (Base::addLocalNeighbor(w, localQ, attributes, dw))
         {
-            MatrixBB dQ;
-            dQ.template topLeftCorner<Dim,Dim>().setZero();
-            dQ.col(Dim).template head<Dim>() = Base::m_dSumP.col(dim);
-            dQ.row(Dim).template head<Dim>() = Base::m_dSumP.col(dim);
-            dQ(Dim,Dim) = m_dSumDotPP[dim];
-            dQ -= Base::m_dSumW[dim] * Base::m_matQ;
-            dQ *= invSumW;
+            VectorB basis;
+            basis << attributes.normal(), attributes.normal().dot(localQ);
+            const MatrixBB prod = basis * basis.transpose();
 
-            const VectorB vec = (m_dmatA[dim] - eigenval_i * dQ) * eigenvec_i;
+            m_dSumDotPP += dw * localQ.squaredNorm();
 
-            VectorB deigvec = VectorB::Zero();
-            for(int j = 0; j < Dim+1; ++j)
+            for (int dim = 0; dim < Base::NbDerivatives; ++dim)
             {
-                if(j != i)
-                {
-                    const Scalar eigenval_j = Base::m_solver.eigenvalues().real()[j];
-                    const Scalar eigengap = eigenval_i - eigenval_j; // positive since eigenval_i is the maximal eigenvalue
-
-                    if(eigengap > epsilon)
-                    {
-                        const VectorB eigenvec_j = Base::m_solver.eigenvectors().real().col(j);
-                        deigvec += Scalar(1)/eigengap * eigenvec_j.dot(vec) * eigenvec_j;
-                    }
-                }
+                m_dmatA[dim] += dw[dim] * prod;
             }
 
-            deigvec = Base::m_matQ * deigvec;
-
-            m_dUq[dim] = Scalar(.5) * deigvec[dim];
-            m_dUl.col(dim) = deigvec.template head<Dim>();
+            return true;
         }
-
-        // same as in OrientedSphereDerImpl::finalize()
-        m_dUc = -invSumW*( Base::m_sumP.transpose() * m_dUl
-            + Base::m_sumDotPP * m_dUq
-            + Base::m_ul.transpose() * Base::m_dSumP
-            + Base::m_uq * m_dSumDotPP
-            + Base::m_dSumW * Base::m_uc);
-
-        return FIT_RESULT::STABLE;
+        return false;
     }
-    return Base::m_eCurrentState;
-}
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::ScalarArray
-UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::dPotential() const
-{
-    // same as OrientedSphereDerImpl::dPotential()
-    ScalarArray dfield = m_dUc;
-    if(Base::isSpaceDer())
-        dfield.template tail<DataPoint::Dim>() += Base::m_ul;
-    return dfield;
-}
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    FIT_RESULT UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::finalize()
+    {
+        constexpr int Dim        = DataPoint::Dim;
+        constexpr Scalar epsilon = Eigen::NumTraits<Scalar>::dummy_precision();
 
-template < class DataPoint, class _NFilter, int DiffType, typename T>
-typename UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::VectorArray
-UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::dNormal() const
-{
-    // same as OrientedSphereDerImpl::dNormal()
-    VectorArray dgrad = m_dUl;
-    if(Base::isSpaceDer())
-        dgrad.template rightCols<DataPoint::Dim>().diagonal().array() += Scalar(2)*Base::m_uq;
-    Scalar norm  = Base::m_ul.norm();
-    Scalar norm3 = norm*norm*norm;
-    return dgrad / norm - Base::m_ul * (Base::m_ul.transpose() * dgrad) / norm3;
-}
+        Base::finalize();
+        if (this->isReady())
+        {
+            int i = 0;
+            Base::m_solver.eigenvalues().real().maxCoeff(&i);
+            const Scalar eigenval_i  = Base::m_solver.eigenvalues().real()[i];
+            const VectorB eigenvec_i = Base::m_solver.eigenvectors().real().col(i);
 
-} //namespace Ponca
+            const Scalar invSumW = Scalar(1) / Base::getWeightSum();
+
+            // the derivative of (A vi = li Q vi), where A and Q are symmetric real, is
+            //
+            //     dA vi + A dvi = dli Q vi + li dQ vi + li Q dvi
+            //
+            // left-multiply by vj (i!=j, associated to eigenvalue lj)
+            //
+            //     vj . dA vi + vj . A dvi = dli vj . Q vi + li vj . dQ vi + li vj . Q dvi
+            //                  ^^^^^^           ^^^^^^^^^
+            //                  = lj vj . Q         = 0
+            //
+            // which simplified to
+            //
+            //     (Q vj) . dvi = 1/(li - lj) vj . dQ vi
+            //
+            // therefore
+            //
+            //     dvi = sum_j (1/(li - lj) vj . dQ vi) Q vj
+            //         = Q sum_j (1/(li - lj) vj . ((dA - li dQ) vi)) vj
+            //
+            for (int dim = 0; dim < Base::NbDerivatives; ++dim)
+            {
+                MatrixBB dQ;
+                dQ.template topLeftCorner<Dim, Dim>().setZero();
+                dQ.col(Dim).template head<Dim>() = Base::m_dSumP.col(dim);
+                dQ.row(Dim).template head<Dim>() = Base::m_dSumP.col(dim);
+                dQ(Dim, Dim)                     = m_dSumDotPP[dim];
+                dQ -= Base::m_dSumW[dim] * Base::m_matQ;
+                dQ *= invSumW;
+
+                const VectorB vec = (m_dmatA[dim] - eigenval_i * dQ) * eigenvec_i;
+
+                VectorB deigvec = VectorB::Zero();
+                for (int j = 0; j < Dim + 1; ++j)
+                {
+                    if (j != i)
+                    {
+                        const Scalar eigenval_j = Base::m_solver.eigenvalues().real()[j];
+                        const Scalar eigengap =
+                            eigenval_i - eigenval_j; // positive since eigenval_i is the maximal eigenvalue
+
+                        if (eigengap > epsilon)
+                        {
+                            const VectorB eigenvec_j = Base::m_solver.eigenvectors().real().col(j);
+                            deigvec += Scalar(1) / eigengap * eigenvec_j.dot(vec) * eigenvec_j;
+                        }
+                    }
+                }
+
+                deigvec = Base::m_matQ * deigvec;
+
+                m_dUq[dim]     = Scalar(.5) * deigvec[dim];
+                m_dUl.col(dim) = deigvec.template head<Dim>();
+            }
+
+            // same as in OrientedSphereDerImpl::finalize()
+            m_dUc = -invSumW *
+                    (Base::m_sumP.transpose() * m_dUl + Base::m_sumDotPP * m_dUq +
+                     Base::m_ul.transpose() * Base::m_dSumP + Base::m_uq * m_dSumDotPP + Base::m_dSumW * Base::m_uc);
+
+            return FIT_RESULT::STABLE;
+        }
+        return Base::m_eCurrentState;
+    }
+
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    typename UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::ScalarArray UnorientedSphereDerImpl<
+        DataPoint, _NFilter, DiffType, T>::dPotential() const
+    {
+        // same as OrientedSphereDerImpl::dPotential()
+        ScalarArray dfield = m_dUc;
+        if (Base::isSpaceDer())
+            dfield.template tail<DataPoint::Dim>() += Base::m_ul;
+        return dfield;
+    }
+
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    typename UnorientedSphereDerImpl<DataPoint, _NFilter, DiffType, T>::VectorArray UnorientedSphereDerImpl<
+        DataPoint, _NFilter, DiffType, T>::dNormal() const
+    {
+        // same as OrientedSphereDerImpl::dNormal()
+        VectorArray dgrad = m_dUl;
+        if (Base::isSpaceDer())
+            dgrad.template rightCols<DataPoint::Dim>().diagonal().array() += Scalar(2) * Base::m_uq;
+        Scalar norm  = Base::m_ul.norm();
+        Scalar norm3 = norm * norm * norm;
+        return dgrad / norm - Base::m_ul * (Base::m_ul.transpose() * dgrad) / norm3;
+    }
+
+} // namespace Ponca

--- a/Ponca/src/Fitting/weightFunc.h
+++ b/Ponca/src/Fitting/weightFunc.h
@@ -21,7 +21,7 @@ namespace Ponca
  * \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
  * This frame does not apply rotation.
  *
- * @tparam DataPoint Point type used for computation
+ * \tparam DataPoint Point type used for computation
  */
 template<class DataPoint>
 class CenteredNeighborhoodFrame {
@@ -45,12 +45,12 @@ public:
 
     /*!
      * \brief Convert query from local to global coordinate system, such as \f$\mathbf{x}=\mathbf{x}'+\mathbf{p}\f$.
-     * @param _q Vector expressed relatively to the basis center
-     * @param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+     * \param _q Vector expressed relatively to the basis center
+     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
      *        (e.g., in contrast to displacement or normal vectors)
-     * @return Vector expressed in the global coordinate system
+     * \return Vector expressed in the global coordinate system
      *
-     * @see convertToLocalBasis
+     * \see convertToLocalBasis
      */
     PONCA_MULTIARCH [[nodiscard]] inline VectorType convertToGlobalBasis(const VectorType& _q,
                                                                          bool _isPositionVector = true) const {
@@ -60,12 +60,12 @@ public:
     /*!
      * \brief Convert query from global to local coordinate system, such as \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
      *
-     * @param _q Input Vector in global coordinate system
-     * @param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+     * \param _q Input Vector in global coordinate system
+     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
      *        (e.g., in contrast to displacement or normal vectors)
-     * @return Vector expressed relatively to the basis center
+     * \return Vector expressed relatively to the basis center
      *
-     * @see convertToGlobalBasis
+     * \see convertToGlobalBasis
      */
     PONCA_MULTIARCH [[nodiscard]] inline VectorType convertToLocalBasis(const VectorType& _q,
                                                                         bool _isPositionVector = true) const {
@@ -74,7 +74,7 @@ public:
 
     /*!
      * \brief Get access to the stored points of evaluation
-     * @return Position of the local basis center
+     * \return Position of the local basis center
      */
     PONCA_MULTIARCH [[nodiscard]] inline const VectorType& evalPos() const { return m_p; }
 
@@ -89,7 +89,7 @@ private:
  * \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
  * This frame does not apply rotation.
  *
- * @tparam DataPoint Point type used for computation
+ * \tparam DataPoint Point type used for computation
  */
 template<class DataPoint>
 class GlobalNeighborhoodFrame {
@@ -109,10 +109,10 @@ public:
 
     /*!
      * \brief Convert position from local to global coordinate system : does nothing as this is global frame
-     * @param _q Position in local coordinate
-     * @param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+     * \param _q Position in local coordinate
+     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
      *        (e.g., in contrast to displacement or normal vectors)
-     * @return _q
+     * \return _q
      */
     PONCA_MULTIARCH [[nodiscard]] inline const VectorType& convertToGlobalBasis(const VectorType& _q,
                                                                                 bool /*_isPositionVector*/ = true) const {
@@ -121,10 +121,10 @@ public:
 
     /*!
      * \brief Convert query from global to local coordinate system : does nothing as this is global frame
-     * @param _q Query in global coordinate
-     * @param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+     * \param _q Query in global coordinate
+     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
      *        (e.g., in contrast to displacement or normal vectors)
-     * @return _q
+     * \return _q
      */
     PONCA_MULTIARCH [[nodiscard]] inline const VectorType& convertToLocalBasis(const VectorType& _q,
                                                                                bool /*_isPositionVector*/ = true) const {

--- a/Ponca/src/Fitting/weightFunc.h
+++ b/Ponca/src/Fitting/weightFunc.h
@@ -11,441 +11,460 @@
 
 namespace Ponca
 {
-/*!
- * \brief NeighborhoodFrame that express 3d points relatively to a prescribed center.
- *
- * This class is useful to get all coordinates centered around a point, which ease weights computation, and limits
- * issues with big numbers and rounding errors.
- *
- * Express points \f$\mathbf{x}\f$ relatively to a center \f$\mathbf{p}\f$, ie.
- * \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
- * This frame does not apply rotation.
- *
- * \tparam DataPoint Point type used for computation
- */
-template<class DataPoint>
-class CenteredNeighborhoodFrame {
-public:
-    /*! \brief Scalar type from DataPoint */
-    using Scalar =  typename DataPoint::Scalar;
-    /*! \brief Vector type from DataPoint */
-    using VectorType =  typename DataPoint::VectorType;
-
-    /// \brief Flag indicating that this class modifies the coordinates when passing from global to local
-    static constexpr bool hasLocalFrame = true;
-
-    PONCA_MULTIARCH inline explicit CenteredNeighborhoodFrame(const VectorType & _evalPos = VectorType::Zero())
-    : m_p(_evalPos) {}
-
-    PONCA_MULTIARCH inline explicit CenteredNeighborhoodFrame(const DataPoint & _evalPoint)
-    : m_p(_evalPoint.pos()) {}
-
-    /// \brief Change neighborhood frame (move basis center)
-    PONCA_MULTIARCH inline void changeNeighborhoodFrame(const VectorType& _newEvalPos) { m_p = _newEvalPos; };
-
     /*!
-     * \brief Convert query from local to global coordinate system, such as \f$\mathbf{x}=\mathbf{x}'+\mathbf{p}\f$.
-     * \param _q Vector expressed relatively to the basis center
-     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
-     *        (e.g., in contrast to displacement or normal vectors)
-     * \return Vector expressed in the global coordinate system
+     * \brief NeighborhoodFrame that express 3d points relatively to a prescribed center.
      *
-     * \see convertToLocalBasis
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType convertToGlobalBasis(const VectorType& _q,
-                                                                         bool _isPositionVector = true) const {
-        return ( _isPositionVector ? (_q + m_p) : _q );
-    }
-
-    /*!
-     * \brief Convert query from global to local coordinate system, such as \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
+     * This class is useful to get all coordinates centered around a point, which ease weights computation, and limits
+     * issues with big numbers and rounding errors.
      *
-     * \param _q Input Vector in global coordinate system
-     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
-     *        (e.g., in contrast to displacement or normal vectors)
-     * \return Vector expressed relatively to the basis center
+     * Express points \f$\mathbf{x}\f$ relatively to a center \f$\mathbf{p}\f$, ie.
+     * \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
+     * This frame does not apply rotation.
      *
-     * \see convertToGlobalBasis
+     * \tparam DataPoint Point type used for computation
      */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType convertToLocalBasis(const VectorType& _q,
-                                                                        bool _isPositionVector = true) const {
-        return ( _isPositionVector ? (_q - m_p) : _q );
-    }
-
-    /*!
-     * \brief Get access to the stored points of evaluation
-     * \return Position of the local basis center
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline const VectorType& evalPos() const { return m_p; }
-
-private:
-    VectorType m_p;  /*!< \brief basis center */
-};
-/*!
- * \brief NeighborhoodFrame that keep points in the global frame without applying any transformation
- *
- * This class is useful to compute
- * Express points \f$\mathbf{x}\f$ relatively to a center \f$\mathbf{p}\f$, ie.
- * \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
- * This frame does not apply rotation.
- *
- * \tparam DataPoint Point type used for computation
- */
-template<class DataPoint>
-class GlobalNeighborhoodFrame {
-public:
-    /*! \brief Scalar type from DataPoint */
-    using Scalar =  typename DataPoint::Scalar;
-    /*! \brief Vector type from DataPoint */
-    using VectorType =  typename DataPoint::VectorType;
-
-    /// \brief Flag indicating that this class does not modify the coordinates when passing from global to local
-    static constexpr bool hasLocalFrame = false;
-
-    PONCA_MULTIARCH inline explicit GlobalNeighborhoodFrame(const VectorType & /*_evalPos*/ = VectorType::Zero()) {}
-
-    /// \brief Change neighborhood frame (has no effect for global basis)
-    PONCA_MULTIARCH inline void changeNeighborhoodFrame(const VectorType& /*_newEvalPos*/) {};
-
-    /*!
-     * \brief Convert position from local to global coordinate system : does nothing as this is global frame
-     * \param _q Position in local coordinate
-     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
-     *        (e.g., in contrast to displacement or normal vectors)
-     * \return _q
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline const VectorType& convertToGlobalBasis(const VectorType& _q,
-                                                                                bool /*_isPositionVector*/ = true) const {
-        return _q;
-    }
-
-    /*!
-     * \brief Convert query from global to local coordinate system : does nothing as this is global frame
-     * \param _q Query in global coordinate
-     * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
-     *        (e.g., in contrast to displacement or normal vectors)
-     * \return _q
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline const VectorType& convertToLocalBasis(const VectorType& _q,
-                                                                               bool /*_isPositionVector*/ = true) const {
-        return _q;
-    }
-};
-
-
-/*!
-    \brief Weight neighbors according to the euclidean distance between a query and a reference position
-
-    The evaluation position is set in the constructor. All the queries are expressed in global system, and converted
-    internally to relatively to the evaluation position using #CenteredNeighborhoodFrame.
-
-    \tparam DataPoint Type of input points.
-    \tparam WeightKernel 1d function used to compute the weight depending on the distance between query point and the
-    basis center. If `WeightKernel::isCompact == true`, the distance to the basis center is checked against the scale
-    parameter, and any point whose distance is larger than the scale will be assigned with a weight of \f$0\f$. For
-    non-compact (ie. global) kernels, the weights are computed for all points.
-
-    \see operator()
-
-    \warning DistWeightFunc assumes that the evaluation scale t is strictly positive, but the valus is not checked
-*/
-template <class DataPoint, class WeightKernel>
-class DistWeightFunc : public CenteredNeighborhoodFrame<DataPoint>
-{
-public:
-    /*! \brief Scalar type from DataPoint */
-    using Scalar =  typename DataPoint::Scalar;
-    /*! \brief Vector type from DataPoint */
-    using VectorType =  typename DataPoint::VectorType;
-    /*! \brief Matrix type from DataPoint */
-    using MatrixType = typename DataPoint::MatrixType;
-    /*! \brief Return type of the method #w() */
-    using WeightReturnType = PONCA_MULTIARCH_CU_STD_NAMESPACE(pair)<Scalar, VectorType>;
-    /// \brief Frame used to express the neighbors locally
-    using NeighborhoodFrame = CenteredNeighborhoodFrame<DataPoint>;
-    /// \brief Flag indicating if the weighting kernel is compact of not
-    static constexpr bool isCompact = WeightKernel::isCompact;
-
-    /*!
-        \brief Constructor that defines the current evaluation scale
-        \warning t > 0
-    */
-    PONCA_MULTIARCH inline DistWeightFunc(const VectorType & _evalPos = VectorType::Zero(),
-                                              const Scalar& _t = Scalar(1.))
-    : NeighborhoodFrame(_evalPos), m_t(_t)
+    template <class DataPoint>
+    class CenteredNeighborhoodFrame
     {
-        //\todo manage that assert on __host__ and __device__
-        //assert(_t > Scalar(0));
-    }
+    public:
+        /*! \brief Scalar type from DataPoint */
+        using Scalar = typename DataPoint::Scalar;
+        /*! \brief Vector type from DataPoint */
+        using VectorType = typename DataPoint::VectorType;
 
-    ///! \copydoc DistWeightFunc
-    PONCA_MULTIARCH inline DistWeightFunc(const DataPoint & _evalPoint,
-                                              const Scalar& _t = Scalar(1.))
-    : NeighborhoodFrame(_evalPoint.pos()), m_t(_t)
+        /// \brief Flag indicating that this class modifies the coordinates when passing from global to local
+        static constexpr bool hasLocalFrame = true;
+
+        PONCA_MULTIARCH inline explicit CenteredNeighborhoodFrame(const VectorType& _evalPos = VectorType::Zero())
+            : m_p(_evalPos)
+        {
+        }
+
+        PONCA_MULTIARCH inline explicit CenteredNeighborhoodFrame(const DataPoint& _evalPoint) : m_p(_evalPoint.pos())
+        {
+        }
+
+        /// \brief Change neighborhood frame (move basis center)
+        PONCA_MULTIARCH inline void changeNeighborhoodFrame(const VectorType& _newEvalPos) { m_p = _newEvalPos; };
+
+        /*!
+         * \brief Convert query from local to global coordinate system, such as \f$\mathbf{x}=\mathbf{x}'+\mathbf{p}\f$.
+         * \param _q Vector expressed relatively to the basis center
+         * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+         *        (e.g., in contrast to displacement or normal vectors)
+         * \return Vector expressed in the global coordinate system
+         *
+         * \see convertToLocalBasis
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType convertToGlobalBasis(const VectorType& _q,
+                                                                             bool _isPositionVector = true) const
+        {
+            return (_isPositionVector ? (_q + m_p) : _q);
+        }
+
+        /*!
+         * \brief Convert query from global to local coordinate system, such as \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
+         *
+         * \param _q Input Vector in global coordinate system
+         * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+         *        (e.g., in contrast to displacement or normal vectors)
+         * \return Vector expressed relatively to the basis center
+         *
+         * \see convertToGlobalBasis
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType convertToLocalBasis(const VectorType& _q,
+                                                                            bool _isPositionVector = true) const
+        {
+            return (_isPositionVector ? (_q - m_p) : _q);
+        }
+
+        /*!
+         * \brief Get access to the stored points of evaluation
+         * \return Position of the local basis center
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& evalPos() const { return m_p; }
+
+    private:
+        VectorType m_p; /*!< \brief basis center */
+    };
+    /*!
+     * \brief NeighborhoodFrame that keep points in the global frame without applying any transformation
+     *
+     * This class is useful to compute
+     * Express points \f$\mathbf{x}\f$ relatively to a center \f$\mathbf{p}\f$, ie.
+     * \f$\mathbf{x}'=\mathbf{x}-\mathbf{p}\f$.
+     * This frame does not apply rotation.
+     *
+     * \tparam DataPoint Point type used for computation
+     */
+    template <class DataPoint>
+    class GlobalNeighborhoodFrame
     {
-        //\todo manage that assert on __host__ and __device__
-        //assert(_t > Scalar(0));
-    }
+    public:
+        /*! \brief Scalar type from DataPoint */
+        using Scalar = typename DataPoint::Scalar;
+        /*! \brief Vector type from DataPoint */
+        using VectorType = typename DataPoint::VectorType;
+
+        /// \brief Flag indicating that this class does not modify the coordinates when passing from global to local
+        static constexpr bool hasLocalFrame = false;
+
+        PONCA_MULTIARCH inline explicit GlobalNeighborhoodFrame(const VectorType& /*_evalPos*/ = VectorType::Zero()) {}
+
+        /// \brief Change neighborhood frame (has no effect for global basis)
+        PONCA_MULTIARCH inline void changeNeighborhoodFrame(const VectorType& /*_newEvalPos*/) {};
+
+        /*!
+         * \brief Convert position from local to global coordinate system : does nothing as this is global frame
+         * \param _q Position in local coordinate
+         * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+         *        (e.g., in contrast to displacement or normal vectors)
+         * \return _q
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& convertToGlobalBasis(
+            const VectorType& _q, bool /*_isPositionVector*/ = true) const
+        {
+            return _q;
+        }
+
+        /*!
+         * \brief Convert query from global to local coordinate system : does nothing as this is global frame
+         * \param _q Query in global coordinate
+         * \param _isPositionVector Indicate if the input vector `_q` is a position that is influenced by translations
+         *        (e.g., in contrast to displacement or normal vectors)
+         * \return _q
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline const VectorType& convertToLocalBasis(
+            const VectorType& _q, bool /*_isPositionVector*/ = true) const
+        {
+            return _q;
+        }
+    };
 
     /*!
-        \brief Compute the weight of the given query with respect to its coordinates.
+        \brief Weight neighbors according to the euclidean distance between a query and a reference position
 
-        \param _q Query in global coordinate system
+        The evaluation position is set in the constructor. All the queries are expressed in global system, and converted
+        internally to relatively to the evaluation position using #CenteredNeighborhoodFrame.
 
-        As the query \f$\mathbf{q}\f$ is expressed in global coordinate, it is
-        first converted to the centered basis. Then, the WeightKernel is directly
-        applied to the norm of its coordinates with respect to the current scale  \f$ t \f$ :
+        \tparam DataPoint Type of input points.
+        \tparam WeightKernel 1d function used to compute the weight depending on the distance between query point and
+       the basis center. If `WeightKernel::isCompact == true`, the distance to the basis center is checked against the
+       scale parameter, and any point whose distance is larger than the scale will be assigned with a weight of \f$0\f$.
+       For non-compact (ie. global) kernels, the weights are computed for all points.
 
-        \f$ w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) \f$
+        \see operator()
 
-        \see convertToLocalBasis
-        \return The computed weight + the point expressed in local basis
+        \warning DistWeightFunc assumes that the evaluation scale t is strictly positive, but the valus is not checked
     */
-    PONCA_MULTIARCH inline WeightReturnType operator()(const DataPoint& q) const;
-
-
-    /*!
-        \brief First order derivative in space (for each spatial dimension \f$\mathsf{x})\f$
-
-        \param _q Query in global coordinate system
-
-        \f$ \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}
-        \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t})
-        = \frac{\mathbf{q}}{t\left|q\right|}  \nabla{w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t})}  \f$
-
-        where \f$ \left|\mathbf{q}_\mathsf{x}\right| \f$ represents the norm of the
-        query coordinates expressed in centered basis,
-        for each spatial dimensions \f$ \mathsf{x}\f$.
-
-        \warning Requires \f$\nabla w(x)\f$ to be valid
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType spacedw(const VectorType& _q,
-        const DataPoint&  /*attributes*/) const;
-
-
-    /*!
-        \brief Second order derivative in space (for each spatial dimension \f$\mathsf{x})\f$
-
-        \param _q Query in global coordinate system
-
-        \f$ \frac{\delta^2 \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}^2}
-        \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
-        \left(\frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}\right)^2
-        \nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) =
-        \frac{1}{t\left|\mathbf{q}_\mathsf{x}\right|} \left( I_d - \frac{\mathbf{q}_\mathsf{x}\mathbf{q}_\mathsf{x}^T}{\left|\mathbf{q}_\mathsf{x}\right|^2}\right)
-        \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
-        \frac{\mathbf{q}_\mathsf{x}\mathbf{q}_\mathsf{x}^T}{t^2\left|\mathbf{q}_\mathsf{x}\right|^2}
-        \nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) \f$
-
-        where \f$ \left|\mathbf{q}_\mathsf{x}\right| \f$ represents the norm of the
-        query coordinates expressed in centered basis,
-        for each spatial dimensions \f$ \mathsf{x}\f$.
-
-        \warning Requires \f$\nabla^2 w(x)\f$ to be valid
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline MatrixType spaced2w(const VectorType& _q,
-        const DataPoint&  /*attributes*/) const;
-
-    /*!
-        \brief First order derivative in scale  \f$t\f$
-
-        \param _q Query in global coordinate system
-
-        \f$ \frac{\delta \frac{\left|\mathbf{q}\right|}{t}}{\delta t}
-        \nabla w(\frac{\left|\mathbf{q}\right|}{t})
-        = - \frac{\left|\mathbf{q}\right|}{t^2} \nabla{w(\frac{\left|\mathbf{q}\right|}{t})} \f$
-
-        where \f$ \left|\mathbf{q}\right| \f$ represents the norm of the
-        query coordinates expressed in centered basis.
-
-        \warning Requires \f$\nabla w(x)\f$ to be valid
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar scaledw(const VectorType& _q,
-        const DataPoint&  /*attributes*/) const;
-
-    /*!
-        \brief Second order derivative in scale  \f$t\f$
-
-        \param _q Query in global coordinate system
-
-        \f$ \frac{\delta^2 \frac{\left|\mathbf{q}\right|}{t}}{\delta t^2}
-        \nabla w(\frac{\left|\mathbf{q}\right|}{t}) +
-        \left(\frac{\delta \frac{\left|\mathbf{q}\right|}{t}}{\delta t}\right)^2
-        \nabla^2 w(\frac{\left|\mathbf{q}\right|}{t}) =
-        \frac{2\left|\mathbf{q}\right|}{t^3} \nabla{w(\frac{\left|\mathbf{q}\right|}{t})} +
-        \frac{\left|\mathbf{q}\right|^2}{t^4} \nabla^2{w(\frac{\left|\mathbf{q}\right|}{t})}
-        \f$
-
-        where \f$ \left|\mathbf{q}\right| \f$ represents the norm of the
-        query coordinates expressed in centered basis.
-
-        \warning Requires \f$\nabla^2 w(x)\f$ to be valid
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar scaled2w(const VectorType& _q,
-        const DataPoint&  /*attributes*/) const;
-
-    /*!
-        \brief Cross derivative in scale \f$t\f$ and in space (for each spatial dimension \f$\mathsf{x})\f$
-
-        \param _q Query in global coordinate system
-
-        \f$ \frac{\delta^2 \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta t\ \delta \mathsf{x}}
-        \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
-        \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}
-        \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta t}
-        \nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) =
-        -\frac{\mathbf{q}_\mathsf{x}}{t^2}
-        \left( \frac{1}{\left|\mathbf{q}_\mathsf{x}\right|}\nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
-        \frac{1}{t}\nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) \right)\f$
-
-        where \f$ \left|\mathbf{q}_\mathsf{x}\right| \f$ represents the norm of the
-        query coordinates expressed in centered basis.
-
-        \warning Requires \f$\nabla^2 w(x)\f$ to be valid
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType scaleSpaced2w(const VectorType& _q,
-        const DataPoint&  /*attributes*/) const;
-
-    /*! \brief Access to the evaluation scale set during the initialization */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar evalScale() const { return m_t; }
-
-protected:
-    Scalar       m_t;  /*!< \brief Evaluation scale */
-    WeightKernel m_wk; /*!< \brief 1D function applied to weight queries */
-
-};// class DistWeightFunc
-
-/*!
-    \brief Base Weighting function that set uniform weight to all samples
-
-    In contrast to DistWeightFunc with ConstantWeight, it does not check for scale range.
-    \tparam _NeighborhoodFrame Base NeighborhoodFrame used to performs (or not) local basis conversion and maintain
-    computation accuracy
-*/
-template <class DataPoint, template <typename>typename _NeighborhoodFrame>
-class NoWeightFuncBase : public _NeighborhoodFrame<DataPoint>
-{
-public:
-    /*! \brief Scalar type from DataPoint */
-    using Scalar =  typename DataPoint::Scalar;
-    /*! \brief Vector type from DataPoint */
-    using VectorType =  typename DataPoint::VectorType;
-    /*! \brief Matrix type from DataPoint */
-    using MatrixType = typename DataPoint::MatrixType;
-    /*! \brief Return type of the method #w() */
-    using WeightReturnType = PONCA_MULTIARCH_CU_STD_NAMESPACE(pair)<Scalar, VectorType>;
-
-    using NeighborhoodFrame = _NeighborhoodFrame<DataPoint>;
-
-    /*!
-        \brief Default constructor. All parameters are ignored (kept for API compatibility with DistWeightFunc.
-    */
-    PONCA_MULTIARCH inline NoWeightFuncBase(const VectorType& v = VectorType::Zero(), Scalar = 0)
-    : NeighborhoodFrame(v){ }
-
-    ///! \copydoc NoWeightFuncBase
-    PONCA_MULTIARCH inline NoWeightFuncBase(const DataPoint& v, Scalar = 0)
-    : NeighborhoodFrame(v.pos()){ }
-
-    /*!
-        \brief Compute the weight of the given query, which is always $1$
-        \param _q Query in global coordinate system
-    */
-    PONCA_MULTIARCH inline WeightReturnType operator()(const DataPoint& _q) const
+    template <class DataPoint, class WeightKernel>
+    class DistWeightFunc : public CenteredNeighborhoodFrame<DataPoint>
     {
-        return {Scalar(1), NeighborhoodFrame::convertToLocalBasis(_q.pos())};
-    }
+    public:
+        /*! \brief Scalar type from DataPoint */
+        using Scalar = typename DataPoint::Scalar;
+        /*! \brief Vector type from DataPoint */
+        using VectorType = typename DataPoint::VectorType;
+        /*! \brief Matrix type from DataPoint */
+        using MatrixType = typename DataPoint::MatrixType;
+        /*! \brief Return type of the method #w() */
+        using WeightReturnType = PONCA_MULTIARCH_CU_STD_NAMESPACE(pair)<Scalar, VectorType>;
+        /// \brief Frame used to express the neighbors locally
+        using NeighborhoodFrame = CenteredNeighborhoodFrame<DataPoint>;
+        /// \brief Flag indicating if the weighting kernel is compact of not
+        static constexpr bool isCompact = WeightKernel::isCompact;
 
+        /*!
+            \brief Constructor that defines the current evaluation scale
+            \warning t > 0
+        */
+        PONCA_MULTIARCH inline DistWeightFunc(const VectorType& _evalPos = VectorType::Zero(),
+                                              const Scalar& _t           = Scalar(1.))
+            : NeighborhoodFrame(_evalPos), m_t(_t)
+        {
+            //\todo manage that assert on __host__ and __device__
+            // assert(_t > Scalar(0));
+        }
+
+        ///! \copydoc DistWeightFunc
+        PONCA_MULTIARCH inline DistWeightFunc(const DataPoint& _evalPoint, const Scalar& _t = Scalar(1.))
+            : NeighborhoodFrame(_evalPoint.pos()), m_t(_t)
+        {
+            //\todo manage that assert on __host__ and __device__
+            // assert(_t > Scalar(0));
+        }
+
+        /*!
+            \brief Compute the weight of the given query with respect to its coordinates.
+
+            \param _q Query in global coordinate system
+
+            As the query \f$\mathbf{q}\f$ is expressed in global coordinate, it is
+            first converted to the centered basis. Then, the WeightKernel is directly
+            applied to the norm of its coordinates with respect to the current scale  \f$ t \f$ :
+
+            \f$ w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) \f$
+
+            \see convertToLocalBasis
+            \return The computed weight + the point expressed in local basis
+        */
+        PONCA_MULTIARCH inline WeightReturnType operator()(const DataPoint& q) const;
+
+        /*!
+            \brief First order derivative in space (for each spatial dimension \f$\mathsf{x})\f$
+
+            \param _q Query in global coordinate system
+
+            \f$ \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}
+            \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t})
+            = \frac{\mathbf{q}}{t\left|q\right|}  \nabla{w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t})}  \f$
+
+            where \f$ \left|\mathbf{q}_\mathsf{x}\right| \f$ represents the norm of the
+            query coordinates expressed in centered basis,
+            for each spatial dimensions \f$ \mathsf{x}\f$.
+
+            \warning Requires \f$\nabla w(x)\f$ to be valid
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType spacedw(const VectorType& _q,
+                                                                const DataPoint& /*attributes*/) const;
+
+        /*!
+            \brief Second order derivative in space (for each spatial dimension \f$\mathsf{x})\f$
+
+            \param _q Query in global coordinate system
+
+            \f$ \frac{\delta^2 \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}^2}
+            \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
+            \left(\frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}\right)^2
+            \nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) =
+            \frac{1}{t\left|\mathbf{q}_\mathsf{x}\right|} \left( I_d -
+           \frac{\mathbf{q}_\mathsf{x}\mathbf{q}_\mathsf{x}^T}{\left|\mathbf{q}_\mathsf{x}\right|^2}\right)
+            \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
+            \frac{\mathbf{q}_\mathsf{x}\mathbf{q}_\mathsf{x}^T}{t^2\left|\mathbf{q}_\mathsf{x}\right|^2}
+            \nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) \f$
+
+            where \f$ \left|\mathbf{q}_\mathsf{x}\right| \f$ represents the norm of the
+            query coordinates expressed in centered basis,
+            for each spatial dimensions \f$ \mathsf{x}\f$.
+
+            \warning Requires \f$\nabla^2 w(x)\f$ to be valid
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline MatrixType spaced2w(const VectorType& _q,
+                                                                 const DataPoint& /*attributes*/) const;
+
+        /*!
+            \brief First order derivative in scale  \f$t\f$
+
+            \param _q Query in global coordinate system
+
+            \f$ \frac{\delta \frac{\left|\mathbf{q}\right|}{t}}{\delta t}
+            \nabla w(\frac{\left|\mathbf{q}\right|}{t})
+            = - \frac{\left|\mathbf{q}\right|}{t^2} \nabla{w(\frac{\left|\mathbf{q}\right|}{t})} \f$
+
+            where \f$ \left|\mathbf{q}\right| \f$ represents the norm of the
+            query coordinates expressed in centered basis.
+
+            \warning Requires \f$\nabla w(x)\f$ to be valid
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar scaledw(const VectorType& _q,
+                                                            const DataPoint& /*attributes*/) const;
+
+        /*!
+            \brief Second order derivative in scale  \f$t\f$
+
+            \param _q Query in global coordinate system
+
+            \f$ \frac{\delta^2 \frac{\left|\mathbf{q}\right|}{t}}{\delta t^2}
+            \nabla w(\frac{\left|\mathbf{q}\right|}{t}) +
+            \left(\frac{\delta \frac{\left|\mathbf{q}\right|}{t}}{\delta t}\right)^2
+            \nabla^2 w(\frac{\left|\mathbf{q}\right|}{t}) =
+            \frac{2\left|\mathbf{q}\right|}{t^3} \nabla{w(\frac{\left|\mathbf{q}\right|}{t})} +
+            \frac{\left|\mathbf{q}\right|^2}{t^4} \nabla^2{w(\frac{\left|\mathbf{q}\right|}{t})}
+            \f$
+
+            where \f$ \left|\mathbf{q}\right| \f$ represents the norm of the
+            query coordinates expressed in centered basis.
+
+            \warning Requires \f$\nabla^2 w(x)\f$ to be valid
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar scaled2w(const VectorType& _q,
+                                                             const DataPoint& /*attributes*/) const;
+
+        /*!
+            \brief Cross derivative in scale \f$t\f$ and in space (for each spatial dimension \f$\mathsf{x})\f$
+
+            \param _q Query in global coordinate system
+
+            \f$ \frac{\delta^2 \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta t\ \delta \mathsf{x}}
+            \nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
+            \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta \mathsf{x}}
+            \frac{\delta \frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}}{\delta t}
+            \nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) =
+            -\frac{\mathbf{q}_\mathsf{x}}{t^2}
+            \left( \frac{1}{\left|\mathbf{q}_\mathsf{x}\right|}\nabla w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) +
+            \frac{1}{t}\nabla^2 w(\frac{\left|\mathbf{q}_\mathsf{x}\right|}{t}) \right)\f$
+
+            where \f$ \left|\mathbf{q}_\mathsf{x}\right| \f$ represents the norm of the
+            query coordinates expressed in centered basis.
+
+            \warning Requires \f$\nabla^2 w(x)\f$ to be valid
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType scaleSpaced2w(const VectorType& _q,
+                                                                      const DataPoint& /*attributes*/) const;
+
+        /*! \brief Access to the evaluation scale set during the initialization */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar evalScale() const { return m_t; }
+
+    protected:
+        Scalar m_t;        /*!< \brief Evaluation scale */
+        WeightKernel m_wk; /*!< \brief 1D function applied to weight queries */
+
+    }; // class DistWeightFunc
 
     /*!
-        \brief First order derivative in space (for each spatial dimension \f$\mathsf{x})\f$, which are always $0$
-        \param _q Query in global coordinate system
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType spacedw(const VectorType& /*_q*/,
-                                              const DataPoint&  /*attributes*/) const
-    { return VectorType::Zeros(); }
+        \brief Base Weighting function that set uniform weight to all samples
 
+        In contrast to DistWeightFunc with ConstantWeight, it does not check for scale range.
+        \tparam _NeighborhoodFrame Base NeighborhoodFrame used to performs (or not) local basis conversion and maintain
+        computation accuracy
+    */
+    template <class DataPoint, template <typename> typename _NeighborhoodFrame>
+    class NoWeightFuncBase : public _NeighborhoodFrame<DataPoint>
+    {
+    public:
+        /*! \brief Scalar type from DataPoint */
+        using Scalar = typename DataPoint::Scalar;
+        /*! \brief Vector type from DataPoint */
+        using VectorType = typename DataPoint::VectorType;
+        /*! \brief Matrix type from DataPoint */
+        using MatrixType = typename DataPoint::MatrixType;
+        /*! \brief Return type of the method #w() */
+        using WeightReturnType = PONCA_MULTIARCH_CU_STD_NAMESPACE(pair)<Scalar, VectorType>;
+
+        using NeighborhoodFrame = _NeighborhoodFrame<DataPoint>;
+
+        /*!
+            \brief Default constructor. All parameters are ignored (kept for API compatibility with DistWeightFunc.
+        */
+        PONCA_MULTIARCH inline NoWeightFuncBase(const VectorType& v = VectorType::Zero(), Scalar = 0)
+            : NeighborhoodFrame(v)
+        {
+        }
+
+        ///! \copydoc NoWeightFuncBase
+        PONCA_MULTIARCH inline NoWeightFuncBase(const DataPoint& v, Scalar = 0) : NeighborhoodFrame(v.pos()) {}
+
+        /*!
+            \brief Compute the weight of the given query, which is always $1$
+            \param _q Query in global coordinate system
+        */
+        PONCA_MULTIARCH inline WeightReturnType operator()(const DataPoint& _q) const
+        {
+            return {Scalar(1), NeighborhoodFrame::convertToLocalBasis(_q.pos())};
+        }
+
+        /*!
+            \brief First order derivative in space (for each spatial dimension \f$\mathsf{x})\f$, which are always $0$
+            \param _q Query in global coordinate system
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType spacedw(const VectorType& /*_q*/,
+                                                                const DataPoint& /*attributes*/) const
+        {
+            return VectorType::Zeros();
+        }
+
+        /*!
+            \brief Second order derivative in space (for each spatial dimension \f$\mathsf{x})\f$, which are always $0$
+            \param _q Query in global coordinate
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline MatrixType spaced2w(const VectorType& /*_q*/,
+                                                                 const DataPoint& /*attributes*/) const
+        {
+            return MatrixType::Zeros();
+        }
+
+        /*!
+            \brief First order derivative in scale  \f$t\f$, which are always $0$
+            \param _q Query in global coordinate
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar scaledw(const VectorType& /*_q*/,
+                                                            const DataPoint& /*attributes*/) const
+        {
+            return Scalar(0);
+        }
+
+        /*!
+            \brief Second order derivative in scale  \f$t\f$, which are always $0$
+            \param _q Query in global coordinate
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar scaled2w(const VectorType& /*_q*/,
+                                                             const DataPoint& /*attributes*/) const
+        {
+            return Scalar(0);
+        }
+
+        /*!
+            \brief Cross derivative in scale \f$t\f$ and in space (for each spatial dimension \f$\mathsf{x})\f$, which
+           are always $0$
+            \param _q Query in global coordinate
+        */
+        PONCA_MULTIARCH [[nodiscard]] inline VectorType scaleSpaced2w(const VectorType& /*_q*/,
+                                                                      const DataPoint& /*attributes*/) const
+        {
+            return VectorType::Zeros();
+        }
+    }; // class NoWeightFuncBase
 
     /*!
-        \brief Second order derivative in space (for each spatial dimension \f$\mathsf{x})\f$, which are always $0$
-        \param _q Query in global coordinate
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline MatrixType spaced2w(const VectorType& /*_q*/,
-                                               const DataPoint&  /*attributes*/) const
-    { return MatrixType::Zeros(); }
+     * This class extends a NeighborFilter class to also store the normal of the evaluation point, for use outside the
+     * scope of this class.
+     *
+     * \tparam Any NeighborFilter type (NoWeightFunc or DistWeightFunc<ConstantWeightKernel> for example)
+     */
+    template <class DataPoint, typename NeighborFilter>
+    class NeighborFilterStoreNormal : public NeighborFilter
+    {
+    public:
+        using Base = NeighborFilter;
+        /*! \brief Scalar type from DataPoint */
+        using Scalar = typename DataPoint::Scalar;
+        /*! \brief Vector type from DataPoint */
+        using VectorType = typename DataPoint::VectorType;
+        /*! \brief Matrix type from DataPoint */
+        using MatrixType = typename DataPoint::MatrixType;
+        /*! \brief Return type of the method #w() */
+        using WeightReturnType = PONCA_MULTIARCH_CU_STD_NAMESPACE(pair)<Scalar, VectorType>;
 
-    /*!
-        \brief First order derivative in scale  \f$t\f$, which are always $0$
-        \param _q Query in global coordinate
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar scaledw(const VectorType& /*_q*/,
-                                          const DataPoint&  /*attributes*/) const
-    { return Scalar(0); }
+        /*!
+            \brief Constructor that defines the current evaluation scale
+            \warning t > 0
+        */
+        PONCA_MULTIARCH inline NeighborFilterStoreNormal(const VectorType& _evalPos    = VectorType::Zero(),
+                                                         const Scalar& _t              = Scalar(0),
+                                                         const VectorType& _evalNormal = VectorType::Zero())
+            : Base(_evalPos, _t), m_n(_evalNormal)
+        {
+        }
 
-    /*!
-        \brief Second order derivative in scale  \f$t\f$, which are always $0$
-        \param _q Query in global coordinate
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar scaled2w(const VectorType& /*_q*/,
-                                           const DataPoint&  /*attributes*/) const
-    { return Scalar(0); }
+        PONCA_MULTIARCH inline NeighborFilterStoreNormal(const DataPoint& _evalPoint, const Scalar& _t = Scalar(0))
+            : Base(_evalPoint.pos(), _t), m_n(_evalPoint.normal())
+        {
+        }
 
-    /*!
-        \brief Cross derivative in scale \f$t\f$ and in space (for each spatial dimension \f$\mathsf{x})\f$, which are
-        always $0$
-        \param _q Query in global coordinate
-    */
-    PONCA_MULTIARCH [[nodiscard]] inline VectorType scaleSpaced2w(const VectorType& /*_q*/,
-                                                    const DataPoint&  /*attributes*/) const
-    { return VectorType::Zeros(); }
-};// class NoWeightFuncBase
+        /*! \brief Access to the evaluation normal set during the initialization */
+        PONCA_MULTIARCH inline const VectorType& evalNormal() const { return m_n; }
 
-/*!
- * This class extends a NeighborFilter class to also store the normal of the evaluation point, for use outside the scope of this class.
- *
- * \tparam Any NeighborFilter type (NoWeightFunc or DistWeightFunc<ConstantWeightKernel> for example)
- */
-template <class DataPoint, typename NeighborFilter>
-class NeighborFilterStoreNormal : public NeighborFilter {
-public:
-    using Base       = NeighborFilter;
-    /*! \brief Scalar type from DataPoint */
-    using Scalar     =  typename DataPoint::Scalar;
-    /*! \brief Vector type from DataPoint */
-    using VectorType =  typename DataPoint::VectorType;
-    /*! \brief Matrix type from DataPoint */
-    using MatrixType = typename DataPoint::MatrixType;
-    /*! \brief Return type of the method #w() */
-    using WeightReturnType = PONCA_MULTIARCH_CU_STD_NAMESPACE(pair)<Scalar, VectorType>;
+    protected:
+        VectorType m_n; /*!< \brief Evaluation normal */
+    }; // class NeighborFilterStoreNormal
 
-    /*!
-        \brief Constructor that defines the current evaluation scale
-        \warning t > 0
-    */
-    PONCA_MULTIARCH inline NeighborFilterStoreNormal(
-        const VectorType & _evalPos = VectorType::Zero(),
-        const Scalar& _t = Scalar(0),
-        const VectorType & _evalNormal = VectorType::Zero())
-    : Base(_evalPos, _t), m_n(_evalNormal) {}
+    template <class DataPoint>
+    /// \brief
+    using NoWeightFunc = NoWeightFuncBase<DataPoint, CenteredNeighborhoodFrame>;
 
-    PONCA_MULTIARCH inline NeighborFilterStoreNormal(
-        const DataPoint& _evalPoint,
-        const Scalar& _t = Scalar(0))
-    : Base(_evalPoint.pos(), _t), m_n(_evalPoint.normal()) {}
-
-    /*! \brief Access to the evaluation normal set during the initialization */
-    PONCA_MULTIARCH inline const VectorType & evalNormal() const { return m_n; }
-protected:
-    VectorType   m_n;  /*!< \brief Evaluation normal */
-}; // class NeighborFilterStoreNormal
-
-template <class DataPoint>
-/// \brief
-using NoWeightFunc = NoWeightFuncBase<DataPoint, CenteredNeighborhoodFrame>;
-
-template <class DataPoint>
-/// \brief
-using NoWeightFuncGlobal = NoWeightFuncBase<DataPoint, GlobalNeighborhoodFrame>;
+    template <class DataPoint>
+    /// \brief
+    using NoWeightFuncGlobal = NoWeightFuncBase<DataPoint, GlobalNeighborhoodFrame>;
 #include "weightFunc.hpp"
 
-}// namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/weightFunc.hpp
+++ b/Ponca/src/Fitting/weightFunc.hpp
@@ -1,90 +1,85 @@
 /*
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
 #pragma once
 
 template <class DataPoint, class WeightKernel>
-typename DistWeightFunc<DataPoint, WeightKernel>::WeightReturnType
-DistWeightFunc<DataPoint, WeightKernel>::operator()( const DataPoint& _q) const
+typename DistWeightFunc<DataPoint, WeightKernel>::WeightReturnType DistWeightFunc<DataPoint, WeightKernel>::operator()(
+    const DataPoint& _q) const
 {
     const auto lq = NeighborhoodFrame::convertToLocalBasis(_q.pos());
-    Scalar d  = lq.norm();
+    Scalar d      = lq.norm();
     if (isCompact) // compile-time branching
-        return { (d <= m_t) ? m_wk.f(d/m_t) : Scalar(0.), lq };
+        return {(d <= m_t) ? m_wk.f(d / m_t) : Scalar(0.), lq};
     else
-        return {m_wk.f(d/m_t), lq};
+        return {m_wk.f(d / m_t), lq};
 }
 
 template <class DataPoint, class WeightKernel>
-typename DistWeightFunc<DataPoint, WeightKernel>::VectorType
-DistWeightFunc<DataPoint, WeightKernel>::spacedw( const VectorType& _q,
-						                                                  const DataPoint&) const
+typename DistWeightFunc<DataPoint, WeightKernel>::VectorType DistWeightFunc<DataPoint, WeightKernel>::spacedw(
+    const VectorType& _q, const DataPoint&) const
 {
     static_assert(WeightKernel::isDValid, "First order derivatives are required");
     VectorType result = VectorType::Zero();
-    const auto q = NeighborhoodFrame::convertToLocalBasis(_q);
-    Scalar d = q.norm();
+    const auto q      = NeighborhoodFrame::convertToLocalBasis(_q);
+    Scalar d          = q.norm();
     // isCompact is tested at compile-time
-    if ((!isCompact) || (d <= m_t && d != Scalar(0.))) result = (q / (d * m_t)) * m_wk.df(d / m_t);
+    if ((!isCompact) || (d <= m_t && d != Scalar(0.)))
+        result = (q / (d * m_t)) * m_wk.df(d / m_t);
     return result;
 }
 
 template <class DataPoint, class WeightKernel>
-typename DistWeightFunc<DataPoint, WeightKernel>::MatrixType
-DistWeightFunc<DataPoint, WeightKernel>::spaced2w( const VectorType& _q,
-                                                                           const DataPoint&) const
+typename DistWeightFunc<DataPoint, WeightKernel>::MatrixType DistWeightFunc<DataPoint, WeightKernel>::spaced2w(
+    const VectorType& _q, const DataPoint&) const
 {
     static_assert(WeightKernel::isDDValid, "Second order derivatives are required");
     MatrixType result = MatrixType::Zero();
-    const auto q = NeighborhoodFrame::convertToLocalBasis(_q);
-    Scalar d = q.norm();
-    if ((!isCompact) ||(d <= m_t && d != Scalar(0.)))
+    const auto q      = NeighborhoodFrame::convertToLocalBasis(_q);
+    Scalar d          = q.norm();
+    if ((!isCompact) || (d <= m_t && d != Scalar(0.)))
     {
-        Scalar der = m_wk.df(d/m_t);
-        result = q*q.transpose()/d*(m_wk.ddf(d/m_t)/m_t - der/d);
+        Scalar der = m_wk.df(d / m_t);
+        result     = q * q.transpose() / d * (m_wk.ddf(d / m_t) / m_t - der / d);
         result.diagonal().array() += der;
-        result *= Scalar(1.)/(m_t*d);
+        result *= Scalar(1.) / (m_t * d);
     }
     return result;
 }
 
 template <class DataPoint, class WeightKernel>
-typename DistWeightFunc<DataPoint, WeightKernel>::Scalar
-DistWeightFunc<DataPoint, WeightKernel>::scaledw( const VectorType& _q,
-                                                                          const DataPoint&) const
+typename DistWeightFunc<DataPoint, WeightKernel>::Scalar DistWeightFunc<DataPoint, WeightKernel>::scaledw(
+    const VectorType& _q, const DataPoint&) const
 {
     static_assert(WeightKernel::isDValid, "First order derivatives are required");
-    Scalar d  = NeighborhoodFrame::convertToLocalBasis(_q).norm();
-    return ((!isCompact) ||(d <= m_t)) ? Scalar( - d*m_wk.df(d/m_t)/(m_t*m_t) ) : Scalar(0.);
+    Scalar d = NeighborhoodFrame::convertToLocalBasis(_q).norm();
+    return ((!isCompact) || (d <= m_t)) ? Scalar(-d * m_wk.df(d / m_t) / (m_t * m_t)) : Scalar(0.);
 }
 
 template <class DataPoint, class WeightKernel>
-typename DistWeightFunc<DataPoint, WeightKernel>::Scalar
-DistWeightFunc<DataPoint, WeightKernel>::scaled2w( const VectorType& _q,
-                                                                           const DataPoint&) const
+typename DistWeightFunc<DataPoint, WeightKernel>::Scalar DistWeightFunc<DataPoint, WeightKernel>::scaled2w(
+    const VectorType& _q, const DataPoint&) const
 {
     static_assert(WeightKernel::isDDValid, "Second order derivatives are required");
-    Scalar d  = NeighborhoodFrame::convertToLocalBasis(_q).norm();
-    return ((!isCompact) ||(d <= m_t)) ? Scalar(Scalar(2.)*d/(m_t*m_t*m_t)*m_wk.df(d/m_t) +
-                               d*d/(m_t*m_t*m_t*m_t)*m_wk.ddf(d/m_t)) :
-                        Scalar(0.);
+    Scalar d = NeighborhoodFrame::convertToLocalBasis(_q).norm();
+    return ((!isCompact) || (d <= m_t)) ? Scalar(Scalar(2.) * d / (m_t * m_t * m_t) * m_wk.df(d / m_t) +
+                                                 d * d / (m_t * m_t * m_t * m_t) * m_wk.ddf(d / m_t))
+                                        : Scalar(0.);
 }
 
 template <class DataPoint, class WeightKernel>
-typename DistWeightFunc<DataPoint, WeightKernel>::VectorType
-DistWeightFunc<DataPoint, WeightKernel>::scaleSpaced2w( const VectorType& _q,
-                                                                                const DataPoint&) const
+typename DistWeightFunc<DataPoint, WeightKernel>::VectorType DistWeightFunc<DataPoint, WeightKernel>::scaleSpaced2w(
+    const VectorType& _q, const DataPoint&) const
 {
     static_assert(WeightKernel::isDDValid, "Second order derivatives are required");
     VectorType result = VectorType::Zero();
-    const auto q = NeighborhoodFrame::convertToLocalBasis(_q);
-    Scalar d = q.norm();
-    if ((!isCompact) ||(d <= m_t && d != Scalar(0.)))
-        result = -q/(m_t*m_t)*(m_wk.df(d/m_t)/d + m_wk.ddf(d/m_t)/m_t);
+    const auto q      = NeighborhoodFrame::convertToLocalBasis(_q);
+    Scalar d          = q.norm();
+    if ((!isCompact) || (d <= m_t && d != Scalar(0.)))
+        result = -q / (m_t * m_t) * (m_wk.df(d / m_t) / d + m_wk.ddf(d / m_t) / m_t);
     return result;
 }
-
 

--- a/Ponca/src/Fitting/weightKernel.h
+++ b/Ponca/src/Fitting/weightKernel.h
@@ -12,281 +12,291 @@
     \file weightKernel.h Define 1D weight kernel functors
 */
 
-
 namespace Ponca
 {
-/*!
-    \brief Concept::WeightKernelConcept returning a constant value
+    /*!
+        \brief Concept::WeightKernelConcept returning a constant value
 
-    \inherit Concept::WeightKernelConcept
-*/
-template <typename _Scalar>
-class ConstantWeightKernel
-{
-public:
-    /*! \brief Scalar type defined outside the class */
-    typedef _Scalar Scalar;
+        \inherit Concept::WeightKernelConcept
+    */
+    template <typename _Scalar>
+    class ConstantWeightKernel
+    {
+    public:
+        /*! \brief Scalar type defined outside the class */
+        typedef _Scalar Scalar;
 
-    /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
-    /// \see #NoWeightFunc and #NoWeightFuncGlobal for alternative way to use uniform weight.
-    static constexpr bool isCompact = true;
+        /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
+        /// \see #NoWeightFunc and #NoWeightFuncGlobal for alternative way to use uniform weight.
+        static constexpr bool isCompact = true;
 
-    // Init
-    //! \brief Default constructor that could be used to set the returned value
-    PONCA_MULTIARCH inline ConstantWeightKernel(const Scalar& _value = Scalar(1.)) : m_y(_value){}
-    //! \brief Set the returned value
-    PONCA_MULTIARCH inline void setValue(const Scalar& _value){ m_y = _value; }
+        // Init
+        //! \brief Default constructor that could be used to set the returned value
+        PONCA_MULTIARCH inline ConstantWeightKernel(const Scalar& _value = Scalar(1.)) : m_y(_value) {}
+        //! \brief Set the returned value
+        PONCA_MULTIARCH inline void setValue(const Scalar& _value) { m_y = _value; }
 
-    // Functor
-    //! \brief Return the constant value
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar&) const { return m_y; }
-    //! \brief Return \f$ 0 \f$
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar&) const { return Scalar(0.); }
-    //! \brief Return \f$ 0 \f$
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar&) const { return Scalar(0.); }
+        // Functor
+        //! \brief Return the constant value
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar&) const { return m_y; }
+        //! \brief Return \f$ 0 \f$
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar&) const { return Scalar(0.); }
+        //! \brief Return \f$ 0 \f$
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar&) const { return Scalar(0.); }
 
-    //! \brief #df is defined and valid on the definition interval
-    static constexpr bool isDValid = true;
-    //! \brief #ddf is defined and valid on the definition interval
-    static constexpr bool isDDValid = true;
+        //! \brief #df is defined and valid on the definition interval
+        static constexpr bool isDValid = true;
+        //! \brief #ddf is defined and valid on the definition interval
+        static constexpr bool isDDValid = true;
 
-private:
-    Scalar m_y; /*!< \brief Constant value returned by the kernel */
-};// class ConstantWeightKernel
+    private:
+        Scalar m_y; /*!< \brief Constant value returned by the kernel */
+    }; // class ConstantWeightKernel
+
+    /*!
+        \brief Compact smooth WeightKernel of 2nd degree, defined in \f$\left[0 : 1\right]\f$
+        Special case of PolynomialSmoothWeightKernel<Scalar, 2, 2>
+
+        \inherit Concept::WeightKernelConcept
+    */
+    template <typename _Scalar>
+    class SmoothWeightKernel
+    {
+    public:
+        /*! \brief Scalar type defined outside the class*/
+        typedef _Scalar Scalar;
+
+        /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
+        static constexpr bool isCompact = true;
+
+        // Functor
+        /*! \brief Defines the smooth weighting function \f$ w(x) = (x^2-1)^2 \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar& _x) const
+        {
+            Scalar v = _x * _x - Scalar(1.);
+            return v * v;
+        }
+        /*! \brief Defines the smooth first order weighting function \f$ \nabla w(x) = 4x(x^2-1) \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar& _x) const
+        {
+            return Scalar(4.) * _x * (_x * _x - Scalar(1.));
+        }
+        /*! \brief Defines the smooth second order weighting function \f$ \nabla^2 w(x) = 12x^2-4 \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const
+        {
+            return Scalar(12.) * _x * _x - Scalar(4.);
+        }
+        //! \brief #df is defined and valid on the definition interval
+        static constexpr bool isDValid = true;
+        //! \brief #ddf is defined and valid on the definition interval
+        static constexpr bool isDDValid = true;
+    }; // class SmoothWeightKernel
+
+    /*!
+        \brief Compact generalised version of SmoothWeightKernel with arbitrary degrees : \f$ w(x)=(x^n-1)^m \f$
+
+        \inherit Concept::WeightKernelConcept
+    */
+    template <typename _Scalar, int m, int n>
+    class PolynomialSmoothWeightKernel
+    {
+    public:
+        /*! \brief Scalar type defined outside the class*/
+        typedef _Scalar Scalar;
+
+        /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
+        static constexpr bool isCompact = true;
+
+        // Functor
+        /*! \brief Defines the smooth weighting function \f$  w(x)=(x^n-1)^m \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar& _x) const
+        {
+            PONCA_MULTIARCH_STD_MATH(pow);
+            return pow(pow(_x, Scalar(n)) - Scalar(1.), Scalar(m));
+        }
+        /*! \brief Defines the smooth first order weighting function \f$ \nabla w(x) = m n x^{n-1}
+         * \left(x^n-1\right)^{m-1} \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar& _x) const
+        {
+            PONCA_MULTIARCH_STD_MATH(pow);
+            return pow(Scalar(m * n) * _x, Scalar(n - 1)) * pow(pow(_x, Scalar(n)) - 1, Scalar(m - 1));
+        }
+        /*! \brief Defines the smooth second order weighting function \f$ \nabla^2 w(x) = (m-1) m n^2 x^{2 n-2}
+         * \left(x^n-1\right)^{m-2}+m (n-1) n x^{n-2} \left(x^n-1\right)^{m-1} \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const
+        {
+            PONCA_MULTIARCH_STD_MATH(pow);
+            return Scalar((m - 1) * m * n * n) * pow(_x, Scalar(2 * n - 2)) *
+                       pow(pow(_x, Scalar(n)) - Scalar(1), Scalar(m - 2)) +
+                   Scalar(m * (n - 1) * n) * pow(_x, Scalar(n - 2)) *
+                       pow(pow(_x, Scalar(n)) - Scalar(1), Scalar(m - 1));
+        }
+        //! \brief #df is defined and valid on the definition interval
+        static constexpr bool isDValid = true;
+        //! \brief #ddf is defined and valid on the definition interval
+        static constexpr bool isDDValid = true;
+    }; // class PolynomialSmoothWeightKernel
+
+    /*!
+        \brief Compact Wendland WeightKernel defined in \f$\left[0 : 1\right]\f$
+
+        \inherit Concept::WeightKernelConcept
+
+        Weight function is an implementation of equation 2 in \cite Alexa:2009:Hermite
+    */
+    template <typename _Scalar>
+    class WendlandWeightKernel
+    {
+    public:
+        /*! \brief Scalar type defined outside the class*/
+        typedef _Scalar Scalar;
+
+        /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
+        static constexpr bool isCompact = true;
+
+        // Functor
+        /*! \brief Defines the Wendland weighting function \f$ w(x) = (1-x)^4(4x+1) \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar& _x) const
+        {
+            const Scalar v = Scalar(1.) - _x;
+            return v * v * v * v * ((Scalar(4.) * _x) + Scalar(1.));
+        }
+        /*! \brief Defines the Wendland first order weighting function \f$ \nabla w(x) = 20x * (x−1)^3 \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar& _x) const
+        {
+            const Scalar v = _x - Scalar(1.);
+            return Scalar(20.) * _x * v * v * v;
+        }
+        /*! \brief Defines the Wendland second order weighting function \f$ \nabla^2 w(x) = (x−1)^2 * (80x−20) \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const
+        {
+            const Scalar v = _x - Scalar(1.);
+            return v * v * (Scalar(80.) * _x - Scalar(20));
+        }
+        //! \brief #df is defined and valid on the definition interval
+        static constexpr bool isDValid = true;
+        //! \brief #ddf is defined and valid on the definition interval
+        static constexpr bool isDDValid = true;
+    }; // class WendlandWeightKernel
+
+    /*!
+        \brief Compact singular WeightKernel defined in \f$\left]0 : 1\right]\f$
+
+        \inherit Concept::WeightKernelConcept
+
+        Weight function is an implementation of an unnumbered equation but defined in the Appendices in \cite
+       Alexa:2009:Hermite
+    */
+
+    template <typename _Scalar>
+    class SingularWeightKernel
+    {
+    public:
+        /*! \brief Scalar type defined outside the class*/
+        typedef _Scalar Scalar;
+
+        /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
+        static constexpr bool isCompact = true;
+
+        // Functor
+        /*! \brief Defines the Singular weighting function \f$ w(x) = 1 / (x^2) \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar& _x) const { return Scalar(1.) / (_x * _x); }
+        /*! \brief Defines the Singular first order weighting function \f$ \nabla w(x) = -2 / (x^3) \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar& _x) const { return Scalar(-2.) / (_x * _x * _x); }
+        /*! \brief Defines the Singular second order weighting function \f$ \nabla^2 w(x) = 6 / (x^4) \f$ */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const
+        {
+            return Scalar(6.) / (_x * _x * _x * _x);
+        }
+        //! \brief #df is defined and valid on the definition interval
+        static constexpr bool isDValid = true;
+        //! \brief #ddf is defined and valid on the definition interval
+        static constexpr bool isDDValid = true;
+    }; // class SingularWeightKernel
+
+    /*!
+        \brief Compact Exponential WeightKernel defined in \f$\left[0 : 1\right]\f$
+
+        Continuity is \f$C^\infty\f$ for \f$x=1\f$.
+
+        \warning \f$\nabla^2 w(x)\f$ is not defined for all values in \f$\left[0 : 1\right]\f$. Do not use for
+       second-order differentiation.
+
+        \inherit Concept::WeightKernelConcept
+    */
+    template <typename _Scalar>
+    class CompactExpWeightKernel
+    {
+    public:
+        /*! \brief Scalar type defined outside the class*/
+        typedef _Scalar Scalar;
+
+        /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
+        static constexpr bool isCompact = true;
+
+        // Functor
+        /*! \brief Defines the smooth weighting function \f$ w(x) = e^{-\frac{x^2}{1 - x^2}} \f$
+         *  \see
+         * https://www.wolframalpha.com/input?i=e%5E%28-x%5E2%2F%281+-+x%5E2%29%29&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar& _x) const
+        {
+            PONCA_MULTIARCH_STD_MATH(exp);
+            Scalar v = _x * _x;
+            return exp(-v / (Scalar(1) - v));
+        }
+        /*! \brief Defines the smooth first order weighting function \f$ \nabla w(x) = -\frac{2 x e^{\frac{x^2}{x^2 -
+         * 1}}}{(1 - x^2)^2} \f$
+         * \see
+         * https://www.wolframalpha.com/input?i2d=true&i=+-Divide%5B%5C%2840%292+Power%5Be%2C%5C%2840%29Power%5Bx%2CDivide%5B2%2C%5C%2840%29Power%5Bx%2C2%5D+-+1%5C%2841%29%5D%5D%5C%2841%29%5D+x%5C%2841%29%2CPower%5B%5C%2840%291+-+Power%5Bx%2C2%5D%5C%2841%29%2C2%5D%5D
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar& _x) const
+        {
+            PONCA_MULTIARCH_STD_MATH(exp);
+            Scalar v  = _x * _x;
+            Scalar mv = v - Scalar(1);
+            return -(Scalar(2) * exp(v / mv) * _x) / (mv * mv);
+        }
+        /*! \brief Defines the smooth second order weighting function
+         * \f$ \nabla^2 w(x) = \frac{2 e^\frac{x^2}{x^2 - 1} \left(4 x^{\frac{2}{x^2 - 1} + 2} log(x) - (x^2 - 1)
+         * \left(-3 x^2 + 2 x^\frac{2}{x^2 - 1} - 1\right)\right)}{(x^2 - 1)^4} \f$
+         * \see \see
+         * https://www.wolframalpha.com/input?i2d=true&i=+-Divide%5B%5C%2840%292+Power%5Be%2C%5C%2840%29Power%5Bx%2CDivide%5B2%2C%5C%2840%29Power%5Bx%2C2%5D+-+1%5C%2841%29%5D%5D%5C%2841%29%5D+x%5C%2841%29%2CPower%5B%5C%2840%291+-+Power%5Bx%2C2%5D%5C%2841%29%2C2%5D%5D
+         */
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const
+        {
+            PONCA_MULTIARCH_STD_MATH(exp);
+            PONCA_MULTIARCH_STD_MATH(pow);
+            Scalar v      = _x * _x;        // x^2
+            Scalar mv     = v - Scalar(1);  // x^2-1
+            Scalar mvpow  = Scalar(2) / mv; // 2/(x^2-1)
+            Scalar cmvpow = pow(_x, mvpow); // x^{2/(x^2-1)}
+            return Scalar(2) * exp(cmvpow) *
+                   ((Scalar(4) * pow(_x, mvpow + Scalar(2)) * log(_x) -
+                     mv * (-Scalar(3) * v + Scalar(2) * cmvpow - Scalar(1)))) /
+                   (mv * mv * mv * mv);
+        }
+
+        //! \brief #df is defined and valid on the definition interval
+        static constexpr bool isDValid = true;
+        //! \brief #ddf is not defined and valid on the definition interval
+        static constexpr bool isDDValid = false;
+    }; // class CompactExpWeightKernel
+
+    /*!
+        \brief Non-compact Gaussian WeightKernel
+
+        \note This is not a distribution, thus the kernel is not normalized in order to have \f$f(0)=1\f$.
+
+        \inherit Concept::WeightKernelConcept
+
+        \warning Also, as \f$\sigma=t\f$, a GaussianWeightKernel generates a larger weighting function than a
+        compact kernel, as \f$f(1)\approx 0.6\f$. In order to obtain a comparable weight, it is recommended to scale
+       down
+        \f$t\f$ by a factor of \f$0.16\f$.
 
 
-/*!
-    \brief Compact smooth WeightKernel of 2nd degree, defined in \f$\left[0 : 1\right]\f$
-    Special case of PolynomialSmoothWeightKernel<Scalar, 2, 2>
-
-    \inherit Concept::WeightKernelConcept
-*/
-template <typename _Scalar>
-class SmoothWeightKernel
-{
-public:
-    /*! \brief Scalar type defined outside the class*/
-    typedef _Scalar Scalar;
-
-    /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
-    static constexpr bool isCompact = true;
-
-    // Functor
-    /*! \brief Defines the smooth weighting function \f$ w(x) = (x^2-1)^2 \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar& _x) const { Scalar v = _x*_x - Scalar(1.); return v*v; }
-    /*! \brief Defines the smooth first order weighting function \f$ \nabla w(x) = 4x(x^2-1) \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar& _x) const { return Scalar(4.)*_x*(_x*_x-Scalar(1.)); }
-    /*! \brief Defines the smooth second order weighting function \f$ \nabla^2 w(x) = 12x^2-4 \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const { return Scalar(12.)*_x*_x - Scalar(4.); }
-    //! \brief #df is defined and valid on the definition interval
-    static constexpr bool isDValid = true;
-    //! \brief #ddf is defined and valid on the definition interval
-    static constexpr bool isDDValid = true;
-};//class SmoothWeightKernel
-
-/*!
-    \brief Compact generalised version of SmoothWeightKernel with arbitrary degrees : \f$ w(x)=(x^n-1)^m \f$
-
-    \inherit Concept::WeightKernelConcept
-*/
-template <typename _Scalar, int m, int n>
-class PolynomialSmoothWeightKernel
-{
-public:
-    /*! \brief Scalar type defined outside the class*/
-    typedef _Scalar Scalar;
-
-    /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
-    static constexpr bool isCompact = true;
-
-    // Functor
-    /*! \brief Defines the smooth weighting function \f$  w(x)=(x^n-1)^m \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar& _x) const {
-        PONCA_MULTIARCH_STD_MATH(pow);
-        return pow(
-            pow(_x, Scalar(n)) - Scalar(1.),
-            Scalar(m)
-        );
-    }
-    /*! \brief Defines the smooth first order weighting function \f$ \nabla w(x) = m n x^{n-1} \left(x^n-1\right)^{m-1} \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar& _x) const {
-        PONCA_MULTIARCH_STD_MATH(pow);
-        return pow(
-            Scalar(m*n)*_x,
-            Scalar(n-1)) * pow(pow(_x, Scalar(n)) -1, Scalar(m-1)
-        );
-    }
-    /*! \brief Defines the smooth second order weighting function \f$ \nabla^2 w(x) = (m-1) m n^2 x^{2 n-2} \left(x^n-1\right)^{m-2}+m (n-1) n x^{n-2} \left(x^n-1\right)^{m-1} \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const {
-        PONCA_MULTIARCH_STD_MATH(pow);
-        return Scalar((m-1)*m*n*n)
-            * pow( _x, Scalar(2*n-2))
-            * pow(
-                pow(_x, Scalar(n))-Scalar(1),
-                Scalar(m-2)
-            )
-            + Scalar(m*(n-1)*n)
-            * pow(
-                _x,
-                Scalar(n-2)
-            )
-            * pow(
-                pow(_x, Scalar(n))-Scalar(1),
-                Scalar(m-1)
-            );
-    }
-    //! \brief #df is defined and valid on the definition interval
-    static constexpr bool isDValid = true;
-    //! \brief #ddf is defined and valid on the definition interval
-    static constexpr bool isDDValid = true;
-};//class PolynomialSmoothWeightKernel
-
-/*!
-    \brief Compact Wendland WeightKernel defined in \f$\left[0 : 1\right]\f$
-
-    \inherit Concept::WeightKernelConcept
-
-    Weight function is an implementation of equation 2 in \cite Alexa:2009:Hermite
-*/
-template <typename _Scalar>
-class WendlandWeightKernel
-{
-public:
-    /*! \brief Scalar type defined outside the class*/
-    typedef _Scalar Scalar;
-
-    /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
-    static constexpr bool isCompact = true;
-
-    // Functor
-    /*! \brief Defines the Wendland weighting function \f$ w(x) = (1-x)^4(4x+1) \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar& _x) const {
-        const Scalar v = Scalar(1.) - _x;
-        return v * v * v * v * ((Scalar(4.) * _x) + Scalar(1.));
-    }
-    /*! \brief Defines the Wendland first order weighting function \f$ \nabla w(x) = 20x * (x−1)^3 \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar& _x) const {
-        const Scalar v = _x - Scalar(1.);
-        return Scalar(20.) * _x * v * v * v;
-    }
-    /*! \brief Defines the Wendland second order weighting function \f$ \nabla^2 w(x) = (x−1)^2 * (80x−20) \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const {
-        const Scalar v = _x - Scalar(1.);
-        return v * v * (Scalar(80.) * _x - Scalar(20));
-    }
-    //! \brief #df is defined and valid on the definition interval
-    static constexpr bool isDValid = true;
-    //! \brief #ddf is defined and valid on the definition interval
-    static constexpr bool isDDValid = true;
-};//class WendlandWeightKernel
-
-
-/*!
-    \brief Compact singular WeightKernel defined in \f$\left]0 : 1\right]\f$
-
-    \inherit Concept::WeightKernelConcept
-
-    Weight function is an implementation of an unnumbered equation but defined in the Appendices in \cite Alexa:2009:Hermite
-*/
-
-template <typename _Scalar>
-class SingularWeightKernel
-{
-public:
-    /*! \brief Scalar type defined outside the class*/
-    typedef _Scalar Scalar;
-
-    /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
-    static constexpr bool isCompact = true;
-
-    // Functor
-    /*! \brief Defines the Singular weighting function \f$ w(x) = 1 / (x^2) \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar& _x) const {
-        return Scalar(1.) / (_x * _x);
-    }
-    /*! \brief Defines the Singular first order weighting function \f$ \nabla w(x) = -2 / (x^3) \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar& _x) const {
-        return Scalar(-2.) / (_x * _x * _x);
-    }
-    /*! \brief Defines the Singular second order weighting function \f$ \nabla^2 w(x) = 6 / (x^4) \f$ */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const {
-        return Scalar(6.) / (_x * _x * _x * _x);
-    }
-    //! \brief #df is defined and valid on the definition interval
-    static constexpr bool isDValid = true;
-    //! \brief #ddf is defined and valid on the definition interval
-    static constexpr bool isDDValid = true;
-};//class SingularWeightKernel
-
-
-/*!
-    \brief Compact Exponential WeightKernel defined in \f$\left[0 : 1\right]\f$
-
-    Continuity is \f$C^\infty\f$ for \f$x=1\f$.
-
-    \warning \f$\nabla^2 w(x)\f$ is not defined for all values in \f$\left[0 : 1\right]\f$. Do not use for second-order differentiation.
-
-    \inherit Concept::WeightKernelConcept
-*/
-template <typename _Scalar>
-class CompactExpWeightKernel
-{
-public:
-    /*! \brief Scalar type defined outside the class*/
-    typedef _Scalar Scalar;
-
-    /// \brief The kernel is compact and shall not be evaluated outside of the scale bounds.
-    static constexpr bool isCompact = true;
-
-    // Functor
-    /*! \brief Defines the smooth weighting function \f$ w(x) = e^{-\frac{x^2}{1 - x^2}} \f$
-     *  \see https://www.wolframalpha.com/input?i=e%5E%28-x%5E2%2F%281+-+x%5E2%29%29&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar& _x) const {
-        PONCA_MULTIARCH_STD_MATH(exp);
-        Scalar v = _x*_x;
-        return exp(-v/(Scalar(1)-v));
-    }
-    /*! \brief Defines the smooth first order weighting function \f$ \nabla w(x) = -\frac{2 x e^{\frac{x^2}{x^2 - 1}}}{(1 - x^2)^2} \f$
-     * \see https://www.wolframalpha.com/input?i2d=true&i=+-Divide%5B%5C%2840%292+Power%5Be%2C%5C%2840%29Power%5Bx%2CDivide%5B2%2C%5C%2840%29Power%5Bx%2C2%5D+-+1%5C%2841%29%5D%5D%5C%2841%29%5D+x%5C%2841%29%2CPower%5B%5C%2840%291+-+Power%5Bx%2C2%5D%5C%2841%29%2C2%5D%5D
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar& _x) const {
-        PONCA_MULTIARCH_STD_MATH(exp);
-        Scalar v = _x*_x; Scalar mv = v-Scalar(1); return -(Scalar(2) * exp(v/mv) * _x)/(mv*mv);
-    }
-    /*! \brief Defines the smooth second order weighting function
-     * \f$ \nabla^2 w(x) = \frac{2 e^\frac{x^2}{x^2 - 1} \left(4 x^{\frac{2}{x^2 - 1} + 2} log(x) - (x^2 - 1) \left(-3 x^2 + 2 x^\frac{2}{x^2 - 1} - 1\right)\right)}{(x^2 - 1)^4} \f$
-     * \see \see https://www.wolframalpha.com/input?i2d=true&i=+-Divide%5B%5C%2840%292+Power%5Be%2C%5C%2840%29Power%5Bx%2CDivide%5B2%2C%5C%2840%29Power%5Bx%2C2%5D+-+1%5C%2841%29%5D%5D%5C%2841%29%5D+x%5C%2841%29%2CPower%5B%5C%2840%291+-+Power%5Bx%2C2%5D%5C%2841%29%2C2%5D%5D
-     */
-    PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const {
-        PONCA_MULTIARCH_STD_MATH(exp);
-        PONCA_MULTIARCH_STD_MATH(pow);
-        Scalar v = _x*_x;            // x^2
-        Scalar mv = v-Scalar(1);     // x^2-1
-        Scalar mvpow = Scalar(2)/mv; // 2/(x^2-1)
-        Scalar cmvpow = pow(_x,mvpow); // x^{2/(x^2-1)}
-        return Scalar(2) * exp(cmvpow) * ((Scalar(4) * pow(_x,mvpow + Scalar(2)) * log(_x) - mv * (-Scalar(3) * v + Scalar(2) * cmvpow - Scalar(1))))/(mv*mv*mv*mv);
-    }
-
-    //! \brief #df is defined and valid on the definition interval
-    static constexpr bool isDValid = true;
-    //! \brief #ddf is not defined and valid on the definition interval
-    static constexpr bool isDDValid = false;
-};//class CompactExpWeightKernel
-
-/*!
-    \brief Non-compact Gaussian WeightKernel
-
-    \note This is not a distribution, thus the kernel is not normalized in order to have \f$f(0)=1\f$.
-
-    \inherit Concept::WeightKernelConcept
-
-    \warning Also, as \f$\sigma=t\f$, a GaussianWeightKernel generates a larger weighting function than a
-    compact kernel, as \f$f(1)\approx 0.6\f$. In order to obtain a comparable weight, it is recommended to scale down
-    \f$t\f$ by a factor of \f$0.16\f$.
-
-
-*/
+    */
     template <typename _Scalar>
     class GaussianWeightKernel
     {
@@ -303,23 +313,24 @@ public:
          * As \f$x\f$ is normalized wrt scale such that \f$ x \in [0:1]\f$, \f$\sigma=0\f$ and the gaussian kernel boils
          * down to \f$e^{\frac{-x^2}{2}}\f$.
          */
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar f  (const Scalar& _x) const {
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar f(const Scalar& _x) const
+        {
             PONCA_MULTIARCH_STD_MATH(exp);
-            return exp((-_x*_x)/Scalar(2));
+            return exp((-_x * _x) / Scalar(2));
         }
 
         /// \brief Defines the Gaussian weighting function first order derivative \f$-e^{\frac{-x^2}{2\sigma^2}}x\f$.
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar df (const Scalar& _x) const {
-            return - f(_x)*_x;
-        }
-        /// \brief Defines the Gaussian weighting function second order derivative \f$e^{\frac{-x^2}{2\sigma^2}}(x^2-1)\f$.
-        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const {
-            return f(_x)*(_x*_x-Scalar(1));
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar df(const Scalar& _x) const { return -f(_x) * _x; }
+        /// \brief Defines the Gaussian weighting function second order derivative
+        /// \f$e^{\frac{-x^2}{2\sigma^2}}(x^2-1)\f$.
+        PONCA_MULTIARCH [[nodiscard]] inline Scalar ddf(const Scalar& _x) const
+        {
+            return f(_x) * (_x * _x - Scalar(1));
         }
         //! \brief #df is defined and valid on the definition interval
         static constexpr bool isDValid = true;
         //! \brief #ddf is defined and valid on the definition interval
         static constexpr bool isDDValid = true;
-    };//class GaussianWeightKernel
+    }; // class GaussianWeightKernel
 
-}// namespace Ponca
+} // namespace Ponca

--- a/Ponca/src/Fitting/weingarten.h
+++ b/Ponca/src/Fitting/weingarten.h
@@ -10,38 +10,40 @@ This Source Code Form is subject to the terms of the Mozilla Public
 
 namespace Ponca
 {
-/*!
-    \brief Compute a Weingarten map from fundamental forms.
+    /*!
+        \brief Compute a Weingarten map from fundamental forms.
 
-    The Weingarten map, also called Shape Operator, is defined in its matrix form as
-    \f[ \text{W} = \text{F}_\text{I}^{-1}\text{F}_\text{II}, \f]
-    with \f$\text{F}_\text{I}, \text{F}_\text{II}\f$ the first and second fundamental forms,
-    respectively.
+        The Weingarten map, also called Shape Operator, is defined in its matrix form as
+        \f[ \text{W} = \text{F}_\text{I}^{-1}\text{F}_\text{II}, \f]
+        with \f$\text{F}_\text{I}, \text{F}_\text{II}\f$ the first and second fundamental forms,
+        respectively.
 
-    \see WeingartenCurvatureEstimator and WeingartenCurvatureEstimatorDer to compute curvatures from the
-    weingarten map
+        \see WeingartenCurvatureEstimator and WeingartenCurvatureEstimatorDer to compute curvatures from the
+        weingarten map
 
-    This class also provides mean and Gaussian curvature directly from the fundamental forms.
+        This class also provides mean and Gaussian curvature directly from the fundamental forms.
 
-    This primitive provides:
-    \verbatim PROVIDES_WEINGARTEN_MAP \endverbatim
+        This primitive provides:
+        \verbatim PROVIDES_WEINGARTEN_MAP \endverbatim
 
-    This primitive requires:
-    \verbatim PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS, PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS \endverbatim
-    */
-    template < class DataPoint, class _NFilter, typename T >
+        This primitive requires:
+        \verbatim PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS, PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS \endverbatim
+        */
+    template <class DataPoint, class _NFilter, typename T>
     class FundamentalFormWeingartenEstimator : public T
     {
-    PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
         using Matrix2 = Eigen::Matrix<Scalar, 2, 2>;
-        static_assert ( DataPoint::Dim == 3, "FundamentalFormWeingartenEstimator is only valid in 3D");
+        static_assert(DataPoint::Dim == 3, "FundamentalFormWeingartenEstimator is only valid in 3D");
 
     protected:
-        enum {
-            Check = Base::PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS &&
-                    Base::PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS,
+        enum
+        {
+            Check =
+                Base::PROVIDES_FIRST_FUNDAMENTAL_FORM_COMPONENTS && Base::PROVIDES_SECOND_FUNDAMENTAL_FORM_COMPONENTS,
             PROVIDES_WEINGARTEN_MAP
         };
+
     public:
         PONCA_EXPLICIT_CAST_OPERATORS(FundamentalFormWeingartenEstimator, fundamentalFormWeingartenEstimator)
 
@@ -53,7 +55,7 @@ namespace Ponca
 
         /// \copybrief firstFundamentalForm()
         /// \tparam Matrix2Derived Input matrix type that must have same interface than Matrix2
-        template<typename Matrix2Derived>
+        template <typename Matrix2Derived>
         PONCA_MULTIARCH inline void firstFundamentalForm(Matrix2Derived& first) const;
 
         /// \brief Assembles and returns the second fundamental form from the base class
@@ -64,8 +66,8 @@ namespace Ponca
 
         /// \copybrief secondFundamentalForm()
         /// \tparam Matrix2Derived Input matrix type that must have same interface than Matrix2
-        template<typename Matrix2Derived>
-        PONCA_MULTIARCH inline void secondFundamentalForm(Matrix2Derived &second) const;
+        template <typename Matrix2Derived>
+        PONCA_MULTIARCH inline void secondFundamentalForm(Matrix2Derived& second) const;
 
         //! \brief Returns the Weingarten Map
         ///
@@ -75,8 +77,8 @@ namespace Ponca
 
         //! \copybrief weingartenMap()
         /// \tparam Matrix2Derived Input matrix type that must have same interface than Matrix2
-        template<typename Matrix2Derived>
-        PONCA_MULTIARCH inline void weingartenMap(Matrix2Derived &w) const;
+        template <typename Matrix2Derived>
+        PONCA_MULTIARCH inline void weingartenMap(Matrix2Derived& w) const;
 
         /// \brief Returns an estimate of the mean curvature directly from the fundamental forms
         PONCA_MULTIARCH inline Scalar kMean() const;
@@ -85,43 +87,43 @@ namespace Ponca
         PONCA_MULTIARCH inline Scalar GaussianCurvature() const;
     };
 
+    /*!
+        \brief Compute a Weingarten map from the spatial derivatives of the normal field \f$ N \f$.
 
-/*!
-    \brief Compute a Weingarten map from the spatial derivatives of the normal field \f$ N \f$.
+        \see WeingartenCurvatureEstimator and WeingartenCurvatureEstimatorDer to compute curvatures from the
+            weingarten map
 
-    \see WeingartenCurvatureEstimator and WeingartenCurvatureEstimatorDer to compute curvatures from the
-        weingarten map
+        A tangent plane aligned with the map is also computed during the process.
 
-    A tangent plane aligned with the map is also computed during the process.
+        \note Computations are marked as `UNSTABLE` if the computed basis does not properly align with the gradient of
+       the fitted primitive.
 
-    \note Computations are marked as `UNSTABLE` if the computed basis does not properly align with the gradient of the
-          fitted primitive.
+        This primitive provides:
+        \verbatim PROVIDES_WEINGARTEN_MAP, PROVIDES_TANGENT_PLANE_BASIS\endverbatim
 
-    This primitive provides:
-    \verbatim PROVIDES_WEINGARTEN_MAP, PROVIDES_TANGENT_PLANE_BASIS\endverbatim
-
-    This primitive requires:
-    \verbatim PROVIDES_NORMAL_DERIVATIVE \endverbatim
-    */
-    template < class DataPoint, class _NFilter, int DiffType, typename T >
+        This primitive requires:
+        \verbatim PROVIDES_NORMAL_DERIVATIVE \endverbatim
+        */
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     class NormalDerivativeWeingartenEstimator : public T
     {
         PONCA_FITTING_DECLARE_DEFAULT_TYPES
         PONCA_FITTING_DECLARE_MATRIX_TYPE
         PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
         using Matrix2 = Eigen::Matrix<Scalar, 2, 2>;
-        static_assert ( DataPoint::Dim == 3, "NormalDerivativeWeingartenEstimator is only valid in 3D");
-        static_assert ( Base::isSpaceDer(), "NormalDerivativeWeingartenEstimator requires spatial derivation");
+        static_assert(DataPoint::Dim == 3, "NormalDerivativeWeingartenEstimator is only valid in 3D");
+        static_assert(Base::isSpaceDer(), "NormalDerivativeWeingartenEstimator requires spatial derivation");
 
     protected:
-        enum {
+        enum
+        {
             Check = Base::PROVIDES_NORMAL_DERIVATIVE,
             PROVIDES_WEINGARTEN_MAP,
             PROVIDES_TANGENT_PLANE_BASIS
         };
 
     private:
-        MatrixType m_tangentBasis {MatrixType::Zero()};
+        MatrixType m_tangentBasis{MatrixType::Zero()};
 
     public:
         PONCA_EXPLICIT_CAST_OPERATORS_DER(NormalDerivativeWeingartenEstimator, normalDerivativeWeingartenEstimator)
@@ -135,74 +137,75 @@ namespace Ponca
 
         //! \copybrief weingartenMap()
         /// \tparam Matrix2Derived Input matrix type that must have same interface than Matrix2
-        template<typename Matrix2Derived>
-        PONCA_MULTIARCH inline void weingartenMap(Matrix2Derived &w) const;
-
+        template <typename Matrix2Derived>
+        PONCA_MULTIARCH inline void weingartenMap(Matrix2Derived& w) const;
 
         /// \copydoc CovariancePlaneFitImpl::worldToTangentPlane
-        PONCA_MULTIARCH inline VectorType worldToTangentPlane(const VectorType &_q,
+        PONCA_MULTIARCH inline VectorType worldToTangentPlane(const VectorType& _q,
                                                               bool _isPositionVector = true) const;
 
         /// \copydoc CovariancePlaneFitImpl::tangentPlaneToWorld
-        PONCA_MULTIARCH inline VectorType tangentPlaneToWorld(const VectorType &_q,
+        PONCA_MULTIARCH inline VectorType tangentPlaneToWorld(const VectorType& _q,
                                                               bool _isPositionVector = true) const;
     };
 
-
-namespace internal
-{
-    /*!
-        \brief Compute principal curvatures from a base class providing fundamental forms
-
-        Since the weingarten map is self-adjoint, a basis exists consisting of the eigenvectors of W.
-        The eigenvectors, combined with their eigenvalues, define the principal curvature directions and
-        values.
-        The Gaussian and mean curvatures can be retrieved as \f$\text{K} = \text{det}(\text{W})\f$
-        and \f$\text{H} = \frac{1}{2}\text{trace}(\text{W})\f$, respectively.
-
-
-        \warning To map from the tangent plane to ambiant space, we assume that the patch is represented as
-        (h(u,v), u, v) because CovariancePlaneFitImpl::worldToTangentPlane() wraps up coordinates in this order (height, u and v).
-
-        This primitive requires:
-        \verbatim PROVIDES_TANGENT_PLANE_BASIS, PROVIDES_WEINGARTEN_MAP, PROVIDES_PRINCIPAL_CURVATURES \endverbatim
-        */
-    template < class DataPoint, class _NFilter, typename T >
-    class WeingartenCurvatureEstimatorBase : public T
+    namespace internal
     {
-        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+        /*!
+            \brief Compute principal curvatures from a base class providing fundamental forms
+
+            Since the weingarten map is self-adjoint, a basis exists consisting of the eigenvectors of W.
+            The eigenvectors, combined with their eigenvalues, define the principal curvature directions and
+            values.
+            The Gaussian and mean curvatures can be retrieved as \f$\text{K} = \text{det}(\text{W})\f$
+            and \f$\text{H} = \frac{1}{2}\text{trace}(\text{W})\f$, respectively.
+
+
+            \warning To map from the tangent plane to ambiant space, we assume that the patch is represented as
+            (h(u,v), u, v) because CovariancePlaneFitImpl::worldToTangentPlane() wraps up coordinates in this order
+           (height, u and v).
+
+            This primitive requires:
+            \verbatim PROVIDES_TANGENT_PLANE_BASIS, PROVIDES_WEINGARTEN_MAP, PROVIDES_PRINCIPAL_CURVATURES \endverbatim
+            */
+        template <class DataPoint, class _NFilter, typename T>
+        class WeingartenCurvatureEstimatorBase : public T
+        {
+            PONCA_FITTING_DECLARE_DEFAULT_TYPES
             using Matrix2 = Eigen::Matrix<Scalar, 2, 2>;
-        static_assert ( DataPoint::Dim == 3, "WeingartenCurvatureEstimator is only valid in 3D");
+            static_assert(DataPoint::Dim == 3, "WeingartenCurvatureEstimator is only valid in 3D");
 
-    protected:
-        enum {
-            Check = Base::PROVIDES_TANGENT_PLANE_BASIS &&  // required for tangentPlaneToWorld
-                    Base::PROVIDES_PRINCIPAL_CURVATURES && // required curvature storage
-                    Base::PROVIDES_WEINGARTEN_MAP
+        protected:
+            enum
+            {
+                Check = Base::PROVIDES_TANGENT_PLANE_BASIS &&  // required for tangentPlaneToWorld
+                        Base::PROVIDES_PRINCIPAL_CURVATURES && // required curvature storage
+                        Base::PROVIDES_WEINGARTEN_MAP
+            };
+
+        public:
+            PONCA_FITTING_DECLARE_FINALIZE
         };
-
-    public:
-        PONCA_FITTING_DECLARE_FINALIZE
-    };
-}
+    } // namespace internal
 
     /// \copydoc internal::WeingartenCurvatureEstimatorBase
-    template < class DataPoint, class _NFilter, typename T >
-    struct WeingartenCurvatureEstimator : public internal::WeingartenCurvatureEstimatorBase<DataPoint, _NFilter, T>{
+    template <class DataPoint, class _NFilter, typename T>
+    struct WeingartenCurvatureEstimator : public internal::WeingartenCurvatureEstimatorBase<DataPoint, _NFilter, T>
+    {
         PONCA_FITTING_DECLARE_DEFAULT_TYPES
         PONCA_EXPLICIT_CAST_OPERATORS(WeingartenCurvatureEstimator, weingartenCurvatureEstimator)
     };
 
     /// \copydoc internal::WeingartenCurvatureEstimatorBase
-    template < class DataPoint, class _NFilter, int DiffType, typename T >
-    struct WeingartenCurvatureEstimatorDer : public internal::WeingartenCurvatureEstimatorBase<DataPoint, _NFilter, T>{
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    struct WeingartenCurvatureEstimatorDer : public internal::WeingartenCurvatureEstimatorBase<DataPoint, _NFilter, T>
+    {
         PONCA_FITTING_DECLARE_DEFAULT_TYPES
         PONCA_FITTING_DECLARE_DEFAULT_DER_TYPES
         PONCA_EXPLICIT_CAST_OPERATORS_DER(WeingartenCurvatureEstimatorDer, weingartenCurvatureEstimator)
-
     };
 
-} //namespace Ponca
+} // namespace Ponca
 
 #include "weingarten.hpp"
 

--- a/Ponca/src/Fitting/weingarten.hpp
+++ b/Ponca/src/Fitting/weingarten.hpp
@@ -4,81 +4,89 @@
 namespace Ponca
 {
     ///////// FundamentalFormWeingartenEstimator
-    template<class DataPoint, class _NFilter, typename T>
-    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Matrix2
-    FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::firstFundamentalForm() const {
+    template <class DataPoint, class _NFilter, typename T>
+    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Matrix2 FundamentalFormWeingartenEstimator<
+        DataPoint, _NFilter, T>::firstFundamentalForm() const
+    {
         Matrix2 first;
         firstFundamentalForm(first);
         return first;
     }
 
-    template<class DataPoint, class _NFilter, typename T>
-    template<typename Matrix2Derived>
-    void FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::firstFundamentalForm(Matrix2Derived& first) const {
-        Base::firstFundamentalFormComponents(first(0,0), first(1,0), first(1,1));
-        first(0,1) = first(1,0); // diagonal
+    template <class DataPoint, class _NFilter, typename T>
+    template <typename Matrix2Derived>
+    void FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::firstFundamentalForm(Matrix2Derived& first) const
+    {
+        Base::firstFundamentalFormComponents(first(0, 0), first(1, 0), first(1, 1));
+        first(0, 1) = first(1, 0); // diagonal
     }
 
-    template<class DataPoint, class _NFilter, typename T>
-    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Matrix2
-    FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::secondFundamentalForm() const {
+    template <class DataPoint, class _NFilter, typename T>
+    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Matrix2 FundamentalFormWeingartenEstimator<
+        DataPoint, _NFilter, T>::secondFundamentalForm() const
+    {
         Matrix2 second;
         secondFundamentalForm(second);
         return second;
     }
 
-    template<class DataPoint, class _NFilter, typename T>
-    template<typename Matrix2Derived>
-    void FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::secondFundamentalForm(Matrix2Derived &second) const {
-        Base::secondFundamentalFormComponents(second(0,0), second(1,0), second(1,1));
-        second(0,1) = second(1,0); // diagonal
+    template <class DataPoint, class _NFilter, typename T>
+    template <typename Matrix2Derived>
+    void FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::secondFundamentalForm(Matrix2Derived& second) const
+    {
+        Base::secondFundamentalFormComponents(second(0, 0), second(1, 0), second(1, 1));
+        second(0, 1) = second(1, 0); // diagonal
     }
 
-
-    template<class DataPoint, class _NFilter, typename T>
-    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Matrix2
-    FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::weingartenMap() const {
+    template <class DataPoint, class _NFilter, typename T>
+    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Matrix2 FundamentalFormWeingartenEstimator<
+        DataPoint, _NFilter, T>::weingartenMap() const
+    {
         Matrix2 w;
         weingartenMap(w);
         return w;
     }
 
-    template<class DataPoint, class _NFilter, typename T>
-    template<typename Matrix2Derived>
-    void FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::weingartenMap(Matrix2Derived &w) const {
-        w = firstFundamentalForm().inverse() *  secondFundamentalForm();
+    template <class DataPoint, class _NFilter, typename T>
+    template <typename Matrix2Derived>
+    void FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::weingartenMap(Matrix2Derived& w) const
+    {
+        w = firstFundamentalForm().inverse() * secondFundamentalForm();
     }
 
-    template<class DataPoint, class _NFilter, typename T>
-    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Scalar
-    FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::kMean() const {
+    template <class DataPoint, class _NFilter, typename T>
+    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Scalar FundamentalFormWeingartenEstimator<
+        DataPoint, _NFilter, T>::kMean() const
+    {
         Scalar E, F, G, L, M, N;
         Base::firstFundamentalFormComponents(E, F, G);
         Base::secondFundamentalFormComponents(L, M, N);
-        return (G*L-Scalar(2)*F*M+E*N)/(Scalar(2)*(E*G-F*F));
+        return (G * L - Scalar(2) * F * M + E * N) / (Scalar(2) * (E * G - F * F));
     }
 
-    template<class DataPoint, class _NFilter, typename T>
-    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Scalar
-    FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::GaussianCurvature() const {
+    template <class DataPoint, class _NFilter, typename T>
+    typename FundamentalFormWeingartenEstimator<DataPoint, _NFilter, T>::Scalar FundamentalFormWeingartenEstimator<
+        DataPoint, _NFilter, T>::GaussianCurvature() const
+    {
         Scalar E, F, G, L, M, N;
         Base::firstFundamentalFormComponents(E, F, G);
         Base::secondFundamentalFormComponents(L, M, N);
-        return (L*N-M*M)/(E*G-F*F);
+        return (L * N - M * M) / (E * G - F * F);
     }
 
     ///////// NormalDerivativeWeingartenEstimator
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     typename NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::Matrix2
-    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::weingartenMap() const {
+    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::weingartenMap() const
+    {
         Matrix2 w;
         weingartenMap(w);
         return w;
     }
 
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
-    FIT_RESULT
-    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::finalize() {
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    FIT_RESULT NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::finalize()
+    {
 
         PONCA_MULTIARCH_STD_MATH(abs);
         PONCA_MULTIARCH_STD_MATH(sqrt);
@@ -89,14 +97,14 @@ namespace Ponca
         // Test if base finalize end on a viable case (stable / unstable)
         if (this->isReady())
         {
-            Index i0=Index(-1), i1=Index(-1), i2=Index(-1);
+            Index i0 = Index(-1), i1 = Index(-1), i2 = Index(-1);
 
             MatrixType dN = Base::dNormal().template middleCols<DataPoint::Dim>(Base::isScaleDer() ? 1 : 0);
 
             VectorType n = Base::primitiveGradient();
             n.array().abs().minCoeff(&i0); // i0: dimension where n extends the least
-            i1 = (i0+1)%3;
-            i2 = (i0+2)%3;
+            i1 = (i0 + 1) % 3;
+            i2 = (i0 + 2) % 3;
 
             m_tangentBasis.col(0) = n;
 
@@ -110,17 +118,18 @@ namespace Ponca
         return Base::m_eCurrentState;
     }
 
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
-    template<typename Matrix2Derived>
-    void NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::weingartenMap(Matrix2Derived &W) const {
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
+    template <typename Matrix2Derived>
+    void NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::weingartenMap(Matrix2Derived& W) const
+    {
         PONCA_MULTIARCH_STD_MATH(abs);
         PONCA_MULTIARCH_STD_MATH(sqrt);
 
-        using Index = typename VectorType::Index;
-        using Matrix32 = Eigen::Matrix<Scalar,3,2>;
+        using Index    = typename VectorType::Index;
+        using Matrix32 = Eigen::Matrix<Scalar, 3, 2>;
 
         // Get the object space Weingarten map dN
-        MatrixType dN = Base::dNormal().template middleCols<DataPoint::Dim>(Base::isScaleDer() ? 1: 0);
+        MatrixType dN = Base::dNormal().template middleCols<DataPoint::Dim>(Base::isScaleDer() ? 1 : 0);
 
         // Compute tangent-space change of basis function
         auto B = m_tangentBasis.template rightCols<2>();
@@ -129,44 +138,49 @@ namespace Ponca
         // Recall that dN is a bilinear form, it thus transforms as follows:
         W = B.transpose() * dN * B;
 
-        // Recall that at this stage, the shape operator represented by W describes the normal curvature K_n(u) in the direction u \in R^2 as follows:
+        // Recall that at this stage, the shape operator represented by W describes the normal curvature K_n(u) in the
+        // direction u \in R^2 as follows:
         //   K_n(u) = u^T W u
         // The principal curvatures are fully defined by the values and the directions of the extrema of K_n.
         //
-        // If the normal field N(x) comes from the gradient of a scalar field, then N(x) is curl-free, and dN and W are symmetric matrices.
-        // In this case, the extrema of the previous quadratic form are directly obtained by the eigenvalue decomposition of W.
-        // However, if N(x) is only an approximation of the normal field of a surface, then N(x) is not necessarily curl-free, and in this case W is not symmetric.
-        // In this case, we first have to find an equivalent symmetric matrix W' such that:
+        // If the normal field N(x) comes from the gradient of a scalar field, then N(x) is curl-free, and dN and W are
+        // symmetric matrices. In this case, the extrema of the previous quadratic form are directly obtained by the
+        // eigenvalue decomposition of W. However, if N(x) is only an approximation of the normal field of a surface,
+        // then N(x) is not necessarily curl-free, and in this case W is not symmetric. In this case, we first have to
+        // find an equivalent symmetric matrix W' such that:
         //   K_n(u) = u^T W' u,
         // for any u \in R^2.
         // It is easy to see that such a W' is simply obtained as:
         //   W' = (W + W^T)/2
-        W(0,1) = W(1,0) = (W(0,1) + W(1,0))/Scalar(2);
+        W(0, 1) = W(1, 0) = (W(0, 1) + W(1, 0)) / Scalar(2);
     }
 
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     typename NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::VectorType
-    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::worldToTangentPlane(const VectorType &_q,
-                                                                                               bool _isPositionVector) const{
+    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::worldToTangentPlane(
+        const VectorType& _q, bool _isPositionVector) const
+    {
         return m_tangentBasis.normalized().transpose() *
                Base::getNeighborFilter().convertToLocalBasis(_q, _isPositionVector);
     }
 
-    template<class DataPoint, class _NFilter, int DiffType, typename T>
+    template <class DataPoint, class _NFilter, int DiffType, typename T>
     typename NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::VectorType
-    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::tangentPlaneToWorld(const VectorType &_lq,
-                                                                                               bool _isPositionVector) const{
+    NormalDerivativeWeingartenEstimator<DataPoint, _NFilter, DiffType, T>::tangentPlaneToWorld(
+        const VectorType& _lq, bool _isPositionVector) const
+    {
         return Base::getNeighborFilter().convertToGlobalBasis(m_tangentBasis.normalized().transpose().inverse() * _lq,
                                                               _isPositionVector);
     }
 
-    namespace internal {
+    namespace internal
+    {
         ///////// WeingartenCurvatureEstimator
-        template<class DataPoint, class _NFilter, typename T>
-        FIT_RESULT
-        WeingartenCurvatureEstimatorBase<DataPoint, _NFilter, T>::finalize() {
+        template <class DataPoint, class _NFilter, typename T>
+        FIT_RESULT WeingartenCurvatureEstimatorBase<DataPoint, _NFilter, T>::finalize()
+        {
 
-            if(Base::finalize() != STABLE)
+            if (Base::finalize() != STABLE)
                 return Base::m_eCurrentState;
 
             Matrix2 w;
@@ -180,8 +194,8 @@ namespace Ponca
             Scalar kmax = solver.eigenvalues().y();
             VectorType vmin, vmax; // maxi directions
 
-            vmin(0) = Scalar(0); // set height
-            vmax(0) = Scalar(0); // set height
+            vmin(0)                       = Scalar(0); // set height
+            vmax(0)                       = Scalar(0); // set height
             vmin.template bottomRows<2>() = solver.eigenvectors().col(0);
             vmax.template bottomRows<2>() = solver.eigenvectors().col(1);
 
@@ -192,6 +206,6 @@ namespace Ponca
 
             return Base::m_eCurrentState;
         }
-    }
-}
+    } // namespace internal
+} // namespace Ponca
 

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeKNearestIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeKNearestIterator.h
@@ -8,66 +8,72 @@
 
 #include <cstddef>
 
-namespace Ponca {
-
-/*!
- *  \brief Input iterator to read the `KdTreeKNearestQueryBase` object.
- *
- *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
- *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator functionalities,
- *  you should copy the index values in an STL-like container.
- *
- *  \note This iterator object can be duplicated with no issues.
- *
- *  \see KdTreeKNearestQueryBase
- */
-template <typename Index, typename DataPoint>
-class KdTreeKNearestIterator
+namespace Ponca
 {
-public:
-    using iterator_category = std::input_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
-    using value_type = Index;
-    using pointer    = Index*;
-    using reference  = const Index&;
 
-    using Scalar   = typename DataPoint::Scalar;
-    using Iterator = typename limited_priority_queue<IndexSquaredDistance<Index, Scalar>>::iterator;
+    /*!
+     *  \brief Input iterator to read the `KdTreeKNearestQueryBase` object.
+     *
+     *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
+     *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator
+     * functionalities, you should copy the index values in an STL-like container.
+     *
+     *  \note This iterator object can be duplicated with no issues.
+     *
+     *  \see KdTreeKNearestQueryBase
+     */
+    template <typename Index, typename DataPoint>
+    class KdTreeKNearestIterator
+    {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Index;
+        using pointer           = Index*;
+        using reference         = const Index&;
 
-    PONCA_MULTIARCH inline KdTreeKNearestIterator() = default;
-    PONCA_MULTIARCH inline KdTreeKNearestIterator(const Iterator& iterator) : m_iterator(iterator) {}
-    PONCA_MULTIARCH virtual inline ~KdTreeKNearestIterator() = default;
+        using Scalar   = typename DataPoint::Scalar;
+        using Iterator = typename limited_priority_queue<IndexSquaredDistance<Index, Scalar>>::iterator;
 
-public:
-    /// \brief Inequality operand
-    PONCA_MULTIARCH inline bool operator !=(const KdTreeKNearestIterator& other) const {
-        return m_iterator != other.m_iterator;
-    }
+        PONCA_MULTIARCH inline KdTreeKNearestIterator() = default;
+        PONCA_MULTIARCH inline KdTreeKNearestIterator(const Iterator& iterator) : m_iterator(iterator) {}
+        PONCA_MULTIARCH virtual inline ~KdTreeKNearestIterator() = default;
 
-    /// \brief Equality operand
-    PONCA_MULTIARCH inline bool operator ==(const KdTreeKNearestIterator& other) const {
-        return m_iterator == other.m_iterator;
-    }
+    public:
+        /// \brief Inequality operand
+        PONCA_MULTIARCH inline bool operator!=(const KdTreeKNearestIterator& other) const
+        {
+            return m_iterator != other.m_iterator;
+        }
 
-    /// Prefix increment
-    PONCA_MULTIARCH inline KdTreeKNearestIterator& operator ++() {++m_iterator; return *this;}
+        /// \brief Equality operand
+        PONCA_MULTIARCH inline bool operator==(const KdTreeKNearestIterator& other) const
+        {
+            return m_iterator == other.m_iterator;
+        }
 
-    /// \brief Postfix increment
-    PONCA_MULTIARCH inline KdTreeKNearestIterator operator++(int) {
-        KdTreeKNearestIterator tmp = *this;
-        ++m_iterator;
-        return tmp;
-    }
+        /// Prefix increment
+        PONCA_MULTIARCH inline KdTreeKNearestIterator& operator++()
+        {
+            ++m_iterator;
+            return *this;
+        }
 
-    /// \brief Value increment
-    PONCA_MULTIARCH inline void operator +=(int i) {m_iterator += i;}
+        /// \brief Postfix increment
+        PONCA_MULTIARCH inline KdTreeKNearestIterator operator++(int)
+        {
+            KdTreeKNearestIterator tmp = *this;
+            ++m_iterator;
+            return tmp;
+        }
 
-    /// \brief Dereference operator
-    PONCA_MULTIARCH inline reference operator *() const {
-        return const_cast<reference>(m_iterator->index);
-    }
+        /// \brief Value increment
+        PONCA_MULTIARCH inline void operator+=(int i) { m_iterator += i; }
 
-protected:
-    Iterator m_iterator;
-};
-} // namespace ponca
+        /// \brief Dereference operator
+        PONCA_MULTIARCH inline reference operator*() const { return const_cast<reference>(m_iterator->index); }
+
+    protected:
+        Iterator m_iterator;
+    };
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeNearestIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeNearestIterator.h
@@ -8,67 +8,70 @@
 
 #include <cstddef>
 
-namespace Ponca {
-
-/*!
- *  \brief Input iterator to read the `KdTreeKNearestQueryBase` object.
- *
- *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
- *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator functionalities,
- *  you should copy the index values in an STL-like container.
- *
- *  \note This iterator object can be duplicated with no issues.
- *
- *  \see KdTreeNearestQueryBase
- */
-template<typename Index>
-class KdTreeNearestIterator
+namespace Ponca
 {
-public:
-    using iterator_category = std::input_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
-    using value_type = Index;
-    using pointer    = Index*;
-    using reference  = const Index&;
 
-    PONCA_MULTIARCH inline KdTreeNearestIterator() = default;
-    PONCA_MULTIARCH inline KdTreeNearestIterator(Index index) : m_index(index) {}
-    PONCA_MULTIARCH virtual inline ~KdTreeNearestIterator() = default;
+    /*!
+     *  \brief Input iterator to read the `KdTreeKNearestQueryBase` object.
+     *
+     *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
+     *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator
+     * functionalities, you should copy the index values in an STL-like container.
+     *
+     *  \note This iterator object can be duplicated with no issues.
+     *
+     *  \see KdTreeNearestQueryBase
+     */
+    template <typename Index>
+    class KdTreeNearestIterator
+    {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Index;
+        using pointer           = Index*;
+        using reference         = const Index&;
 
-public:
-    /// \brief Inequality operand
-    PONCA_MULTIARCH inline bool operator !=(const KdTreeNearestIterator& other) const {
-        return m_index != other.m_index;
-    }
+        PONCA_MULTIARCH inline KdTreeNearestIterator() = default;
+        PONCA_MULTIARCH inline KdTreeNearestIterator(Index index) : m_index(index) {}
+        PONCA_MULTIARCH virtual inline ~KdTreeNearestIterator() = default;
 
-    /// \brief Equality operand
-    PONCA_MULTIARCH inline bool operator ==(const KdTreeNearestIterator& other) const {
-        return m_index == other.m_index;
-    }
+    public:
+        /// \brief Inequality operand
+        PONCA_MULTIARCH inline bool operator!=(const KdTreeNearestIterator& other) const
+        {
+            return m_index != other.m_index;
+        }
 
-    /// Prefix increment
-    PONCA_MULTIARCH inline KdTreeNearestIterator& operator ++() {
-        ++m_index;
-        return *this;
-    }
+        /// \brief Equality operand
+        PONCA_MULTIARCH inline bool operator==(const KdTreeNearestIterator& other) const
+        {
+            return m_index == other.m_index;
+        }
 
-    /// \brief Postfix increment
-    PONCA_MULTIARCH inline KdTreeNearestIterator operator++(int) {
-        KdTreeNearestIterator tmp = *this;
-        ++m_index;
-        return tmp;
-    }
+        /// Prefix increment
+        PONCA_MULTIARCH inline KdTreeNearestIterator& operator++()
+        {
+            ++m_index;
+            return *this;
+        }
 
-    /// \brief Value increment
-    PONCA_MULTIARCH inline void operator +=(int i) {m_index += i;}
+        /// \brief Postfix increment
+        PONCA_MULTIARCH inline KdTreeNearestIterator operator++(int)
+        {
+            KdTreeNearestIterator tmp = *this;
+            ++m_index;
+            return tmp;
+        }
 
-    /// \brief Dereference operator
-    PONCA_MULTIARCH inline reference operator *() const {
-        return const_cast<reference>(m_index);
-    }
+        /// \brief Value increment
+        PONCA_MULTIARCH inline void operator+=(int i) { m_index += i; }
 
-protected:
-    Index m_index {-1};
-};
+        /// \brief Dereference operator
+        PONCA_MULTIARCH inline reference operator*() const { return const_cast<reference>(m_index); }
 
-} // namespace ponca
+    protected:
+        Index m_index{-1};
+    };
+
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeRangeIterator.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Iterator/kdTreeRangeIterator.h
@@ -8,77 +8,82 @@
 
 #include <cstddef>
 
-namespace Ponca {
-
-/*!
- *  \brief Input iterator to read the `KdTreeRangeQueryBase` object.
- *
- *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
- *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator functionalities,
- *  you should copy the index values in an STL-like container.
- *
- *  \note The increment logic resides in `KdTreeRangeQueryBase::advance(Iterator& it)`
- *  Since the `KdTreeRangeQueryBase::advance` method doesn't update the internal state of the
- *  `KdTreeRangeQuery` object, this iterator object can be duplicated without causing issues.
- *  If a copy of this iterator is made  (e.g., passed by copy to a function),
- *  incrementing one iterator won't update the state of the other.
- *
- *  \see KdTreeRangeQueryBase
- */
-template<typename Index, typename DataPoint, typename QueryT_>
-class KdTreeRangeIterator
+namespace Ponca
 {
-protected:
-    friend QueryT_;
 
-public:
-    using iterator_category = std::input_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
-    using value_type = Index;
-    using pointer    = Index*;
-    using reference  = const Index&;
+    /*!
+     *  \brief Input iterator to read the `KdTreeRangeQueryBase` object.
+     *
+     *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
+     *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator
+     * functionalities, you should copy the index values in an STL-like container.
+     *
+     *  \note The increment logic resides in `KdTreeRangeQueryBase::advance(Iterator& it)`
+     *  Since the `KdTreeRangeQueryBase::advance` method doesn't update the internal state of the
+     *  `KdTreeRangeQuery` object, this iterator object can be duplicated without causing issues.
+     *  If a copy of this iterator is made  (e.g., passed by copy to a function),
+     *  incrementing one iterator won't update the state of the other.
+     *
+     *  \see KdTreeRangeQueryBase
+     */
+    template <typename Index, typename DataPoint, typename QueryT_>
+    class KdTreeRangeIterator
+    {
+    protected:
+        friend QueryT_;
 
-    using Scalar     = typename DataPoint::Scalar;
-    using QueryType  = QueryT_;
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Index;
+        using pointer           = Index*;
+        using reference         = const Index&;
 
-    PONCA_MULTIARCH inline KdTreeRangeIterator() = default;
-    PONCA_MULTIARCH inline KdTreeRangeIterator(QueryType* query, Index index = -1) :
-        m_query(query), m_index(index), m_start(0), m_end(0) {}
+        using Scalar    = typename DataPoint::Scalar;
+        using QueryType = QueryT_;
 
-    /// \brief Inequality operand
-    PONCA_MULTIARCH inline bool operator !=(const KdTreeRangeIterator& other) const {
-        return m_index != other.m_index;
-    }
+        PONCA_MULTIARCH inline KdTreeRangeIterator() = default;
+        PONCA_MULTIARCH inline KdTreeRangeIterator(QueryType* query, Index index = -1)
+            : m_query(query), m_index(index), m_start(0), m_end(0)
+        {
+        }
 
-    /// \brief Equality operand
-    PONCA_MULTIARCH inline bool operator ==(const KdTreeRangeIterator& other) const {
-        return m_index == other.m_index;
-    }
+        /// \brief Inequality operand
+        PONCA_MULTIARCH inline bool operator!=(const KdTreeRangeIterator& other) const
+        {
+            return m_index != other.m_index;
+        }
 
-    /// \brief Prefix increment
-    /// \see KdTreeRangeQueryBase::advance(Iterator& it) for the iteration logic
-    PONCA_MULTIARCH inline KdTreeRangeIterator& operator++() {
-        m_query->advance(*this);
-        return *this;
-    }
+        /// \brief Equality operand
+        PONCA_MULTIARCH inline bool operator==(const KdTreeRangeIterator& other) const
+        {
+            return m_index == other.m_index;
+        }
 
-    /// \brief Postfix increment
-    /// \see KdTreeRangeQueryBase::advance(Iterator& it) for the iteration logic
-    PONCA_MULTIARCH inline KdTreeRangeIterator operator++(int) {
-        KdTreeRangeIterator tmp = *this;
-        m_query->advance(*this);
-        return tmp;
-    }
+        /// \brief Prefix increment
+        /// \see KdTreeRangeQueryBase::advance(Iterator& it) for the iteration logic
+        PONCA_MULTIARCH inline KdTreeRangeIterator& operator++()
+        {
+            m_query->advance(*this);
+            return *this;
+        }
 
-    /// \brief Dereference operator
-    PONCA_MULTIARCH inline reference operator *() const {
-       return const_cast<reference>(m_index);
-    }
+        /// \brief Postfix increment
+        /// \see KdTreeRangeQueryBase::advance(Iterator& it) for the iteration logic
+        PONCA_MULTIARCH inline KdTreeRangeIterator operator++(int)
+        {
+            KdTreeRangeIterator tmp = *this;
+            m_query->advance(*this);
+            return tmp;
+        }
 
-protected:
-    QueryType* m_query {nullptr};
-    Index m_index {-1};
-    Index m_start {0};
-    Index m_end {0};
-};
-} // namespace ponca
+        /// \brief Dereference operator
+        PONCA_MULTIARCH inline reference operator*() const { return const_cast<reference>(m_index); }
+
+    protected:
+        QueryType* m_query{nullptr};
+        Index m_index{-1};
+        Index m_start{0};
+        Index m_end{0};
+    };
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestQueries.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeKNearestQueries.h
@@ -10,82 +10,88 @@
 #include "../../query.h"
 #include "../Iterator/kdTreeKNearestIterator.h"
 
-namespace Ponca {
-
-/*!
- * \brief Extension of the Query class that allows to read the result of a k-nearest neighbors search on the KdTree.
- *
- *  Output result of a `KdTreeBase::kNearestNeighbors` query request.
- *
- *  \see KdTreeBase
- */
-template <typename Traits,
-          template <typename, typename> typename IteratorType,
-          typename QueryType>
-class KdTreeKNearestQueryBase : public KdTreeQuery<Traits>, public QueryType
+namespace Ponca
 {
-public:
-    using DataPoint      = typename Traits::DataPoint;
-    using IndexType      = typename Traits::IndexType;
-    using Scalar         = typename DataPoint::Scalar;
-    using VectorType     = typename DataPoint::VectorType;
-    using QueryAccelType = KdTreeQuery<Traits>;
-    using Iterator       = IteratorType<typename Traits::IndexType, typename Traits::DataPoint>;
-    using Self           = KdTreeKNearestQueryBase<Traits, IteratorType, QueryType>;
 
-    PONCA_MULTIARCH inline KdTreeKNearestQueryBase(const StaticKdTreeBase<Traits>* kdtree, IndexType k, typename QueryType::InputType input) :
-            KdTreeQuery<Traits>(kdtree), QueryType(k, input) { }
-
-    /// \brief Call the k-nearest neighbors query with new input and neighbor number parameters.
-    PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input, IndexType k)
+    /*!
+     * \brief Extension of the Query class that allows to read the result of a k-nearest neighbors search on the KdTree.
+     *
+     *  Output result of a `KdTreeBase::kNearestNeighbors` query request.
+     *
+     *  \see KdTreeBase
+     */
+    template <typename Traits, template <typename, typename> typename IteratorType, typename QueryType>
+    class KdTreeKNearestQueryBase : public KdTreeQuery<Traits>, public QueryType
     {
-        return QueryType::template operator()<Self>(input, k);
-    }
-    /// \brief Call the k-nearest neighbors query with new input parameter.
-    PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input)
-    {
-        return QueryType::template operator()<Self>(input);
-    }
+    public:
+        using DataPoint      = typename Traits::DataPoint;
+        using IndexType      = typename Traits::IndexType;
+        using Scalar         = typename DataPoint::Scalar;
+        using VectorType     = typename DataPoint::VectorType;
+        using QueryAccelType = KdTreeQuery<Traits>;
+        using Iterator       = IteratorType<typename Traits::IndexType, typename Traits::DataPoint>;
+        using Self           = KdTreeKNearestQueryBase<Traits, IteratorType, QueryType>;
 
-    /// \brief Returns an iterator to the beginning of the k-nearest neighbors query.
-    PONCA_MULTIARCH inline Iterator begin(){
-        QueryAccelType::reset();
-        QueryType::reset();
-        this->search();
-        return Iterator(QueryType::m_queue.begin());
-    }
+        PONCA_MULTIARCH inline KdTreeKNearestQueryBase(const StaticKdTreeBase<Traits>* kdtree, IndexType k,
+                                                       typename QueryType::InputType input)
+            : KdTreeQuery<Traits>(kdtree), QueryType(k, input)
+        {
+        }
 
-    /// \brief Returns an iterator to the end of the k-nearest neighbors query.
-    PONCA_MULTIARCH inline Iterator end(){
-        return Iterator(QueryType::m_queue.end());
-    }
+        /// \brief Call the k-nearest neighbors query with new input and neighbor number parameters.
+        PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input, IndexType k)
+        {
+            return QueryType::template operator()<Self>(input, k);
+        }
+        /// \brief Call the k-nearest neighbors query with new input parameter.
+        PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input)
+        {
+            return QueryType::template operator()<Self>(input);
+        }
 
-protected:
-    PONCA_MULTIARCH inline void search(){
-        KdTreeQuery<Traits>::searchInternal(QueryType::template getInputPosition<VectorType>(QueryAccelType::m_kdtree->points()),
-                                             [](IndexType, IndexType){},
-                                             [this](){return QueryType::descentDistanceThreshold();},
-                                             [this](IndexType idx){return QueryType::skipIndexFunctor(idx);},
-                                             [this](IndexType idx, IndexType, Scalar d){QueryType::m_queue.push({idx, d}); return false;}
-        );
-    }
-};
-/*!
- * \copybrief KdTreeKNearestQueryBase
- *
- * Output result of a `KdTreeBase::kNearestNeighbors` query made with the **index** of the point to evaluate.
- * \see KNearestIndexQuery
- */
-template <typename Traits>
-using KdTreeKNearestIndexQuery = KdTreeKNearestQueryBase< Traits, KdTreeKNearestIterator,
-                                 KNearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>>;
-/*!
- * \copybrief KdTreeKNearestQueryBase
- *
- * Output result of a `KdTreeBase::kNearestNeighbors` query made with the **position** of the point to evaluate.
- * \see KNearestPointQuery
- */
-template <typename Traits>
-using KdTreeKNearestPointQuery = KdTreeKNearestQueryBase< Traits, KdTreeKNearestIterator,
-                                 KNearestPointQuery<typename Traits::IndexType, typename Traits::DataPoint>>;
-} // namespace ponca
+        /// \brief Returns an iterator to the beginning of the k-nearest neighbors query.
+        PONCA_MULTIARCH inline Iterator begin()
+        {
+            QueryAccelType::reset();
+            QueryType::reset();
+            this->search();
+            return Iterator(QueryType::m_queue.begin());
+        }
+
+        /// \brief Returns an iterator to the end of the k-nearest neighbors query.
+        PONCA_MULTIARCH inline Iterator end() { return Iterator(QueryType::m_queue.end()); }
+
+    protected:
+        PONCA_MULTIARCH inline void search()
+        {
+            KdTreeQuery<Traits>::searchInternal(
+                QueryType::template getInputPosition<VectorType>(QueryAccelType::m_kdtree->points()),
+                [](IndexType, IndexType) {}, [this]() { return QueryType::descentDistanceThreshold(); },
+                [this](IndexType idx) { return QueryType::skipIndexFunctor(idx); },
+                [this](IndexType idx, IndexType, Scalar d) {
+                    QueryType::m_queue.push({idx, d});
+                    return false;
+                });
+        }
+    };
+    /*!
+     * \copybrief KdTreeKNearestQueryBase
+     *
+     * Output result of a `KdTreeBase::kNearestNeighbors` query made with the **index** of the point to evaluate.
+     * \see KNearestIndexQuery
+     */
+    template <typename Traits>
+    using KdTreeKNearestIndexQuery =
+        KdTreeKNearestQueryBase<Traits, KdTreeKNearestIterator,
+                                KNearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>>;
+    /*!
+     * \copybrief KdTreeKNearestQueryBase
+     *
+     * Output result of a `KdTreeBase::kNearestNeighbors` query made with the **position** of the point to evaluate.
+     * \see KNearestPointQuery
+     */
+    template <typename Traits>
+    using KdTreeKNearestPointQuery =
+        KdTreeKNearestQueryBase<Traits, KdTreeKNearestIterator,
+                                KNearestPointQuery<typename Traits::IndexType, typename Traits::DataPoint>>;
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestQueries.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeNearestQueries.h
@@ -10,76 +10,78 @@
 #include "../../query.h"
 #include "../Iterator/kdTreeNearestIterator.h"
 
-namespace Ponca {
-
-/*!
- * \brief Extension of the Query class that allows to read the result of a nearest neighbor search on the KdTree.
- *
- *  Output result of a `KdTreeBase::nearestNeighbor` query request.
- *
- *  \see KdTreeBase
- */
-template <typename Traits,
-          template <typename> typename IteratorType,
-          typename QueryType>
-class KdTreeNearestQueryBase : public KdTreeQuery<Traits>, public QueryType
+namespace Ponca
 {
-public:
-    using DataPoint      = typename Traits::DataPoint;
-    using IndexType      = typename Traits::IndexType;
-    using Scalar         = typename DataPoint::Scalar;
-    using VectorType     = typename DataPoint::VectorType;
-    using QueryAccelType = KdTreeQuery<Traits>;
-    using Iterator       = IteratorType<typename Traits::IndexType>;
 
-    PONCA_MULTIARCH KdTreeNearestQueryBase(const StaticKdTreeBase<Traits>* kdtree, typename QueryType::InputType input) :
-            KdTreeQuery<Traits>(kdtree), QueryType(input){}
+    /*!
+     * \brief Extension of the Query class that allows to read the result of a nearest neighbor search on the KdTree.
+     *
+     *  Output result of a `KdTreeBase::nearestNeighbor` query request.
+     *
+     *  \see KdTreeBase
+     */
+    template <typename Traits, template <typename> typename IteratorType, typename QueryType>
+    class KdTreeNearestQueryBase : public KdTreeQuery<Traits>, public QueryType
+    {
+    public:
+        using DataPoint      = typename Traits::DataPoint;
+        using IndexType      = typename Traits::IndexType;
+        using Scalar         = typename DataPoint::Scalar;
+        using VectorType     = typename DataPoint::VectorType;
+        using QueryAccelType = KdTreeQuery<Traits>;
+        using Iterator       = IteratorType<typename Traits::IndexType>;
 
-    /// \brief Returns an iterator to the beginning of the nearest neighbor query.
-    PONCA_MULTIARCH inline Iterator begin(){
-        QueryAccelType::reset();
-        QueryType::reset();
-        this->search();
-        return Iterator(QueryType::m_nearest);
-    }
+        PONCA_MULTIARCH KdTreeNearestQueryBase(const StaticKdTreeBase<Traits>* kdtree,
+                                               typename QueryType::InputType input)
+            : KdTreeQuery<Traits>(kdtree), QueryType(input)
+        {
+        }
 
-    /// \brief Returns an iterator to the end of the nearest neighbor query.
-    PONCA_MULTIARCH inline Iterator end(){
-        return Iterator(QueryType::m_nearest + 1);
-    }
+        /// \brief Returns an iterator to the beginning of the nearest neighbor query.
+        PONCA_MULTIARCH inline Iterator begin()
+        {
+            QueryAccelType::reset();
+            QueryType::reset();
+            this->search();
+            return Iterator(QueryType::m_nearest);
+        }
 
-protected:
-    PONCA_MULTIARCH inline void search(){
-        KdTreeQuery<Traits>::searchInternal(QueryType::template getInputPosition<VectorType>(QueryAccelType::m_kdtree->points()),
-                                             [](IndexType, IndexType){},
-                                             [this](){return QueryType::descentDistanceThreshold();},
-                                             [this](IndexType idx){return QueryType::skipIndexFunctor(idx);},
-                                             [this](IndexType idx, IndexType, Scalar d)
-                                             {
-                                                 QueryType::m_nearest = idx;
-                                                 QueryType::m_squared_distance = d;
-                                                 return false;
-                                             }
-        );
-    }
-};
-/*!
- * \copybrief KdTreeNearestQueryBase
- *
- * Output result of a `KdTreeBase::nearestNeighbor` query made with the **index** of the point to evaluate.
- * \see NearestIndexQuery
- */
-template <typename Traits>
-using KdTreeNearestIndexQuery = KdTreeNearestQueryBase< Traits, KdTreeNearestIterator,
-                                NearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>>;
+        /// \brief Returns an iterator to the end of the nearest neighbor query.
+        PONCA_MULTIARCH inline Iterator end() { return Iterator(QueryType::m_nearest + 1); }
 
-/*!
- * \copybrief KdTreeNearestQueryBase
- *
- * Output result of a `KdTreeBase::nearestNeighbor` query made with the **position** of the point to evaluate.
- * \see NearestPointQuery
- */
-template <typename Traits>
-using KdTreeNearestPointQuery = KdTreeNearestQueryBase< Traits, KdTreeNearestIterator,
-                                NearestPointQuery<typename Traits::IndexType, typename Traits::DataPoint>>;
-} // namespace ponca
+    protected:
+        PONCA_MULTIARCH inline void search()
+        {
+            KdTreeQuery<Traits>::searchInternal(
+                QueryType::template getInputPosition<VectorType>(QueryAccelType::m_kdtree->points()),
+                [](IndexType, IndexType) {}, [this]() { return QueryType::descentDistanceThreshold(); },
+                [this](IndexType idx) { return QueryType::skipIndexFunctor(idx); },
+                [this](IndexType idx, IndexType, Scalar d) {
+                    QueryType::m_nearest          = idx;
+                    QueryType::m_squared_distance = d;
+                    return false;
+                });
+        }
+    };
+    /*!
+     * \copybrief KdTreeNearestQueryBase
+     *
+     * Output result of a `KdTreeBase::nearestNeighbor` query made with the **index** of the point to evaluate.
+     * \see NearestIndexQuery
+     */
+    template <typename Traits>
+    using KdTreeNearestIndexQuery =
+        KdTreeNearestQueryBase<Traits, KdTreeNearestIterator,
+                               NearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>>;
+
+    /*!
+     * \copybrief KdTreeNearestQueryBase
+     *
+     * Output result of a `KdTreeBase::nearestNeighbor` query made with the **position** of the point to evaluate.
+     * \see NearestPointQuery
+     */
+    template <typename Traits>
+    using KdTreeNearestPointQuery =
+        KdTreeNearestQueryBase<Traits, KdTreeNearestIterator,
+                               NearestPointQuery<typename Traits::IndexType, typename Traits::DataPoint>>;
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeQuery.h
@@ -9,107 +9,110 @@
 #include "../../indexSquaredDistance.h"
 #include "../../../Common/Containers/stack.h"
 
-namespace Ponca {
-template <typename Traits> class StaticKdTreeBase;
-
-/*!
- * \brief Query object that provides a method to search neighbors on the KdTree depending on a distance threshold.
- *
- * Base class for KdTreeRangeQueryBase, KdTreeKNearestQueryBase and KdTreeNearestQueryBase.
- */
-template <typename Traits>
-class KdTreeQuery
+namespace Ponca
 {
-public:
-    using DataPoint  = typename Traits::DataPoint;
-    using IndexType  = typename Traits::IndexType;
-    using Scalar     = typename DataPoint::Scalar;
-    using VectorType = typename DataPoint::VectorType;
+    template <typename Traits>
+    class StaticKdTreeBase;
 
-    PONCA_MULTIARCH explicit inline KdTreeQuery(const StaticKdTreeBase<Traits>* kdtree) : m_kdtree( kdtree ), m_stack() {}
-
-protected:
-    /// \brief Init stack for a new search
-    PONCA_MULTIARCH inline void reset() {
-        m_stack.clear();
-        m_stack.push({0,0});
-    }
-
-    /// [KdTreeQuery kdtree type]
-    const StaticKdTreeBase<Traits>* m_kdtree { nullptr };
-    /// [KdTreeQuery kdtree type]
-    Stack<IndexSquaredDistance<IndexType, Scalar>, 2 * Traits::MAX_DEPTH> m_stack;
-
-    /// \brief Search internally the neighbors of a point using the kdtree.
-    /// \return false if the kdtree is empty
-    template<typename LeafPreparationFunctor,
-            typename DescentDistanceThresholdFunctor,
-            typename SkipIndexFunctor,
-            typename ProcessNeighborFunctor>
-    PONCA_MULTIARCH bool searchInternal(const VectorType& point,
-                         LeafPreparationFunctor prepareLeafTraversal,
-                         DescentDistanceThresholdFunctor descentDistanceThreshold,
-                         SkipIndexFunctor skipFunctor,
-                         ProcessNeighborFunctor processNeighborFunctor
-                         )
+    /*!
+     * \brief Query object that provides a method to search neighbors on the KdTree depending on a distance threshold.
+     *
+     * Base class for KdTreeRangeQueryBase, KdTreeKNearestQueryBase and KdTreeNearestQueryBase.
+     */
+    template <typename Traits>
+    class KdTreeQuery
     {
-        const auto& nodes  = m_kdtree->nodes();
-        const auto& points = m_kdtree->points();
+    public:
+        using DataPoint  = typename Traits::DataPoint;
+        using IndexType  = typename Traits::IndexType;
+        using Scalar     = typename DataPoint::Scalar;
+        using VectorType = typename DataPoint::VectorType;
 
-        if (m_kdtree->nodeCount() == 0 || m_kdtree->pointCount() == 0 || m_kdtree->sampleCount() == 0)
-            return false;
-
-        while(!m_stack.empty())
+        PONCA_MULTIARCH explicit inline KdTreeQuery(const StaticKdTreeBase<Traits>* kdtree)
+            : m_kdtree(kdtree), m_stack()
         {
-            auto& qnode = m_stack.top();
-            const auto& node = nodes[qnode.index];
+        }
 
-            if(qnode.squared_distance < descentDistanceThreshold())
+    protected:
+        /// \brief Init stack for a new search
+        PONCA_MULTIARCH inline void reset()
+        {
+            m_stack.clear();
+            m_stack.push({0, 0});
+        }
+
+        /// [KdTreeQuery kdtree type]
+        const StaticKdTreeBase<Traits>* m_kdtree{nullptr};
+        /// [KdTreeQuery kdtree type]
+        Stack<IndexSquaredDistance<IndexType, Scalar>, 2 * Traits::MAX_DEPTH> m_stack;
+
+        /// \brief Search internally the neighbors of a point using the kdtree.
+        /// \return false if the kdtree is empty
+        template <typename LeafPreparationFunctor, typename DescentDistanceThresholdFunctor, typename SkipIndexFunctor,
+                  typename ProcessNeighborFunctor>
+        PONCA_MULTIARCH bool searchInternal(const VectorType& point, LeafPreparationFunctor prepareLeafTraversal,
+                                            DescentDistanceThresholdFunctor descentDistanceThreshold,
+                                            SkipIndexFunctor skipFunctor, ProcessNeighborFunctor processNeighborFunctor)
+        {
+            const auto& nodes  = m_kdtree->nodes();
+            const auto& points = m_kdtree->points();
+
+            if (m_kdtree->nodeCount() == 0 || m_kdtree->pointCount() == 0 || m_kdtree->sampleCount() == 0)
+                return false;
+
+            while (!m_stack.empty())
             {
-                if(node.is_leaf())
+                auto& qnode      = m_stack.top();
+                const auto& node = nodes[qnode.index];
+
+                if (qnode.squared_distance < descentDistanceThreshold())
                 {
-                    m_stack.pop();
-                    IndexType start = node.leaf_start();
-                    IndexType end = node.leaf_start() + node.leaf_size();
-                    prepareLeafTraversal(start, end);
-                    for(IndexType i=start; i<end; ++i)
+                    if (node.is_leaf())
                     {
-                        IndexType idx = m_kdtree->pointFromSample(i);
-                        if(skipFunctor(idx)) continue;
-
-                        Scalar d = (point - points[idx].pos()).squaredNorm();
-
-                        if(d < descentDistanceThreshold())
+                        m_stack.pop();
+                        IndexType start = node.leaf_start();
+                        IndexType end   = node.leaf_start() + node.leaf_size();
+                        prepareLeafTraversal(start, end);
+                        for (IndexType i = start; i < end; ++i)
                         {
-                            if( processNeighborFunctor( idx, i, d )) return false;
+                            IndexType idx = m_kdtree->pointFromSample(i);
+                            if (skipFunctor(idx))
+                                continue;
+
+                            Scalar d = (point - points[idx].pos()).squaredNorm();
+
+                            if (d < descentDistanceThreshold())
+                            {
+                                if (processNeighborFunctor(idx, i, d))
+                                    return false;
+                            }
                         }
+                    }
+                    else
+                    {
+                        // replace the stack top by the farthest and push the closest
+                        Scalar newOff = point[node.inner_split_dim()] - node.inner_split_value();
+                        m_stack.push();
+                        if (newOff < 0)
+                        {
+                            m_stack.top().index = node.inner_first_child_id();
+                            qnode.index         = node.inner_first_child_id() + 1;
+                        }
+                        else
+                        {
+                            m_stack.top().index = node.inner_first_child_id() + 1;
+                            qnode.index         = node.inner_first_child_id();
+                        }
+                        m_stack.top().squared_distance = qnode.squared_distance;
+                        qnode.squared_distance         = newOff * newOff;
                     }
                 }
                 else
                 {
-                    // replace the stack top by the farthest and push the closest
-                    Scalar newOff = point[node.inner_split_dim()] - node.inner_split_value();
-                    m_stack.push();
-                    if(newOff < 0)
-                    {
-                        m_stack.top().index = node.inner_first_child_id();
-                        qnode.index         = node.inner_first_child_id()+1;
-                    }
-                    else
-                    {
-                        m_stack.top().index = node.inner_first_child_id()+1;
-                        qnode.index         = node.inner_first_child_id();
-                    }
-                    m_stack.top().squared_distance = qnode.squared_distance;
-                    qnode.squared_distance         = newOff*newOff;
+                    m_stack.pop();
                 }
             }
-            else
-            {
-                m_stack.pop();
-            }
+            return true;
         }
-        return true;
-    }
-};
+    };
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeQueries.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/Query/kdTreeRangeQueries.h
@@ -10,125 +10,128 @@
 #include "../../query.h"
 #include "../Iterator/kdTreeRangeIterator.h"
 
-namespace Ponca {
-
-/*!
- * \brief Extension of the Query class that allows to read the result of a range neighbors search on the KdTree.
- *
- *  Output result of a `KdTreeBase::rangeNeighbors` query request.
- *
- *  \see KdTreeBase
- */
-template <typename Traits,
-        template <typename,typename,typename> typename IteratorType,
-        typename QueryType>
-class KdTreeRangeQueryBase : public KdTreeQuery<Traits>, public QueryType
-                              //public RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>
+namespace Ponca
 {
-public:
-    using DataPoint      = typename Traits::DataPoint;
-    using IndexType      = typename Traits::IndexType;
-    using Scalar         = typename DataPoint::Scalar;
-    using VectorType     = typename DataPoint::VectorType;
-    using QueryAccelType = KdTreeQuery<Traits>;
-    using Iterator       = IteratorType<IndexType, DataPoint, KdTreeRangeQueryBase>;
-    using Self           = KdTreeRangeQueryBase<Traits, IteratorType, QueryType>;
 
-protected:
-    friend Iterator;
-
-public:
-    PONCA_MULTIARCH KdTreeRangeQueryBase(const StaticKdTreeBase<Traits>* kdtree, Scalar radius, typename QueryType::InputType input) :
-            KdTreeQuery<Traits>(kdtree), QueryType(radius, input){}
-
-    /// \brief Call the range neighbors query with new input and radius parameters.
-    PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input, Scalar radius)
+    /*!
+     * \brief Extension of the Query class that allows to read the result of a range neighbors search on the KdTree.
+     *
+     *  Output result of a `KdTreeBase::rangeNeighbors` query request.
+     *
+     *  \see KdTreeBase
+     */
+    template <typename Traits, template <typename, typename, typename> typename IteratorType, typename QueryType>
+    class KdTreeRangeQueryBase : public KdTreeQuery<Traits>, public QueryType
+    // public RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>
     {
-        return QueryType::template operator()<Self>(input, radius);
-    }
+    public:
+        using DataPoint      = typename Traits::DataPoint;
+        using IndexType      = typename Traits::IndexType;
+        using Scalar         = typename DataPoint::Scalar;
+        using VectorType     = typename DataPoint::VectorType;
+        using QueryAccelType = KdTreeQuery<Traits>;
+        using Iterator       = IteratorType<IndexType, DataPoint, KdTreeRangeQueryBase>;
+        using Self           = KdTreeRangeQueryBase<Traits, IteratorType, QueryType>;
 
-    /// \brief Call the range neighbors query with new input parameter.
-    PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input)
-    {
-        return QueryType::template operator()<Self>(input);
-    }
+    protected:
+        friend Iterator;
 
-    /// \brief Returns an iterator to the beginning of the Range Query.
-    PONCA_MULTIARCH inline Iterator begin(){
-        QueryAccelType::reset();
-        QueryType::reset();
-        Iterator it(this);
-        this->advance(it);
-        return it;
-    }
-
-    /// \brief Returns an iterator to the end of the Range Query.
-    PONCA_MULTIARCH inline Iterator end(){
-        return Iterator(this, QueryAccelType::m_kdtree->pointCount());
-    }
-
-protected:
-    PONCA_MULTIARCH inline void advance(Iterator& it){
-        const auto& points  = QueryAccelType::m_kdtree->points();
-        const auto& indices = QueryAccelType::m_kdtree->samples();
-        const auto& point   = QueryType::template getInputPosition<VectorType>(points);
-
-        if (QueryAccelType::m_kdtree->pointCount() == 0 || QueryAccelType::m_kdtree->sampleCount() == 0)
+    public:
+        PONCA_MULTIARCH KdTreeRangeQueryBase(const StaticKdTreeBase<Traits>* kdtree, Scalar radius,
+                                             typename QueryType::InputType input)
+            : KdTreeQuery<Traits>(kdtree), QueryType(radius, input)
         {
-            it = end();
-            return;
         }
 
-        auto descentDistanceThreshold = [this](){return QueryType::descentDistanceThreshold();};
-        auto skipFunctor              = [this](IndexType idx){return QueryType::skipIndexFunctor(idx);};
-        auto processNeighborFunctor   = [&it](IndexType idx, IndexType i, Scalar)
+        /// \brief Call the range neighbors query with new input and radius parameters.
+        PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input, Scalar radius)
         {
-            it.m_index = idx;
-            it.m_start = i+1;
-            return true;
-        };
+            return QueryType::template operator()<Self>(input, radius);
+        }
 
-        for(IndexType i=it.m_start; i<it.m_end; ++i)
+        /// \brief Call the range neighbors query with new input parameter.
+        PONCA_MULTIARCH inline Self& operator()(typename QueryType::InputType input)
         {
-            IndexType idx = indices[i];
-            if(skipFunctor(idx)) continue;
+            return QueryType::template operator()<Self>(input);
+        }
 
-            Scalar d = (point - points[idx].pos()).squaredNorm();
-            if(d < descentDistanceThreshold())
+        /// \brief Returns an iterator to the beginning of the Range Query.
+        PONCA_MULTIARCH inline Iterator begin()
+        {
+            QueryAccelType::reset();
+            QueryType::reset();
+            Iterator it(this);
+            this->advance(it);
+            return it;
+        }
+
+        /// \brief Returns an iterator to the end of the Range Query.
+        PONCA_MULTIARCH inline Iterator end() { return Iterator(this, QueryAccelType::m_kdtree->pointCount()); }
+
+    protected:
+        PONCA_MULTIARCH inline void advance(Iterator& it)
+        {
+            const auto& points  = QueryAccelType::m_kdtree->points();
+            const auto& indices = QueryAccelType::m_kdtree->samples();
+            const auto& point   = QueryType::template getInputPosition<VectorType>(points);
+
+            if (QueryAccelType::m_kdtree->pointCount() == 0 || QueryAccelType::m_kdtree->sampleCount() == 0)
             {
-                if( processNeighborFunctor(idx, i, d) ) return;
+                it = end();
+                return;
             }
+
+            auto descentDistanceThreshold = [this]() { return QueryType::descentDistanceThreshold(); };
+            auto skipFunctor              = [this](IndexType idx) { return QueryType::skipIndexFunctor(idx); };
+            auto processNeighborFunctor   = [&it](IndexType idx, IndexType i, Scalar) {
+                it.m_index = idx;
+                it.m_start = i + 1;
+                return true;
+            };
+
+            for (IndexType i = it.m_start; i < it.m_end; ++i)
+            {
+                IndexType idx = indices[i];
+                if (skipFunctor(idx))
+                    continue;
+
+                Scalar d = (point - points[idx].pos()).squaredNorm();
+                if (d < descentDistanceThreshold())
+                {
+                    if (processNeighborFunctor(idx, i, d))
+                        return;
+                }
+            }
+
+            if (KdTreeQuery<Traits>::searchInternal(
+                    point,
+                    [&it](IndexType start, IndexType end) {
+                        it.m_start = start;
+                        it.m_end   = end;
+                    },
+                    descentDistanceThreshold, skipFunctor, processNeighborFunctor))
+                it.m_index = static_cast<IndexType>(QueryAccelType::m_kdtree->pointCount());
         }
+    };
 
-        if (KdTreeQuery<Traits>::searchInternal(point,
-                                                 [&it](IndexType start, IndexType end)
-                                                 {
-                                                     it.m_start = start;
-                                                     it.m_end   = end;
-                                                 },
-                                                 descentDistanceThreshold,
-                                                 skipFunctor,
-                                                 processNeighborFunctor))
-            it.m_index = static_cast<IndexType>(QueryAccelType::m_kdtree->pointCount());
-    }
-};
-
-/*!
- * \copybrief KdTreeRangeQueryBase
- *
- * Output result of a `KdTreeBase::rangeNeighbors` query made with the **index** of the point to evaluate.
- * \see RangeIndexQuery
- */
-template <typename Traits>
-using KdTreeRangeIndexQuery = KdTreeRangeQueryBase< Traits, KdTreeRangeIterator,
-        RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>>;
-/*!
- * \copybrief KdTreeRangeQueryBase
- *
- * Output result of a `KdTreeBase::rangeNeighbors` query made with the **position** of the point to evaluate.
- * \see RangePointQuery
- */
-template <typename Traits>
-using KdTreeRangePointQuery = KdTreeRangeQueryBase< Traits, KdTreeRangeIterator,
-        RangePointQuery<typename Traits::IndexType, typename Traits::DataPoint>>;
-} // namespace ponca
+    /*!
+     * \copybrief KdTreeRangeQueryBase
+     *
+     * Output result of a `KdTreeBase::rangeNeighbors` query made with the **index** of the point to evaluate.
+     * \see RangeIndexQuery
+     */
+    template <typename Traits>
+    using KdTreeRangeIndexQuery =
+        KdTreeRangeQueryBase<Traits, KdTreeRangeIterator,
+                             RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>>;
+    /*!
+     * \copybrief KdTreeRangeQueryBase
+     *
+     * Output result of a `KdTreeBase::rangeNeighbors` query made with the **position** of the point to evaluate.
+     * \see RangePointQuery
+     */
+    template <typename Traits>
+    using KdTreeRangePointQuery =
+        KdTreeRangeQueryBase<Traits, KdTreeRangeIterator,
+                             RangePointQuery<typename Traits::IndexType, typename Traits::DataPoint>>;
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -141,8 +141,8 @@ namespace Ponca
     using DataPoint      = typename Traits::DataPoint;    /*!< DataPoint given by user via Traits                  */  \
     using IndexType      = typename Traits::IndexType;    /*!< Type used to index points into the PointContainer   */  \
     using LeafSizeType   = typename Traits::LeafSizeType; /*!< Type used to store the size of leaf nodes           */  \
-    using PointContainer = typename Traits::PointContainer; /*!< Container for DataPoint used inside the KdTree */                                                                                                                    \
-    using IndexContainer = typename Traits::IndexContainer; /*!< Container for indices used inside the KdTree */                                                                                                                    \
+    using PointContainer = typename Traits::PointContainer; /*!< Container for DataPoint used inside the KdTree */     \
+    using IndexContainer = typename Traits::IndexContainer; /*!< Container for indices used inside the KdTree */       \
     using NodeIndexType  = typename Traits::NodeIndexType; /*!< Type used to index nodes into the NodeContainer     */ \
     using NodeType       = typename Traits::NodeType;      /*!< Type of nodes used inside the KdTree                */ \
     using NodeContainer  = typename Traits::NodeContainer; /*!< Container for nodes used inside the KdTree          */ \

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -25,10 +25,14 @@
 #include "Query/kdTreeKNearestQueries.h"
 #include "Query/kdTreeRangeQueries.h"
 
-namespace Ponca {
-template <typename Traits> class KdTreeBase;
-template <typename Traits> class KdTreeDenseBase;
-template <typename Traits> class KdTreeSparseBase;
+namespace Ponca
+{
+    template <typename Traits>
+    class KdTreeBase;
+    template <typename Traits>
+    class KdTreeDenseBase;
+    template <typename Traits>
+    class KdTreeSparseBase;
 
 /*!
  * \brief Abstract KdTree type with KdTreeDefaultTraits
@@ -43,13 +47,15 @@ template <typename Traits> class KdTreeSparseBase;
  * \snippet examples/cpp/ponca_neighbor_search.cpp KdTree assign dense
  */
 #ifdef PARSED_WITH_DOXYGEN
-// [KdTree type definition]
-template <typename DataPoint>
-struct KdTree : public Ponca::KdTreeBase<KdTreeDefaultTraits<DataPoint>>{};
+    // [KdTree type definition]
+    template <typename DataPoint>
+    struct KdTree : public Ponca::KdTreeBase<KdTreeDefaultTraits<DataPoint>>
+    {
+    };
 // [KdTree type definition]
 #else
-template <typename DataPoint>
-using KdTree = KdTreeBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to avoid redefining methods
+    template <typename DataPoint>
+    using KdTree = KdTreeBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to avoid redefining methods
 #endif
 
 /*!
@@ -62,15 +68,16 @@ using KdTree = KdTreeBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to av
  *
  */
 #ifdef PARSED_WITH_DOXYGEN
-// [StaticKdTree type definition]
-template <typename DataPoint>
-struct StaticKdTree : public Ponca::StaticKdTreeBase<KdTreeDefaultTraits<DataPoint>>{};
+    // [StaticKdTree type definition]
+    template <typename DataPoint>
+    struct StaticKdTree : public Ponca::StaticKdTreeBase<KdTreeDefaultTraits<DataPoint>>
+    {
+    };
 // [StaticKdTree type definition]
 #else
-template <typename DataPoint>
-using StaticKdTree = StaticKdTreeBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to avoid redefining methods
+    template <typename DataPoint>
+    using StaticKdTree = StaticKdTreeBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to avoid redefining methods
 #endif
-
 
 /*!
  * \brief Public interface for dense KdTree datastructure.
@@ -81,13 +88,15 @@ using StaticKdTree = StaticKdTreeBase<KdTreeDefaultTraits<DataPoint>>; // prefer
  * \see KdTreeDenseBase for complete API
  */
 #ifdef PARSED_WITH_DOXYGEN
-// [KdTreeDense type definition]
-template <typename DataPoint>
-struct KdTreeDense : public Ponca::KdTreeDenseBase<KdTreeDefaultTraits<DataPoint>>{};
+    // [KdTreeDense type definition]
+    template <typename DataPoint>
+    struct KdTreeDense : public Ponca::KdTreeDenseBase<KdTreeDefaultTraits<DataPoint>>
+    {
+    };
 // [KdTreeDense type definition]
 #else
-template <typename DataPoint>
-using KdTreeDense = KdTreeDenseBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to avoid redefining methods
+    template <typename DataPoint>
+    using KdTreeDense = KdTreeDenseBase<KdTreeDefaultTraits<DataPoint>>; // prefer alias to avoid redefining methods
 #endif
 
 /*!
@@ -99,524 +108,500 @@ using KdTreeDense = KdTreeDenseBase<KdTreeDefaultTraits<DataPoint>>; // prefer a
  * \see KdTreeSparseBase for complete API
  */
 #ifdef PARSED_WITH_DOXYGEN
-// [KdTreeSparse type definition]
-template <typename DataPoint>
-struct KdTreeSparse : Ponca::KdTreeSparseBase<KdTreeDefaultTraits<DataPoint>>{};
+    // [KdTreeSparse type definition]
+    template <typename DataPoint>
+    struct KdTreeSparse : Ponca::KdTreeSparseBase<KdTreeDefaultTraits<DataPoint>>
+    {
+    };
 // [KdTreeSparse type definition]
 #else
-template <typename DataPoint>
-using KdTreeSparse = KdTreeSparseBase<KdTreeDefaultTraits<DataPoint>>;
+    template <typename DataPoint>
+    using KdTreeSparse = KdTreeSparseBase<KdTreeDefaultTraits<DataPoint>>;
 #endif
 
-/*!
- * \brief Customizable static base class for KdTree datastructure implementations
- *
- * \note This "Static" kdtree can be constructed using the Buffers structure,
- * it only makes the Query functions available and doesn't define any build functionalities,
- * (hence why it is static).
- * This basic class can be used to make kdtree calls from inside a CUDA kernel.
- * \see KdTreeBase to build a kdtree
- * \see rangeNeighbors, kNearestNeighbors, nearestNeighbor for the query calls
- *
- * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
- * same interface as the default traits type.
- * \see KdTreeDefaultTraits for the trait interface documentation.
- */
-template <typename Traits>
-class StaticKdTreeBase
-{
-public:
-#define WRITE_TRAITS \
-    using DataPoint      = typename Traits::DataPoint;      /*!< DataPoint given by user via Traits                  */\
-    using IndexType      = typename Traits::IndexType;      /*!< Type used to index points into the PointContainer   */\
-    using LeafSizeType   = typename Traits::LeafSizeType;   /*!< Type used to store the size of leaf nodes           */\
-    using PointContainer = typename Traits::PointContainer; /*!< Container for DataPoint used inside the KdTree      */\
-    using IndexContainer = typename Traits::IndexContainer; /*!< Container for indices used inside the KdTree        */\
-    using NodeIndexType  = typename Traits::NodeIndexType;  /*!< Type used to index nodes into the NodeContainer     */\
-    using NodeType       = typename Traits::NodeType;       /*!< Type of nodes used inside the KdTree                */\
-    using NodeContainer  = typename Traits::NodeContainer;  /*!< Container for nodes used inside the KdTree          */\
-    using Scalar         = typename DataPoint::Scalar;      /*!< Scalar given by user via DataPoint                  */\
-    using VectorType     = typename DataPoint::VectorType;  /*!< VectorType given by user via DataPoint              */\
-    using AabbType       = typename NodeType::AabbType;     /*!< Bounding box type given by user via NodeType        */
-    WRITE_TRAITS
-
-    /// \brief Internal structure storing all the buffers used by the KdTree
-    struct Buffers
-    {
-        PointContainer points;  ///< Buffer storing the input points (read only)
-        NodeContainer  nodes;   ///< Buffer storing the nodes of the KdTree
-        IndexContainer indices; ///< Buffer storing the indices associating the input points to the nodes
-
-        size_t points_size {0};
-        size_t nodes_size  {0};
-        size_t indices_size{0};
-
-        PONCA_MULTIARCH inline Buffers() = default;
-
-        PONCA_MULTIARCH inline Buffers(
-            PointContainer _points   , NodeContainer _nodes    , IndexContainer _indices,
-            const size_t _points_size, const size_t _nodes_size, const size_t _indices_size
-        ) : points(_points)          , nodes(_nodes)          , indices(_indices),
-            points_size(_points_size), nodes_size(_nodes_size), indices_size(_indices_size)
-        {}
-    };
-
-    /// \brief The maximum number of nodes that the kd-tree can have.
-    static constexpr std::size_t MAX_NODE_COUNT = NodeType::MAX_COUNT;
-    /// \brief The maximum number of points that can be stored in the kd-tree.
-    static constexpr std::size_t MAX_POINT_COUNT = std::size_t(2) << sizeof(IndexType)*8;
-
-    /// \brief The maximum depth of the kd-tree.
-    static constexpr int MAX_DEPTH = Traits::MAX_DEPTH;
-
-    static constexpr bool SUPPORTS_SUBSAMPLING = false;
-
-    // Queries use a value of -1 for invalid indices
-    static_assert(std::is_signed_v<IndexType>, "Index type must be signed");
-    static_assert(MAX_DEPTH > 0, "Max depth must be strictly positive");
-
-    // Construction ------------------------------------------------------------
-protected:
-    PONCA_MULTIARCH inline StaticKdTreeBase() = default;
-public:
-    /*! \brief Constructor that allows the use of prebuilt KdTree containers.
+    /*!
+     * \brief Customizable static base class for KdTree datastructure implementations
      *
-     * Each internal values of a KdTree can be extracted using \ref `KdTreeBase::buffers()`
+     * \note This "Static" kdtree can be constructed using the Buffers structure,
+     * it only makes the Query functions available and doesn't define any build functionalities,
+     * (hence why it is static).
+     * This basic class can be used to make kdtree calls from inside a CUDA kernel.
+     * \see KdTreeBase to build a kdtree
+     * \see rangeNeighbors, kNearestNeighbors, nearestNeighbor for the query calls
      *
-     * \note This constructor can be used to avoid the convertion and building process,
-     * which is useful to transfer directly the KdTree to the device in CUDA.
-     *
-     * \param buf Internal buffers of the KdTree
+     * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
+     * same interface as the default traits type.
+     * \see KdTreeDefaultTraits for the trait interface documentation.
      */
-    PONCA_MULTIARCH inline StaticKdTreeBase(Buffers& buf) : m_bufs(buf) {}
-
-    // Accessors ---------------------------------------------------------------
-public:
-    //! \brief Get the number of nodes in the KdTree
-    PONCA_MULTIARCH [[nodiscard]] inline NodeIndexType nodeCount() const
+    template <typename Traits>
+    class StaticKdTreeBase
     {
-        return (NodeIndexType)m_bufs.nodes_size;
-    }
+    public:
+#define WRITE_TRAITS                                                                                                   \
+    using DataPoint      = typename Traits::DataPoint;    /*!< DataPoint given by user via Traits                  */  \
+    using IndexType      = typename Traits::IndexType;    /*!< Type used to index points into the PointContainer   */  \
+    using LeafSizeType   = typename Traits::LeafSizeType; /*!< Type used to store the size of leaf nodes           */  \
+    using PointContainer = typename Traits::PointContainer; /*!< Container for DataPoint used inside the KdTree */                                                                                                                    \
+    using IndexContainer = typename Traits::IndexContainer; /*!< Container for indices used inside the KdTree */                                                                                                                    \
+    using NodeIndexType  = typename Traits::NodeIndexType; /*!< Type used to index nodes into the NodeContainer     */ \
+    using NodeType       = typename Traits::NodeType;      /*!< Type of nodes used inside the KdTree                */ \
+    using NodeContainer  = typename Traits::NodeContainer; /*!< Container for nodes used inside the KdTree          */ \
+    using Scalar         = typename DataPoint::Scalar;     /*!< Scalar given by user via DataPoint                  */ \
+    using VectorType     = typename DataPoint::VectorType; /*!< VectorType given by user via DataPoint              */ \
+    using AabbType       = typename NodeType::AabbType;    /*!< Bounding box type given by user via NodeType        */
+        WRITE_TRAITS
 
-    //! \brief Get the number of indices
-    PONCA_MULTIARCH [[nodiscard]] inline IndexType sampleCount() const
-    {
-        return (IndexType)m_bufs.indices_size;
-    }
-
-    //! \brief Get the number of points
-    PONCA_MULTIARCH [[nodiscard]] inline IndexType pointCount() const
-    {
-        return (IndexType)m_bufs.points_size;
-    }
-
-    //! \brief Get the number of leafs in the KdTree
-    PONCA_MULTIARCH [[nodiscard]] inline NodeIndexType leafCount() const
-    {
-        return m_leaf_count;
-    }
-
-    //! \brief Get the internal point container
-    PONCA_MULTIARCH [[nodiscard]] inline PointContainer& points()
-    {
-        return m_bufs.points;
-    };
-
-    //! \copybrief KdTreeBase::points
-    PONCA_MULTIARCH [[nodiscard]] inline const PointContainer& points() const
-    {
-        return m_bufs.points;
-    };
-
-    //! \brief Get the internal node container
-    PONCA_MULTIARCH [[nodiscard]] inline const NodeContainer& nodes() const
-    {
-        return m_bufs.nodes;
-    }
-
-    //! \brief Get the internal indice container
-    PONCA_MULTIARCH [[nodiscard]] inline const IndexContainer& samples() const
-    {
-        return m_bufs.indices;
-    }
-
-    //! \brief Get access to the internal buffer, for instance to prepare GPU binding
-    PONCA_MULTIARCH [[nodiscard]] inline const Buffers& buffers() const
-    {
-        return m_bufs;
-    }
-
-    // Parameters --------------------------------------------------------------
-public:
-    /// Read leaf min size
-    PONCA_MULTIARCH [[nodiscard]] inline LeafSizeType minCellSize() const
-    {
-        return m_min_cell_size;
-    }
-
-    /// Write leaf min size
-    PONCA_MULTIARCH inline void setMinCellSize(LeafSizeType min_cell_size)
-    {
-        PONCA_DEBUG_ASSERT(min_cell_size > 0);
-        m_min_cell_size = min_cell_size;
-    }
-
-    // Index mapping -----------------------------------------------------------
-public:
-    /// Return the point index associated with the specified sample index
-    PONCA_MULTIARCH [[nodiscard]] inline IndexType pointFromSample(IndexType sample_index) const
-    {
-        return m_bufs.indices[sample_index];
-    }
-
-    /// Return the \ref DataPoint associated with the specified sample index
-    /// \note Convenience function, equivalent to
-    /// `point_data()[pointFromSample(sample_index)]`
-    PONCA_MULTIARCH [[nodiscard]] inline DataPoint& pointDataFromSample(IndexType sample_index)
-    {
-        return m_bufs.points[pointFromSample(sample_index)];
-    }
-    
-    /// Return the \ref DataPoint associated with the specified sample index
-    /// \note Convenience function, equivalent to
-    /// `point_data()[pointFromSample(sample_index)]`
-    PONCA_MULTIARCH [[nodiscard]] inline const DataPoint& pointDataFromSample(IndexType sample_index) const
-    {
-        return m_bufs.points[pointFromSample(sample_index)];
-    }
-
-    // Query -------------------------------------------------------------------
-public :
-    /// \brief Computes a Query object to iterate over the k-nearest neighbors of a point.
-    /// The returned object can be reset and reused with the () operator
-    /// (using the same argument types as parameters).
-    ///
-    /// \param point Point from where the query is evaluated
-    /// \param k Number of neighbors returned
-    /// \return The \ref KdTreeKNearestIndexQuery mutable object to iterate over the search results.
-    /// \see KdTreeKNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestPointQuery<Traits> kNearestNeighbors(const VectorType& point, IndexType k) const
-    {
-        return KdTreeKNearestPointQuery<Traits>(this, k, point);
-    }
-
-    /// \copybrief KdTreeBase::kNearestNeighbors
-    /// \param index Index of the point from where the query is evaluated
-    /// \param k Number of neighbors returned
-    /// \return The \ref KdTreeKNearestIndexQuery mutable object to iterate over the search results.
-    /// \see KdTreeKNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestIndexQuery<Traits> kNearestNeighbors(IndexType index, IndexType k) const
-    {
-        return KdTreeKNearestIndexQuery<Traits>(this, k, index);
-    }
-
-    /// \brief Convenience function that provides an empty k-nearest neighbors Query object.
-    ///
-    /// The returned object can call for a k-nearest neighbors search using the operator (),
-    /// which takes a k and a **position** as parameters.
-    ///
-    /// Same as `KdTreeBase::kNearestNeighbors (0, VectorType::Zero())`
-    /// \return The empty \ref KdTreeKNearestPointQuery mutable object to iterate over the search results.
-    /// \see KdTreeKNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestPointQuery<Traits> kNearestNeighborsQuery() const
-    {
-        return KdTreeKNearestPointQuery<Traits>(this, 0, VectorType::Zero());
-    }
-
-    /// \copybrief KdTreeBase::kNearestNeighborsQuery
-    ///
-    /// The returned object can call for a k-nearest neighbors search using the operator (),
-    /// which takes a k and an **index** as parameters.
-    ///
-    /// Same as `KdTreeBase::kNearestNeighbors (0, 0)`
-    /// \return The empty \ref KdTreeKNearestIndexQuery mutable object to iterate over the search results.
-    /// \see KdTreeKNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestIndexQuery<Traits> kNearestNeighborsIndexQuery() const
-    {
-        return KdTreeKNearestIndexQuery<Traits>(this, 0, 0);
-    }
-
-    /// \brief Computes a Query object that contains the nearest point.
-    /// The returned object can be reset and reused with the () operator
-    /// (using the same argument types as parameters).
-    ///
-    /// \param point Point from where the query is evaluated
-    /// \return The \ref KdTreeNearestPointQuery mutable object that contains the search result.
-    /// \see KdTreeNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeNearestPointQuery<Traits> nearestNeighbor(const VectorType& point) const
-    {
-        return KdTreeNearestPointQuery<Traits>(this, point);
-    }
-
-
-    /// \copybrief KdTreeBase::nearestNeighbor
-    /// \param index Index of the point from where the query is evaluated
-    /// \return The \ref KdTreeKNearestIndexQuery mutable object that contains the search result.
-    /// \see KdTreeNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeNearestIndexQuery<Traits> nearestNeighbor(IndexType index) const
-    {
-        return KdTreeNearestIndexQuery<Traits>(this, index);
-    }
-
-    /// \brief Convenience function that provides an empty nearest neighbor Query object.
-    ///
-    /// The returned object can call for a nearest neighbor search using the operator (),
-    /// which takes a **position** as parameter.
-    ///
-    /// Same as `KdTreeBase::nearestNeighbor (VectorType::Zero())`
-    ///
-    /// \return The empty \ref KdTreeNearestPointQuery mutable object that contains the search result.
-    /// \see KdTreeNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeNearestIndexQuery<Traits> nearestNeighborQuery() const
-    {
-        return KdTreeNearestIndexQuery<Traits>(this, VectorType::Zero());
-    }
-
-    /// \copybrief KdTreeBase::nearestNeighborQuery
-    ///
-    /// The returned object can call for a nearest neighbor search using the operator (),
-    /// which takes an **index** as parameter.
-    ///
-    /// Same as `KdTreeBase::nearestNeighbor (0)`
-    ///
-    /// \return The \ref KdTreeKNearestIndexQuery mutable object that contains the search result.
-    /// \see KdTreeNearestQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeNearestIndexQuery<Traits> nearestNeighborIndexQuery() const
-    {
-        return KdTreeNearestIndexQuery<Traits>(this, 0);
-    }
-
-    /// \brief Computes a Query object to iterate over the neighbors that are inside a given radius.
-    /// The returned object can be reset and reused with the () operator
-    /// (using the same argument types as parameters).
-    ///
-    /// \param point Point from where the query is evaluated
-    /// \param r Radius around where to search the neighbors
-    /// \return The \ref KdTreeRangePointQuery mutable object to iterate over the search results.
-    /// \see KdTreeRangeQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeRangePointQuery<Traits> rangeNeighbors(const VectorType& point, Scalar r) const
-    {
-        return KdTreeRangePointQuery<Traits>(this, r, point);
-    }
-
-    /// \copybrief KdTreeBase::rangeNeighbors
-    /// \param index Index of the point from where the query is evaluated
-    /// \param r Radius around where to search the neighbors
-    /// \return The \ref KdTreeRangeIndexQuery mutable object to iterate over the search results.
-    /// \see KdTreeRangeQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeRangeIndexQuery<Traits> rangeNeighbors(IndexType index, Scalar r) const
-    {
-        return KdTreeRangeIndexQuery<Traits>(this, r, index);
-    }
-
-    /// \brief Convenience function that provides an empty range neighbor Query object.
-    ///
-    /// The returned object can call for a range neighbor search using the operator (),
-    /// which takes a **position** as parameter.
-    ///
-    /// Same as `KdTreeBase::rangeNeighborsQuery (0, VectorType::Zero())`
-    ///
-    /// \return The empty \ref KdTreeRangePointQuery mutable object to iterate over the search results.
-    /// \see KdTreeRangeQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeRangePointQuery<Traits> rangeNeighborsQuery() const
-    {
-        return KdTreeRangePointQuery<Traits>(this, 0, VectorType::Zero());
-    }
-
-    /// \brief KdTreeBase::rangeNeighborsQuery
-    ///
-    /// The returned object can call for a range neighbor search using the operator (),
-    /// which takes an **index** as parameter.
-    ///
-    /// Same as `KdTreeBase::rangeNeighborsQuery (0, 0)`
-    ///
-    /// \return The empty \ref KdTreeRangeIndexQuery mutable object to iterate over the search results.
-    /// \see KdTreeRangeQueryBase
-    PONCA_MULTIARCH [[nodiscard]] KdTreeRangeIndexQuery<Traits> rangeNeighborsIndexQuery() const
-    {
-        return KdTreeRangeIndexQuery<Traits>(this, 0, 0);
-    }
-
-    // Utilities ---------------------------------------------------------------
-public:
-    PONCA_MULTIARCH_HOST [[nodiscard]] inline bool valid() const;
-    PONCA_MULTIARCH_HOST inline void print(std::ostream& os, bool verbose = false) const;
-
-    // Data --------------------------------------------------------------------
-protected:
-    Buffers m_bufs; ///< Buffers used to store the KdTree
-    LeafSizeType m_min_cell_size {64}; ///< Minimal number of points per leaf
-    NodeIndexType m_leaf_count {0}; ///< Number of leaves in the Kdtree (computed during construction)
-};
-
-/*! \copybrief StaticKdTreeBase
- *
- * Base kdtree class that implements the basic build functionalities of the KdTree.
- * \see KdTreeBase::build
- *
- * This class is the basis for the KdTree Dense and Sparse type
- * \see Ponca::KdTreeDense
- * \see Ponca::KdTreeSparse
- *
- * \warning Variants of this class are not usable on a CUDA device,
- * because it relies on STL-like internal containers to build the kdtree.
- *
- * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
- * same interface as the default traits type.
- * \see KdTreeDefaultTraits for the trait interface documentation.
- */
-template <typename Traits>
-class KdTreeBase : public StaticKdTreeBase<Traits>
-{
-public:
-    using Base = StaticKdTreeBase<Traits>;
-    WRITE_TRAITS
-    /// Generate a tree from a custom contained type converted using the specified converter
-    /// \tparam PointUserContainer Input point container, transformed to PointContainer
-    /// \tparam PointConverter Cast/Convert input container type to point container data type
-    /// \param points Input points
-    /// \param c Cast/Convert input point type to DataType
-    template<typename PointUserContainer, typename PointConverter>
-    PONCA_MULTIARCH_HOST inline void build(PointUserContainer&& points, PointConverter c);
-
-    /// Convert a custom point container to the KdTree \ref PointContainer using \ref DataPoint default constructor
-    struct DefaultConverter
-    {
-        template <typename Input>
-        PONCA_MULTIARCH_HOST inline void operator()(Input&& i, PointContainer& o)
+        /// \brief Internal structure storing all the buffers used by the KdTree
+        struct Buffers
         {
-            using InputContainer = std::remove_reference_t<Input>;
-            if constexpr (std::is_same_v<InputContainer, PointContainer> && std::is_copy_assignable_v<DataPoint>)
-                o = std::forward<Input>(i); // Either move or copy
-            else
-                std::transform(i.cbegin(), i.cend(), std::back_inserter(o),
-                               [](const typename InputContainer::value_type &p) -> DataPoint { return DataPoint(p); });
+            PointContainer points;  ///< Buffer storing the input points (read only)
+            NodeContainer nodes;    ///< Buffer storing the nodes of the KdTree
+            IndexContainer indices; ///< Buffer storing the indices associating the input points to the nodes
+
+            size_t points_size{0};
+            size_t nodes_size{0};
+            size_t indices_size{0};
+
+            PONCA_MULTIARCH inline Buffers() = default;
+
+            PONCA_MULTIARCH inline Buffers(PointContainer _points, NodeContainer _nodes, IndexContainer _indices,
+                                                 const size_t _points_size, const size_t _nodes_size,
+                                                 const size_t _indices_size)
+                : points(_points), nodes(_nodes), indices(_indices), points_size(_points_size), nodes_size(_nodes_size),
+                  indices_size(_indices_size)
+            {
+            }
+        };
+
+        /// \brief The maximum number of nodes that the kd-tree can have.
+        static constexpr std::size_t MAX_NODE_COUNT = NodeType::MAX_COUNT;
+        /// \brief The maximum number of points that can be stored in the kd-tree.
+        static constexpr std::size_t MAX_POINT_COUNT = std::size_t(2) << sizeof(IndexType) * 8;
+
+        /// \brief The maximum depth of the kd-tree.
+        static constexpr int MAX_DEPTH = Traits::MAX_DEPTH;
+
+        static constexpr bool SUPPORTS_SUBSAMPLING = false;
+
+        // Queries use a value of -1 for invalid indices
+        static_assert(std::is_signed_v<IndexType>, "Index type must be signed");
+        static_assert(MAX_DEPTH > 0, "Max depth must be strictly positive");
+
+        // Construction ------------------------------------------------------------
+    protected:
+        PONCA_MULTIARCH inline StaticKdTreeBase() = default;
+
+    public:
+        /*! \brief Constructor that allows the use of prebuilt KdTree containers.
+         *
+         * Each internal values of a KdTree can be extracted using \ref `KdTreeBase::buffers()`
+         *
+         * \note This constructor can be used to avoid the convertion and building process,
+         * which is useful to transfer directly the KdTree to the device in CUDA.
+         *
+         * \param buf Internal buffers of the KdTree
+         */
+        PONCA_MULTIARCH inline StaticKdTreeBase(Buffers& buf) : m_bufs(buf) {}
+
+        // Accessors ---------------------------------------------------------------
+    public:
+        //! \brief Get the number of nodes in the KdTree
+        PONCA_MULTIARCH [[nodiscard]] inline NodeIndexType nodeCount() const
+        {
+            return (NodeIndexType)m_bufs.nodes_size;
+        }
+
+        //! \brief Get the number of indices
+        PONCA_MULTIARCH [[nodiscard]] inline IndexType sampleCount() const { return (IndexType)m_bufs.indices_size; }
+
+        //! \brief Get the number of points
+        PONCA_MULTIARCH [[nodiscard]] inline IndexType pointCount() const { return (IndexType)m_bufs.points_size; }
+
+        //! \brief Get the number of leafs in the KdTree
+        PONCA_MULTIARCH [[nodiscard]] inline NodeIndexType leafCount() const { return m_leaf_count; }
+
+        //! \brief Get the internal point container
+        PONCA_MULTIARCH [[nodiscard]] inline PointContainer& points() { return m_bufs.points; };
+
+        //! \copybrief KdTreeBase::points
+        PONCA_MULTIARCH [[nodiscard]] inline const PointContainer& points() const { return m_bufs.points; };
+
+        //! \brief Get the internal node container
+        PONCA_MULTIARCH [[nodiscard]] inline const NodeContainer& nodes() const { return m_bufs.nodes; }
+
+        //! \brief Get the internal indice container
+        PONCA_MULTIARCH [[nodiscard]] inline const IndexContainer& samples() const { return m_bufs.indices; }
+
+        //! \brief Get access to the internal buffer, for instance to prepare GPU binding
+        PONCA_MULTIARCH [[nodiscard]] inline const Buffers& buffers() const { return m_bufs; }
+
+        // Parameters --------------------------------------------------------------
+    public:
+        /// Read leaf min size
+        PONCA_MULTIARCH [[nodiscard]] inline LeafSizeType minCellSize() const { return m_min_cell_size; }
+
+        /// Write leaf min size
+        PONCA_MULTIARCH inline void setMinCellSize(LeafSizeType min_cell_size)
+        {
+            PONCA_DEBUG_ASSERT(min_cell_size > 0);
+            m_min_cell_size = min_cell_size;
+        }
+
+        // Index mapping -----------------------------------------------------------
+    public:
+        /// Return the point index associated with the specified sample index
+        PONCA_MULTIARCH [[nodiscard]] inline IndexType pointFromSample(IndexType sample_index) const
+        {
+            return m_bufs.indices[sample_index];
+        }
+
+        /// Return the \ref DataPoint associated with the specified sample index
+        /// \note Convenience function, equivalent to
+        /// `point_data()[pointFromSample(sample_index)]`
+        PONCA_MULTIARCH [[nodiscard]] inline DataPoint& pointDataFromSample(IndexType sample_index)
+        {
+            return m_bufs.points[pointFromSample(sample_index)];
+        }
+
+        /// Return the \ref DataPoint associated with the specified sample index
+        /// \note Convenience function, equivalent to
+        /// `point_data()[pointFromSample(sample_index)]`
+        PONCA_MULTIARCH [[nodiscard]] inline const DataPoint& pointDataFromSample(IndexType sample_index) const
+        {
+            return m_bufs.points[pointFromSample(sample_index)];
+        }
+
+        // Query -------------------------------------------------------------------
+    public:
+        /// \brief Computes a Query object to iterate over the k-nearest neighbors of a point.
+        /// The returned object can be reset and reused with the () operator
+        /// (using the same argument types as parameters).
+        ///
+        /// \param point Point from where the query is evaluated
+        /// \param k Number of neighbors returned
+        /// \return The \ref KdTreeKNearestIndexQuery mutable object to iterate over the search results.
+        /// \see KdTreeKNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestPointQuery<Traits> kNearestNeighbors(const VectorType& point,
+                                                                                               IndexType k) const
+        {
+            return KdTreeKNearestPointQuery<Traits>(this, k, point);
+        }
+
+        /// \copybrief KdTreeBase::kNearestNeighbors
+        /// \param index Index of the point from where the query is evaluated
+        /// \param k Number of neighbors returned
+        /// \return The \ref KdTreeKNearestIndexQuery mutable object to iterate over the search results.
+        /// \see KdTreeKNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestIndexQuery<Traits> kNearestNeighbors(IndexType index,
+                                                                                               IndexType k) const
+        {
+            return KdTreeKNearestIndexQuery<Traits>(this, k, index);
+        }
+
+        /// \brief Convenience function that provides an empty k-nearest neighbors Query object.
+        ///
+        /// The returned object can call for a k-nearest neighbors search using the operator (),
+        /// which takes a k and a **position** as parameters.
+        ///
+        /// Same as `KdTreeBase::kNearestNeighbors (0, VectorType::Zero())`
+        /// \return The empty \ref KdTreeKNearestPointQuery mutable object to iterate over the search results.
+        /// \see KdTreeKNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestPointQuery<Traits> kNearestNeighborsQuery() const
+        {
+            return KdTreeKNearestPointQuery<Traits>(this, 0, VectorType::Zero());
+        }
+
+        /// \copybrief KdTreeBase::kNearestNeighborsQuery
+        ///
+        /// The returned object can call for a k-nearest neighbors search using the operator (),
+        /// which takes a k and an **index** as parameters.
+        ///
+        /// Same as `KdTreeBase::kNearestNeighbors (0, 0)`
+        /// \return The empty \ref KdTreeKNearestIndexQuery mutable object to iterate over the search results.
+        /// \see KdTreeKNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeKNearestIndexQuery<Traits> kNearestNeighborsIndexQuery() const
+        {
+            return KdTreeKNearestIndexQuery<Traits>(this, 0, 0);
+        }
+
+        /// \brief Computes a Query object that contains the nearest point.
+        /// The returned object can be reset and reused with the () operator
+        /// (using the same argument types as parameters).
+        ///
+        /// \param point Point from where the query is evaluated
+        /// \return The \ref KdTreeNearestPointQuery mutable object that contains the search result.
+        /// \see KdTreeNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeNearestPointQuery<Traits> nearestNeighbor(const VectorType& point) const
+        {
+            return KdTreeNearestPointQuery<Traits>(this, point);
+        }
+
+        /// \copybrief KdTreeBase::nearestNeighbor
+        /// \param index Index of the point from where the query is evaluated
+        /// \return The \ref KdTreeKNearestIndexQuery mutable object that contains the search result.
+        /// \see KdTreeNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeNearestIndexQuery<Traits> nearestNeighbor(IndexType index) const
+        {
+            return KdTreeNearestIndexQuery<Traits>(this, index);
+        }
+
+        /// \brief Convenience function that provides an empty nearest neighbor Query object.
+        ///
+        /// The returned object can call for a nearest neighbor search using the operator (),
+        /// which takes a **position** as parameter.
+        ///
+        /// Same as `KdTreeBase::nearestNeighbor (VectorType::Zero())`
+        ///
+        /// \return The empty \ref KdTreeNearestPointQuery mutable object that contains the search result.
+        /// \see KdTreeNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeNearestIndexQuery<Traits> nearestNeighborQuery() const
+        {
+            return KdTreeNearestIndexQuery<Traits>(this, VectorType::Zero());
+        }
+
+        /// \copybrief KdTreeBase::nearestNeighborQuery
+        ///
+        /// The returned object can call for a nearest neighbor search using the operator (),
+        /// which takes an **index** as parameter.
+        ///
+        /// Same as `KdTreeBase::nearestNeighbor (0)`
+        ///
+        /// \return The \ref KdTreeKNearestIndexQuery mutable object that contains the search result.
+        /// \see KdTreeNearestQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeNearestIndexQuery<Traits> nearestNeighborIndexQuery() const
+        {
+            return KdTreeNearestIndexQuery<Traits>(this, 0);
+        }
+
+        /// \brief Computes a Query object to iterate over the neighbors that are inside a given radius.
+        /// The returned object can be reset and reused with the () operator
+        /// (using the same argument types as parameters).
+        ///
+        /// \param point Point from where the query is evaluated
+        /// \param r Radius around where to search the neighbors
+        /// \return The \ref KdTreeRangePointQuery mutable object to iterate over the search results.
+        /// \see KdTreeRangeQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeRangePointQuery<Traits> rangeNeighbors(const VectorType& point,
+                                                                                         Scalar r) const
+        {
+            return KdTreeRangePointQuery<Traits>(this, r, point);
+        }
+
+        /// \copybrief KdTreeBase::rangeNeighbors
+        /// \param index Index of the point from where the query is evaluated
+        /// \param r Radius around where to search the neighbors
+        /// \return The \ref KdTreeRangeIndexQuery mutable object to iterate over the search results.
+        /// \see KdTreeRangeQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeRangeIndexQuery<Traits> rangeNeighbors(IndexType index, Scalar r) const
+        {
+            return KdTreeRangeIndexQuery<Traits>(this, r, index);
+        }
+
+        /// \brief Convenience function that provides an empty range neighbor Query object.
+        ///
+        /// The returned object can call for a range neighbor search using the operator (),
+        /// which takes a **position** as parameter.
+        ///
+        /// Same as `KdTreeBase::rangeNeighborsQuery (0, VectorType::Zero())`
+        ///
+        /// \return The empty \ref KdTreeRangePointQuery mutable object to iterate over the search results.
+        /// \see KdTreeRangeQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeRangePointQuery<Traits> rangeNeighborsQuery() const
+        {
+            return KdTreeRangePointQuery<Traits>(this, 0, VectorType::Zero());
+        }
+
+        /// \brief KdTreeBase::rangeNeighborsQuery
+        ///
+        /// The returned object can call for a range neighbor search using the operator (),
+        /// which takes an **index** as parameter.
+        ///
+        /// Same as `KdTreeBase::rangeNeighborsQuery (0, 0)`
+        ///
+        /// \return The empty \ref KdTreeRangeIndexQuery mutable object to iterate over the search results.
+        /// \see KdTreeRangeQueryBase
+        PONCA_MULTIARCH [[nodiscard]] KdTreeRangeIndexQuery<Traits> rangeNeighborsIndexQuery() const
+        {
+            return KdTreeRangeIndexQuery<Traits>(this, 0, 0);
+        }
+
+        // Utilities ---------------------------------------------------------------
+    public:
+        PONCA_MULTIARCH_HOST [[nodiscard]] inline bool valid() const;
+        PONCA_MULTIARCH_HOST inline void print(std::ostream& os, bool verbose = false) const;
+
+        // Data --------------------------------------------------------------------
+    protected:
+        Buffers m_bufs;                   ///< Buffers used to store the KdTree
+        LeafSizeType m_min_cell_size{64}; ///< Minimal number of points per leaf
+        NodeIndexType m_leaf_count{0};    ///< Number of leaves in the Kdtree (computed during construction)
+    };
+
+    /*! \copybrief StaticKdTreeBase
+     *
+     * Base kdtree class that implements the basic build functionalities of the KdTree.
+     * \see KdTreeBase::build
+     *
+     * This class is the basis for the KdTree Dense and Sparse type
+     * \see Ponca::KdTreeDense
+     * \see Ponca::KdTreeSparse
+     *
+     * \warning Variants of this class are not usable on a CUDA device,
+     * because it relies on STL-like internal containers to build the kdtree.
+     *
+     * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
+     * same interface as the default traits type.
+     * \see KdTreeDefaultTraits for the trait interface documentation.
+     */
+    template <typename Traits>
+    class KdTreeBase : public StaticKdTreeBase<Traits>
+    {
+    public:
+        using Base = StaticKdTreeBase<Traits>;
+        WRITE_TRAITS
+        /// Generate a tree from a custom contained type converted using the specified converter
+        /// \tparam PointUserContainer Input point container, transformed to PointContainer
+        /// \tparam PointConverter Cast/Convert input container type to point container data type
+        /// \param points Input points
+        /// \param c Cast/Convert input point type to DataType
+        template <typename PointUserContainer, typename PointConverter>
+        PONCA_MULTIARCH_HOST inline void build(PointUserContainer&& points, PointConverter c);
+
+        /// Convert a custom point container to the KdTree \ref PointContainer using \ref DataPoint default constructor
+        struct DefaultConverter
+        {
+            template <typename Input>
+            PONCA_MULTIARCH_HOST inline void operator()(Input&& i, PointContainer& o)
+            {
+                using InputContainer = std::remove_reference_t<Input>;
+                if constexpr (std::is_same_v<InputContainer, PointContainer> && std::is_copy_assignable_v<DataPoint>)
+                    o = std::forward<Input>(i); // Either move or copy
+                else
+                    std::transform(
+                        i.cbegin(), i.cend(), std::back_inserter(o),
+                        [](const typename InputContainer::value_type& p) -> DataPoint { return DataPoint(p); });
+            }
+        };
+
+        /// Generate a tree from a custom contained type converted using DefaultConverter
+        /// \tparam PointUserContainer Input point container, transformed to PointContainer
+        /// \param points Input points
+        template <typename PointUserContainer>
+        PONCA_MULTIARCH_HOST inline void build(PointUserContainer&& points)
+        {
+            build(std::forward<PointUserContainer>(points), DefaultConverter());
+        }
+
+        // Internal ----------------------------------------------------------------
+    protected:
+        /// Generate a tree sampled from a custom contained type converted using a `Converter`
+        /// \tparam PointUserContainer Input point, transformed to PointContainer
+        /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
+        /// \tparam PointConverter Cast/Convert input container type to point container data type
+        /// \param points Input points
+        /// \param sampling Indices of points used in the tree
+        /// \param c Cast/Convert input point type to DataType
+        template <typename PointUserContainer, typename IndexUserContainer, typename PointConverter>
+        PONCA_MULTIARCH_HOST inline void buildWithSampling(PointUserContainer&& points, IndexUserContainer&& sampling,
+                                                           PointConverter c);
+
+        /// Generate a tree sampled from a custom contained type converted using a \ref KdTreeBase::DefaultConverter
+        /// \tparam PointUserContainer Input points, transformed to PointContainer
+        /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
+        /// \param points Input points
+        /// \param sampling Samples used in the tree
+        template <typename PointUserContainer, typename IndexUserContainer>
+        PONCA_MULTIARCH_HOST inline void buildWithSampling(PointUserContainer&& points, IndexUserContainer&& sampling)
+        {
+            buildWithSampling(std::forward<PointUserContainer>(points), std::forward<IndexUserContainer>(sampling),
+                              DefaultConverter());
+        }
+
+    private:
+        PONCA_MULTIARCH_HOST inline void buildRec(NodeIndexType node_id, IndexType start, IndexType end, int level);
+        PONCA_MULTIARCH_HOST [[nodiscard]] inline IndexType partition(IndexType start, IndexType end, int dim,
+                                                                      Scalar value);
+    };
+
+    /*!
+     * \brief Customizable base class for dense KdTree datastructure
+     *
+     * \note This version of the KdTree does not support subsampling.
+     * For an implementation that supports subsampling, see \ref KdTreeSparseBase.
+     *
+     * \see Ponca::KdTreeDense
+     * \see Ponca::KdTreeSparse
+     *
+     * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
+     * same interface as the default traits type.
+     * \see KdTreeDefaultTraits for the trait interface documentation.
+     */
+    template <typename Traits>
+    class KdTreeDenseBase : public KdTreeBase<Traits>
+    {
+    private:
+        using Base = KdTreeBase<Traits>;
+
+    public:
+        /// Default constructor creating an empty tree
+        /// \see build
+        PONCA_MULTIARCH KdTreeDenseBase() = default;
+
+        /// Constructor generating a tree from a custom contained type converted using a \ref Traits::ContainerConverter
+        template <typename PointUserContainer>
+        PONCA_MULTIARCH_HOST inline explicit KdTreeDenseBase(PointUserContainer&& points) : Base()
+        {
+            Base::build(std::forward<PointUserContainer>(points));
         }
     };
 
-    /// Generate a tree from a custom contained type converted using DefaultConverter
-    /// \tparam PointUserContainer Input point container, transformed to PointContainer
-    /// \param points Input points
-    template<typename PointUserContainer>
-    PONCA_MULTIARCH_HOST inline void build(PointUserContainer&& points)
+    /*!
+     * \brief Customizable base class for KdTreeSparse datastructure
+     *
+     * \note This version of the KdTree supports construction using a subset of samples.
+     *
+     * \see buildWithSampling
+     * \see Ponca::KdTreeDense
+     * \see Ponca::KdTreeSparse
+     *
+     * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
+     * same interface as the default traits type.
+     * \see KdTreeDefaultTraits for the trait interface documentation.
+     */
+    template <typename Traits>
+    class KdTreeSparseBase : public KdTreeBase<Traits>
     {
-        build(std::forward<PointUserContainer>(points), DefaultConverter());
-    }
+    private:
+        using Base = KdTreeBase<Traits>;
 
-    // Internal ----------------------------------------------------------------
-protected:
-    /// Generate a tree sampled from a custom contained type converted using a `Converter`
-    /// \tparam PointUserContainer Input point, transformed to PointContainer
-    /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
-    /// \tparam PointConverter Cast/Convert input container type to point container data type
-    /// \param points Input points
-    /// \param sampling Indices of points used in the tree
-    /// \param c Cast/Convert input point type to DataType
-    template<typename PointUserContainer, typename IndexUserContainer, typename PointConverter>
-    PONCA_MULTIARCH_HOST inline void buildWithSampling(
-        PointUserContainer&& points,
-        IndexUserContainer&& sampling,
-        PointConverter c
-    );
+    public:
+        static constexpr bool SUPPORTS_SUBSAMPLING = true;
 
-    /// Generate a tree sampled from a custom contained type converted using a \ref KdTreeBase::DefaultConverter
-    /// \tparam PointUserContainer Input points, transformed to PointContainer
-    /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
-    /// \param points Input points
-    /// \param sampling Samples used in the tree
-    template<typename PointUserContainer, typename IndexUserContainer>
-    PONCA_MULTIARCH_HOST inline void buildWithSampling(PointUserContainer&& points, IndexUserContainer&& sampling)
-    {
-        buildWithSampling(std::forward<PointUserContainer>(points), std::forward<IndexUserContainer>(sampling), DefaultConverter());
-    }
+        /// Default constructor creating an empty tree
+        /// \see build
+        PONCA_MULTIARCH KdTreeSparseBase() = default;
 
-private:
-    PONCA_MULTIARCH_HOST inline void buildRec(NodeIndexType node_id, IndexType start, IndexType end, int level);
-    PONCA_MULTIARCH_HOST [[nodiscard]] inline IndexType partition(IndexType start, IndexType end, int dim, Scalar value);
+        /// Constructor generating a tree from a custom contained type converted using a \ref Traits::ContainerConverter
+        template <typename PointUserContainer>
+        PONCA_MULTIARCH_HOST inline explicit KdTreeSparseBase(PointUserContainer&& points) : Base()
+        {
+            this->build(std::forward<PointUserContainer>(points));
+        }
 
-};
+        /// Constructor generating a tree sampled from a custom contained type converted using a \ref
+        /// Traits::ContainerConverter
+        /// \tparam PointUserContainer Input points, transformed to PointContainer
+        /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
+        /// \param points Input points
+        /// \param sampling Samples used in the tree
+        template <typename PointUserContainer, typename IndexUserContainer>
+        PONCA_MULTIARCH_HOST inline KdTreeSparseBase(PointUserContainer&& points, IndexUserContainer sampling) : Base()
+        {
+            this->buildWithSampling(std::forward<PointUserContainer>(points), std::move(sampling));
+        }
 
-/*!
- * \brief Customizable base class for dense KdTree datastructure
- *
- * \note This version of the KdTree does not support subsampling.
- * For an implementation that supports subsampling, see \ref KdTreeSparseBase.
- *
- * \see Ponca::KdTreeDense
- * \see Ponca::KdTreeSparse
- *
- * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
- * same interface as the default traits type.
- * \see KdTreeDefaultTraits for the trait interface documentation.
- */
-template <typename Traits>
-class KdTreeDenseBase : public KdTreeBase<Traits>
-{
-private:
-    using Base = KdTreeBase<Traits>;
-
-public:
-    /// Default constructor creating an empty tree
-    /// \see build
-    PONCA_MULTIARCH KdTreeDenseBase() = default;
-
-    /// Constructor generating a tree from a custom contained type converted using a \ref Traits::ContainerConverter
-    template<typename PointUserContainer>
-    PONCA_MULTIARCH_HOST inline explicit KdTreeDenseBase(PointUserContainer&& points)
-        : Base()
-    {
-        Base::build(std::forward<PointUserContainer>(points));
-    }
-};
-
-/*!
- * \brief Customizable base class for KdTreeSparse datastructure
- *
- * \note This version of the KdTree supports construction using a subset of samples.
- *
- * \see buildWithSampling
- * \see Ponca::KdTreeDense
- * \see Ponca::KdTreeSparse
- *
- * \tparam Traits Traits type providing the types and constants used by the kd-tree. Must have the
- * same interface as the default traits type.
- * \see KdTreeDefaultTraits for the trait interface documentation.
- */
-template <typename Traits>
-class KdTreeSparseBase : public KdTreeBase<Traits>
-{
-private:
-    using Base = KdTreeBase<Traits>;
-
-public:
-    static constexpr bool SUPPORTS_SUBSAMPLING = true;
-
-    /// Default constructor creating an empty tree
-    /// \see build
-    PONCA_MULTIARCH KdTreeSparseBase() = default;
-
-    /// Constructor generating a tree from a custom contained type converted using a \ref Traits::ContainerConverter
-    template<typename PointUserContainer>
-    PONCA_MULTIARCH_HOST inline explicit KdTreeSparseBase(PointUserContainer&& points)
-        : Base()
-    {
-        this->build(std::forward<PointUserContainer>(points));
-    }
-
-    /// Constructor generating a tree sampled from a custom contained type converted using a \ref Traits::ContainerConverter
-    /// \tparam PointUserContainer Input points, transformed to PointContainer
-    /// \tparam IndexUserContainer Input sampling, transformed to IndexContainer
-    /// \param points Input points
-    /// \param sampling Samples used in the tree
-    template<typename PointUserContainer, typename IndexUserContainer>
-    PONCA_MULTIARCH_HOST inline KdTreeSparseBase(PointUserContainer&& points, IndexUserContainer sampling)
-        : Base()
-    {
-        this->buildWithSampling(std::forward<PointUserContainer>(points), std::move(sampling));
-    }
-
-    using Base::buildWithSampling;
-};
+        using Base::buildWithSampling;
+    };
 
 #include "./kdTree.hpp"
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -6,32 +6,32 @@
 
 // KdTree ----------------------------------------------------------------------
 
-template<typename Traits>
-template<typename PointUserContainer, typename PointConverter>
+template <typename Traits>
+template <typename PointUserContainer, typename PointConverter>
 PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::build(PointUserContainer&& points, PointConverter c)
 {
-    IndexContainer ids (points.size());
+    IndexContainer ids(points.size());
     std::iota(ids.begin(), ids.end(), IndexType(0));
     this->buildWithSampling(std::forward<PointUserContainer>(points), std::move(ids), std::move(c));
 }
 
-template<typename Traits>
+template <typename Traits>
 PONCA_MULTIARCH_HOST [[nodiscard]] inline bool StaticKdTreeBase<Traits>::valid() const
 {
     if (m_bufs.points_size == 0)
         return m_bufs.nodes_size == 0 && m_bufs.indices_size == 0;
 
-    if(m_bufs.nodes_size == 0 || m_bufs.indices_size == 0)
+    if (m_bufs.nodes_size == 0 || m_bufs.indices_size == 0)
     {
         std::cerr << "KdTree validation check failed in " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
         return false;
     }
 
     std::vector<bool> b(pointCount(), false);
-    for(unsigned int i = 0; i < sampleCount(); ++i)
+    for (unsigned int i = 0; i < sampleCount(); ++i)
     {
         const int idx = m_bufs.indices[i];
-        if(idx < 0 || pointCount() <= idx || b[idx])
+        if (idx < 0 || pointCount() <= idx || b[idx])
         {
             std::cerr << "KdTree validation check failed in " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
             return false;
@@ -39,12 +39,12 @@ PONCA_MULTIARCH_HOST [[nodiscard]] inline bool StaticKdTreeBase<Traits>::valid()
         b[idx] = true;
     }
 
-    for(NodeIndexType n=0;n<nodeCount();++n)
+    for (NodeIndexType n = 0; n < nodeCount(); ++n)
     {
         const NodeType& node = m_bufs.nodes[n];
-        if(node.is_leaf())
+        if (node.is_leaf())
         {
-            if(sampleCount() <= node.leaf_start() || node.leaf_start()+node.leaf_size() > sampleCount())
+            if (sampleCount() <= node.leaf_start() || node.leaf_start() + node.leaf_size() > sampleCount())
             {
                 std::cerr << "KdTree validation check failed in " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
                 return false;
@@ -52,12 +52,12 @@ PONCA_MULTIARCH_HOST [[nodiscard]] inline bool StaticKdTreeBase<Traits>::valid()
         }
         else
         {
-            if(node.inner_split_dim() < 0 || DataPoint::Dim-1 < node.inner_split_dim())
+            if (node.inner_split_dim() < 0 || DataPoint::Dim - 1 < node.inner_split_dim())
             {
                 std::cerr << "KdTree validation check failed in " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
                 return false;
             }
-            if(nodeCount() <= node.inner_first_child_id() || nodeCount() <= node.inner_first_child_id()+1)
+            if (nodeCount() <= node.inner_first_child_id() || nodeCount() <= node.inner_first_child_id() + 1)
             {
                 std::cerr << "KdTree validation check failed in " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
                 return false;
@@ -68,7 +68,7 @@ PONCA_MULTIARCH_HOST [[nodiscard]] inline bool StaticKdTreeBase<Traits>::valid()
     return true;
 }
 
-template<typename Traits>
+template <typename Traits>
 PONCA_MULTIARCH_HOST inline void StaticKdTreeBase<Traits>::print(std::ostream& os, bool verbose) const
 {
     os << "KdTree:";
@@ -113,11 +113,11 @@ PONCA_MULTIARCH_HOST inline void StaticKdTreeBase<Traits>::print(std::ostream& o
     }
 }
 
-template<typename Traits>
-template<typename PointUserContainer, typename IndexUserContainer, typename PointConverter>
-PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildWithSampling(
-    PointUserContainer&& points, IndexUserContainer&& sampling, PointConverter c
-) {
+template <typename Traits>
+template <typename PointUserContainer, typename IndexUserContainer, typename PointConverter>
+PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildWithSampling(PointUserContainer&& points,
+                                                                       IndexUserContainer&& sampling, PointConverter c)
+{
     PONCA_DEBUG_ASSERT(static_cast<IndexType>(Base::pointCount()) <= Base::MAX_POINT_COUNT);
     Base::m_leaf_count = 0;
 
@@ -132,27 +132,26 @@ PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildWithSampling(
     Base::m_bufs.nodes.emplace_back();
 
     this->buildRec(0, 0, Base::sampleCount(), 1);
-    Base::m_bufs.nodes_size   = Base::m_bufs.nodes.size();
+    Base::m_bufs.nodes_size = Base::m_bufs.nodes.size();
 
     PONCA_DEBUG_ASSERT(this->valid());
 }
 
-template<typename Traits>
-PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildRec(NodeIndexType node_id, IndexType start, IndexType end, int level)
+template <typename Traits>
+PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildRec(NodeIndexType node_id, IndexType start, IndexType end,
+                                                              int level)
 {
     NodeType& node = Base::m_bufs.nodes[node_id];
     AabbType aabb;
-    for(IndexType i=start; i<end; ++i)
+    for (IndexType i = start; i < end; ++i)
         aabb.extend(Base::m_bufs.points[Base::m_bufs.indices[i]].pos());
 
-    node.set_is_leaf(
-        end-start <= Base::m_min_cell_size ||
-        level >= Traits::MAX_DEPTH ||
-        // Since we add 2 nodes per inner node we need to stop if we can't add
-        // them both
-        static_cast<NodeIndexType>(Base::m_bufs.nodes.size()) > Base::MAX_NODE_COUNT - 2);
+    node.set_is_leaf(end - start <= Base::m_min_cell_size || level >= Traits::MAX_DEPTH ||
+                     // Since we add 2 nodes per inner node we need to stop if we can't add
+                     // them both
+                     static_cast<NodeIndexType>(Base::m_bufs.nodes.size()) > Base::MAX_NODE_COUNT - 2);
 
-    node.configure_range(start, end-start, aabb);
+    node.configure_range(start, end - start, aabb);
     if (node.is_leaf())
     {
         ++Base::m_leaf_count;
@@ -166,23 +165,21 @@ PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildRec(NodeIndexType node
         Base::m_bufs.nodes.emplace_back();
 
         IndexType mid_id = this->partition(start, end, split_dim, node.inner_split_value());
-        buildRec(node.inner_first_child_id(), start, mid_id, level+1);
-        buildRec(node.inner_first_child_id()+1, mid_id, end, level+1);
+        buildRec(node.inner_first_child_id(), start, mid_id, level + 1);
+        buildRec(node.inner_first_child_id() + 1, mid_id, end, level + 1);
     }
 }
 
-template<typename Traits>
-PONCA_MULTIARCH_HOST [[nodiscard]] inline auto KdTreeBase<Traits>::partition(IndexType start, IndexType end, int dim, Scalar value)
-    -> IndexType
+template <typename Traits>
+PONCA_MULTIARCH_HOST [[nodiscard]] inline auto KdTreeBase<Traits>::partition(IndexType start, IndexType end, int dim,
+                                                                             Scalar value) -> IndexType
 {
     const auto& points = Base::m_bufs.points;
-    
-    auto it = std::partition(std::begin(Base::m_bufs.indices)+start, std::begin(Base::m_bufs.indices)+end, [&](IndexType i)
-    {
-        return points[i].pos()[dim] < value;
-    });
+
+    auto it = std::partition(std::begin(Base::m_bufs.indices) + start, std::begin(Base::m_bufs.indices) + end,
+                             [&](IndexType i) { return points[i].pos()[dim] < value; });
 
     auto distance = std::distance(std::begin(Base::m_bufs.indices), it);
-    
+
     return static_cast<IndexType>(distance);
 }

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTreeTraits.h
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 #pragma once
 
 #include "../defines.h"
@@ -14,144 +13,128 @@
 
 #include <Eigen/Geometry>
 
-namespace Ponca {
+namespace Ponca
+{
 #ifndef PARSED_WITH_DOXYGEN
-namespace internal
-{
-    constexpr int clz(unsigned int value)
+    namespace internal
     {
-#if PONCA_HAS_BUILTIN_CLZ
-        return __builtin_clz(value);
-#else
-        if (value == 0)
+        constexpr int clz(unsigned int value)
         {
-            return 0;
-        }
+#    if PONCA_HAS_BUILTIN_CLZ
+            return __builtin_clz(value);
+#    else
+            if (value == 0)
+            {
+                return 0;
+            }
 
-        unsigned int msb_mask = 1 << (sizeof(unsigned int)*8 - 1);
-        int count = 0;
-        for (; (value & msb_mask) == 0; value <<= 1, ++count)
-        {
+            unsigned int msb_mask = 1 << (sizeof(unsigned int) * 8 - 1);
+            int count             = 0;
+            for (; (value & msb_mask) == 0; value <<= 1, ++count)
+            {
+            }
+            return count;
+#    endif
         }
-        return count;
-#endif
-    }
-}
+    } // namespace internal
 #endif
 
-template <typename NodeIndex, typename Scalar, int DIM>
-struct KdTreeDefaultInnerNode
-{
-private:
-    enum
+    template <typename NodeIndex, typename Scalar, int DIM>
+    struct KdTreeDefaultInnerNode
     {
-        // The minimum bit width required to store the split dimension.
-        // 
-        // Equal to the index of DIM's most significant bit (starting at 1), e.g.:
-        // With DIM = 4,
-        //             -------------
-        // DIM =    0b | 1 | 0 | 0 |
-        //             -------------
-        // Bit index =  #3  #2  #1
-        // 
-        // The MSB has an index of 3, so we store the dimension on 3 bits.
-        DIM_BITS = sizeof(unsigned int)*8 - internal::clz((unsigned int)DIM),
+    private:
+        enum
+        {
+            // The minimum bit width required to store the split dimension.
+            //
+            // Equal to the index of DIM's most significant bit (starting at 1), e.g.:
+            // With DIM = 4,
+            //             -------------
+            // DIM =    0b | 1 | 0 | 0 |
+            //             -------------
+            // Bit index =  #3  #2  #1
+            //
+            // The MSB has an index of 3, so we store the dimension on 3 bits.
+            DIM_BITS = sizeof(unsigned int) * 8 - internal::clz((unsigned int)DIM),
+        };
+
+        // The node stores bitfields as unsigned indices.
+        using UIndex = typename std::make_unsigned<NodeIndex>::type;
+
+    public:
+        enum
+        {
+            /*!
+             * \brief The bit width used to store the first child index.
+             */
+            INDEX_BITS = sizeof(UIndex) * 8 - DIM_BITS,
+        };
+
+        Scalar split_value{0};
+        UIndex first_child_id : INDEX_BITS;
+        UIndex split_dim : DIM_BITS;
     };
 
-    // The node stores bitfields as unsigned indices.
-    using UIndex = typename std::make_unsigned<NodeIndex>::type;
-
-public:
-    enum
+    template <typename Index, typename Size>
+    struct KdTreeDefaultLeafNode
     {
-        /*!
-         * \brief The bit width used to store the first child index.
-         */
-        INDEX_BITS = sizeof(UIndex)*8 - DIM_BITS,
-    };
-
-    Scalar split_value{0};
-    UIndex first_child_id : INDEX_BITS;
-    UIndex split_dim : DIM_BITS;
-};
-
-template <typename Index, typename Size>
-struct KdTreeDefaultLeafNode
-{
-    Index start{0};
-    Size size{0};
-};
-
-/*!
- * \brief The node type used by default by the kd-tree.
- *
- * It is possible to modify the Inner and Leaf node types by inheritance. For instance, to add a Bounding box to inner
- * nodes, define a custom inner node type:
- *
- * \snippet ponca_customize_kdtree.cpp CustomInnerNodeDefinition
- *
- * Define a custom node type to use it, and expose custom data (inner/leaf node are not exposed directly):
- *
- * \snippet ponca_customize_kdtree.cpp CustomNodeDefinition
- *
- * To use in the KdTree, define a type using the custom node:
- *
- * \snippet ponca_customize_kdtree.cpp KdTreeTypeWithCustomNode
- *
- * The added attribute can be accessed
- *
- * \snippet ponca_customize_kdtree.cpp ReadCustomProperties
- *
- */
-template <typename Index, typename NodeIndex, typename DataPoint,
-          typename LeafSize = Index,
-          typename _InnerNodeType = KdTreeDefaultInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>,
-          typename _LeafNodeType = KdTreeDefaultLeafNode<Index, LeafSize>>
-class KdTreeCustomizableNode
-{
-private:
-    using Scalar    = typename DataPoint::Scalar;
-    using InnerType = _InnerNodeType;
-    using LeafType  = _LeafNodeType;
-
-public:
-    enum : std::size_t
-    {
-        /*!
-         * \brief The maximum number of nodes that a kd-tree can have when using
-         * this node type.
-         */
-        MAX_COUNT = std::size_t(2) << InnerType::INDEX_BITS,
+        Index start{0};
+        Size size{0};
     };
 
     /*!
-     * \brief The type used to store node bounding boxes.
+     * \brief The node type used by default by the kd-tree.
      *
-     * Must provide `diagonal()`, and `center()` functions, all returning a
-     * `DataPoint::VectorType`.
+     * It is possible to modify the Inner and Leaf node types by inheritance. For instance, to add a Bounding box to
+     * inner nodes, define a custom inner node type:
+     *
+     * \snippet ponca_customize_kdtree.cpp CustomInnerNodeDefinition
+     *
+     * Define a custom node type to use it, and expose custom data (inner/leaf node are not exposed directly):
+     *
+     * \snippet ponca_customize_kdtree.cpp CustomNodeDefinition
+     *
+     * To use in the KdTree, define a type using the custom node:
+     *
+     * \snippet ponca_customize_kdtree.cpp KdTreeTypeWithCustomNode
+     *
+     * The added attribute can be accessed
+     *
+     * \snippet ponca_customize_kdtree.cpp ReadCustomProperties
+     *
      */
-    using AabbType = Eigen::AlignedBox<Scalar, DataPoint::Dim>;
-
-    PONCA_MULTIARCH KdTreeCustomizableNode() = default;
-
-    PONCA_MULTIARCH constexpr KdTreeCustomizableNode(KdTreeCustomizableNode&& n)
-        : m_is_leaf(n.m_is_leaf)
+    template <typename Index, typename NodeIndex, typename DataPoint, typename LeafSize = Index,
+              typename _InnerNodeType = KdTreeDefaultInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>,
+              typename _LeafNodeType  = KdTreeDefaultLeafNode<Index, LeafSize>>
+    class KdTreeCustomizableNode
     {
-        if (m_is_leaf)
-        {
-            data.m_leaf = n.data.m_leaf;
-        }
-        else
-        {
-            data.m_inner = n.data.m_inner;
-        }
-    }
+    private:
+        using Scalar    = typename DataPoint::Scalar;
+        using InnerType = _InnerNodeType;
+        using LeafType  = _LeafNodeType;
 
-    PONCA_MULTIARCH constexpr KdTreeCustomizableNode& operator=(KdTreeCustomizableNode&& n)
-    {
-        if (&n != this)
+    public:
+        enum : std::size_t
         {
-            m_is_leaf = n.m_is_leaf;
+            /*!
+             * \brief The maximum number of nodes that a kd-tree can have when using
+             * this node type.
+             */
+            MAX_COUNT = std::size_t(2) << InnerType::INDEX_BITS,
+        };
+
+        /*!
+         * \brief The type used to store node bounding boxes.
+         *
+         * Must provide `diagonal()`, and `center()` functions, all returning a
+         * `DataPoint::VectorType`.
+         */
+        using AabbType = Eigen::AlignedBox<Scalar, DataPoint::Dim>;
+
+        PONCA_MULTIARCH KdTreeCustomizableNode() = default;
+
+        PONCA_MULTIARCH constexpr KdTreeCustomizableNode(KdTreeCustomizableNode&& n) : m_is_leaf(n.m_is_leaf)
+        {
             if (m_is_leaf)
             {
                 data.m_leaf = n.data.m_leaf;
@@ -162,27 +145,26 @@ public:
             }
         }
 
-        return *this;
-    }
+        PONCA_MULTIARCH constexpr KdTreeCustomizableNode& operator=(KdTreeCustomizableNode&& n)
+        {
+            if (&n != this)
+            {
+                m_is_leaf = n.m_is_leaf;
+                if (m_is_leaf)
+                {
+                    data.m_leaf = n.data.m_leaf;
+                }
+                else
+                {
+                    data.m_inner = n.data.m_inner;
+                }
+            }
 
-    PONCA_MULTIARCH constexpr KdTreeCustomizableNode(const KdTreeCustomizableNode& n)
-        : m_is_leaf(n.m_is_leaf)
-    {
-        if (n.m_is_leaf)
-        {
-            data.m_leaf = n.data.m_leaf;
+            return *this;
         }
-        else
-        {
-            data.m_inner = n.data.m_inner;
-        }
-    }
 
-    PONCA_MULTIARCH constexpr KdTreeCustomizableNode& operator=(const KdTreeCustomizableNode& n)
-    {
-        if (&n != this)
+        PONCA_MULTIARCH constexpr KdTreeCustomizableNode(const KdTreeCustomizableNode& n) : m_is_leaf(n.m_is_leaf)
         {
-            m_is_leaf = n.m_is_leaf;
             if (n.m_is_leaf)
             {
                 data.m_leaf = n.data.m_leaf;
@@ -193,200 +175,211 @@ public:
             }
         }
 
-        return *this;
-    }
-
-    PONCA_MULTIARCH_HOST ~KdTreeCustomizableNode() {}
-    
-    PONCA_MULTIARCH [[nodiscard]] bool is_leaf() const { return m_is_leaf; }
-    PONCA_MULTIARCH void set_is_leaf(bool is_leaf) { m_is_leaf = is_leaf; }
-
-    /*!
-     * \brief Configures the range of the node in the sample index array of the
-     * kd-tree.
-     *
-     * \see the leaf node accessors for a more detailed explanation of each
-     * argument.
-     *
-     * \note The AABB is not required by the implementation, so nodes don't
-     * have to make it available.
-     *
-     * Called after \ref set_is_leaf during kd-tree construction.
-     */
-    PONCA_MULTIARCH void configure_range(Index start, Index size, const AabbType &aabb)
-    {
-        if (m_is_leaf)
+        PONCA_MULTIARCH constexpr KdTreeCustomizableNode& operator=(const KdTreeCustomizableNode& n)
         {
-            data.m_leaf.start = start;
-            data.m_leaf.size = (LeafSize)size;
-        }
-    }
+            if (&n != this)
+            {
+                m_is_leaf = n.m_is_leaf;
+                if (n.m_is_leaf)
+                {
+                    data.m_leaf = n.data.m_leaf;
+                }
+                else
+                {
+                    data.m_inner = n.data.m_inner;
+                }
+            }
 
-    /*!
-     * \brief Configures the inner node information.
-     *
-     * \see the inner node accessors for a more detailed explanation of each
-     * argument.
-     *
-     * Called after \ref set_is_leaf and \ref configure_range during kd-tree
-     * construction.
-     */
-    PONCA_MULTIARCH void configure_inner(Scalar split_value, Index first_child_id, Index split_dim)
-    {
-        if (!m_is_leaf)
+            return *this;
+        }
+
+        PONCA_MULTIARCH_HOST ~KdTreeCustomizableNode() {}
+
+        PONCA_MULTIARCH [[nodiscard]] bool is_leaf() const { return m_is_leaf; }
+        PONCA_MULTIARCH void set_is_leaf(bool is_leaf) { m_is_leaf = is_leaf; }
+
+        /*!
+         * \brief Configures the range of the node in the sample index array of the
+         * kd-tree.
+         *
+         * \see the leaf node accessors for a more detailed explanation of each
+         * argument.
+         *
+         * \note The AABB is not required by the implementation, so nodes don't
+         * have to make it available.
+         *
+         * Called after \ref set_is_leaf during kd-tree construction.
+         */
+        PONCA_MULTIARCH void configure_range(Index start, Index size, const AabbType& aabb)
         {
-            data.m_inner.split_value = split_value;
-            data.m_inner.first_child_id = first_child_id;
-            data.m_inner.split_dim = split_dim;
+            if (m_is_leaf)
+            {
+                data.m_leaf.start = start;
+                data.m_leaf.size  = (LeafSize)size;
+            }
         }
-    }
 
-    /*!
-     * \brief The start index of the range of the leaf node in the sample
-     * index array.
-     */
-    PONCA_MULTIARCH [[nodiscard]] Index leaf_start() const { return data.m_leaf.start; }
-
-    /*!
-     * \brief The size of the range of the leaf node in the sample index array.
-     */
-    PONCA_MULTIARCH [[nodiscard]] LeafSize leaf_size() const { return data.m_leaf.size; }
-
-    /*!
-     * \brief The position of the AABB split of the inner node.
-     */
-    PONCA_MULTIARCH [[nodiscard]] Scalar inner_split_value() const { return data.m_inner.split_value; }
-    
-    /*!
-     * \brief Which axis the split of the AABB of the inner node was done on.
-     */
-    PONCA_MULTIARCH [[nodiscard]] int inner_split_dim() const { return (int)data.m_inner.split_dim; }
-    
-    /*!
-     * \brief The index of the first child of the node in the node array of the
-     * kd-tree.
-     *
-     * \note The second child is stored directly after the first in the array
-     * (i.e. `first_child_id + 1`).
-     */
-    PONCA_MULTIARCH [[nodiscard]] Index inner_first_child_id() const { return (Index)data.m_inner.first_child_id; }
-
-protected:
-    PONCA_MULTIARCH [[nodiscard]] inline LeafType& getAsLeaf() { return data.m_leaf; }
-    PONCA_MULTIARCH [[nodiscard]] inline InnerType& getAsInner() { return data.m_inner; }
-    PONCA_MULTIARCH [[nodiscard]] inline const LeafType& getAsLeaf() const { return data.m_leaf; }
-    PONCA_MULTIARCH [[nodiscard]] inline const InnerType& getAsInner() const { return data.m_inner; }
-
-private:
-    bool m_is_leaf{true};
-    union Data
-    {
-        // We need an explicit constructor here, see https://stackoverflow.com/a/70428826
-        constexpr Data() : m_leaf() {}
-
-        ~Data() {}
-        LeafType m_leaf;
-        InnerType m_inner;
-    };
-    Data data;
-};
-
-template <typename Index, typename NodeIndex, typename DataPoint,
-        typename LeafSize = Index>
-struct KdTreeDefaultNode : public KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
-        KdTreeDefaultInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>,
-        KdTreeDefaultLeafNode<Index, LeafSize>> {
-    using Base =  KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
-            KdTreeDefaultInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>,
-            KdTreeDefaultLeafNode<Index, LeafSize>>;
-};
-
-/*!
- * \brief The default traits type used by the kd-tree.
- *
- * \see KdTreeCustomizableNode Helper class to modify Inner/Leaf nodes without redefining a Trait class
- *
- * \tparam _NodeType Type used to store nodes, set by default to #KdTreeDefaultNode
- */
-template <typename _DataPoint,
-        template <typename /*Index*/,
-                  typename /*NodeIndex*/,
-                  typename /*DataPoint*/,
-                  typename /*LeafSize*/> typename _NodeType = KdTreeDefaultNode>
-struct KdTreeDefaultTraits
-{
-    enum
-    {
         /*!
-         * \brief A compile-time constant specifying the maximum depth of the kd-tree.
+         * \brief Configures the inner node information.
+         *
+         * \see the inner node accessors for a more detailed explanation of each
+         * argument.
+         *
+         * Called after \ref set_is_leaf and \ref configure_range during kd-tree
+         * construction.
          */
-        MAX_DEPTH = 32,
-    };
+        PONCA_MULTIARCH void configure_inner(Scalar split_value, Index first_child_id, Index split_dim)
+        {
+            if (!m_is_leaf)
+            {
+                data.m_inner.split_value    = split_value;
+                data.m_inner.first_child_id = first_child_id;
+                data.m_inner.split_dim      = split_dim;
+            }
+        }
 
-    /*!
-     * \brief The type used to store point data.
-     *
-     * Must provide `Scalar` and `VectorType` typedefs.
-     *
-     * `VectorType` must provide a `squaredNorm()` function returning a `Scalar`, as well as a
-     * `maxCoeff(int*)` function returning the dimension index of its largest scalar in its output
-     * parameter (e.g. 0 for *x*, 1 for *y*, etc.).
-     */
-    using DataPoint    = _DataPoint;
-    using IndexType    = int;
-    using LeafSizeType = unsigned short;
-
-    // Containers
-    using PointContainer = std::vector<DataPoint>;
-    using IndexContainer = std::vector<IndexType>;
-
-    // Nodes
-    using NodeIndexType = std::size_t;
-    using NodeType      = _NodeType<IndexType, NodeIndexType, DataPoint, LeafSizeType>;
-    using NodeContainer = std::vector<NodeType>;
-};
-
-/*! \brief Variant to the KdTree Traits type that uses pointers as internal storage instead of an STL-like container.
- *
- * \see KdTreeCustomizableNode Helper class to modify Inner/Leaf nodes without redefining a Trait class
- *
- * \tparam _NodeType Type used to store nodes, set by default to #KdTreeDefaultNode
- */
-template <typename _DataPoint,
-        template <typename /*Index*/,
-                  typename /*NodeIndex*/,
-                  typename /*DataPoint*/,
-                  typename /*LeafSize*/> typename _NodeType = Ponca::KdTreeDefaultNode>
-struct KdTreePointerTraits
-{
-    enum
-    {
         /*!
-         * \brief A compile-time constant specifying the maximum depth of the kd-tree.
+         * \brief The start index of the range of the leaf node in the sample
+         * index array.
          */
-        MAX_DEPTH = 32,
+        PONCA_MULTIARCH [[nodiscard]] Index leaf_start() const { return data.m_leaf.start; }
+
+        /*!
+         * \brief The size of the range of the leaf node in the sample index array.
+         */
+        PONCA_MULTIARCH [[nodiscard]] LeafSize leaf_size() const { return data.m_leaf.size; }
+
+        /*!
+         * \brief The position of the AABB split of the inner node.
+         */
+        PONCA_MULTIARCH [[nodiscard]] Scalar inner_split_value() const { return data.m_inner.split_value; }
+
+        /*!
+         * \brief Which axis the split of the AABB of the inner node was done on.
+         */
+        PONCA_MULTIARCH [[nodiscard]] int inner_split_dim() const { return (int)data.m_inner.split_dim; }
+
+        /*!
+         * \brief The index of the first child of the node in the node array of the
+         * kd-tree.
+         *
+         * \note The second child is stored directly after the first in the array
+         * (i.e. `first_child_id + 1`).
+         */
+        PONCA_MULTIARCH [[nodiscard]] Index inner_first_child_id() const { return (Index)data.m_inner.first_child_id; }
+
+    protected:
+        PONCA_MULTIARCH [[nodiscard]] inline LeafType& getAsLeaf() { return data.m_leaf; }
+        PONCA_MULTIARCH [[nodiscard]] inline InnerType& getAsInner() { return data.m_inner; }
+        PONCA_MULTIARCH [[nodiscard]] inline const LeafType& getAsLeaf() const { return data.m_leaf; }
+        PONCA_MULTIARCH [[nodiscard]] inline const InnerType& getAsInner() const { return data.m_inner; }
+
+    private:
+        bool m_is_leaf{true};
+        union Data {
+            // We need an explicit constructor here, see https://stackoverflow.com/a/70428826
+            constexpr Data() : m_leaf() {}
+
+            ~Data() {}
+            LeafType m_leaf;
+            InnerType m_inner;
+        };
+        Data data;
+    };
+
+    template <typename Index, typename NodeIndex, typename DataPoint, typename LeafSize = Index>
+    struct KdTreeDefaultNode
+        : public KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
+                                        KdTreeDefaultInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>,
+                                        KdTreeDefaultLeafNode<Index, LeafSize>>
+    {
+        using Base =
+            KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
+                                   KdTreeDefaultInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>,
+                                   KdTreeDefaultLeafNode<Index, LeafSize>>;
     };
 
     /*!
-     * \brief The type used to store point data.
+     * \brief The default traits type used by the kd-tree.
      *
-     * Must provide `Scalar` and `VectorType` typedefs.
+     * \see KdTreeCustomizableNode Helper class to modify Inner/Leaf nodes without redefining a Trait class
      *
-     * `VectorType` must provide a `squaredNorm()` function returning a `Scalar`, as well as a
-     * `maxCoeff(int*)` function returning the dimension index of its largest scalar in its output
-     * parameter (e.g. 0 for *x*, 1 for *y*, etc.).
+     * \tparam _NodeType Type used to store nodes, set by default to #KdTreeDefaultNode
      */
-    using DataPoint    = _DataPoint;
-    using IndexType    = int;
-    using LeafSizeType = unsigned short;
+    template <typename _DataPoint, template <typename /*Index*/, typename /*NodeIndex*/, typename /*DataPoint*/,
+                                             typename /*LeafSize*/> typename _NodeType = KdTreeDefaultNode>
+    struct KdTreeDefaultTraits
+    {
+        enum
+        {
+            /*!
+             * \brief A compile-time constant specifying the maximum depth of the kd-tree.
+             */
+            MAX_DEPTH = 32,
+        };
 
-    // Containers
-    using PointContainer = DataPoint*;
-    using IndexContainer = IndexType*;
+        /*!
+         * \brief The type used to store point data.
+         *
+         * Must provide `Scalar` and `VectorType` typedefs.
+         *
+         * `VectorType` must provide a `squaredNorm()` function returning a `Scalar`, as well as a
+         * `maxCoeff(int*)` function returning the dimension index of its largest scalar in its output
+         * parameter (e.g. 0 for *x*, 1 for *y*, etc.).
+         */
+        using DataPoint    = _DataPoint;
+        using IndexType    = int;
+        using LeafSizeType = unsigned short;
 
-    // Nodes
-    using NodeIndexType = std::size_t;
-    using NodeType      = _NodeType<IndexType, NodeIndexType, DataPoint, LeafSizeType>;
-    using NodeContainer = NodeType*;
-};
+        // Containers
+        using PointContainer = std::vector<DataPoint>;
+        using IndexContainer = std::vector<IndexType>;
+
+        // Nodes
+        using NodeIndexType = std::size_t;
+        using NodeType      = _NodeType<IndexType, NodeIndexType, DataPoint, LeafSizeType>;
+        using NodeContainer = std::vector<NodeType>;
+    };
+
+    /*! \brief Variant to the KdTree Traits type that uses pointers as internal storage instead of an STL-like
+     * container.
+     *
+     * \see KdTreeCustomizableNode Helper class to modify Inner/Leaf nodes without redefining a Trait class
+     *
+     * \tparam _NodeType Type used to store nodes, set by default to #KdTreeDefaultNode
+     */
+    template <typename _DataPoint, template <typename /*Index*/, typename /*NodeIndex*/, typename /*DataPoint*/,
+                                             typename /*LeafSize*/> typename _NodeType = Ponca::KdTreeDefaultNode>
+    struct KdTreePointerTraits
+    {
+        enum
+        {
+            /*!
+             * \brief A compile-time constant specifying the maximum depth of the kd-tree.
+             */
+            MAX_DEPTH = 32,
+        };
+
+        /*!
+         * \brief The type used to store point data.
+         *
+         * Must provide `Scalar` and `VectorType` typedefs.
+         *
+         * `VectorType` must provide a `squaredNorm()` function returning a `Scalar`, as well as a
+         * `maxCoeff(int*)` function returning the dimension index of its largest scalar in its output
+         * parameter (e.g. 0 for *x*, 1 for *y*, etc.).
+         */
+        using DataPoint    = _DataPoint;
+        using IndexType    = int;
+        using LeafSizeType = unsigned short;
+
+        // Containers
+        using PointContainer = DataPoint*;
+        using IndexContainer = IndexType*;
+
+        // Nodes
+        using NodeIndexType = std::size_t;
+        using NodeType      = _NodeType<IndexType, NodeIndexType, DataPoint, LeafSizeType>;
+        using NodeContainer = NodeType*;
+    };
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KnnGraph/Iterator/knnGraphRangeIterator.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/Iterator/knnGraphRangeIterator.h
@@ -8,70 +8,70 @@
 
 #include <cstddef>
 
-namespace Ponca {
-
-template <typename Traits>
-class KnnGraphRangeQuery;
-
-/*!
- *  \brief Input iterator to read the `KnnGraphRangeQuery` object.
- *
- *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
- *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator functionalities,
- *  you should copy the index values in an STL-like container.
- *
- *  \warning This iterator object should never be duplicated, as it is a proxy that holds a reference to the actual data :
- *  The copy of this iterator would still point to the same KnnGraph reference.
- *  So, if the increment operator is used on the iterator, the duplicate will also have its state updated.
- *  If we then call the increment operator on the duplicate, the result will be an incorrect value.
- *
- *  \see KnnGraphRangeQuery
- */
-template <typename Traits>
-class KnnGraphRangeIterator
+namespace Ponca
 {
-protected:
-    friend class KnnGraphRangeQuery<Traits>;
-    using Index  = typename Traits::IndexType;
-public:
-    // Tagged as an input iterator, because the increment logic is shared between iterators of the same queries.
-    // Which makes the iterator not valid when duplicated (through postfix increment for example).
-    using iterator_category = std::input_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
-    using value_type = Index;
-    using pointer    = Index*;
-    using reference  = const Index&;
 
-    inline KnnGraphRangeIterator(KnnGraphRangeQuery<Traits>* query, Index index = Index(-1)) : m_query(query), m_index(index) {}
+    template <typename Traits>
+    class KnnGraphRangeQuery;
 
-public:
-    /// \brief Inequality operand
-    bool operator != (const KnnGraphRangeIterator& other) const{
-        return m_index != other.m_index;
-    }
+    /*!
+     *  \brief Input iterator to read the `KnnGraphRangeQuery` object.
+     *
+     *  As this is an input iterator, we don't guarantee anything other than reading the values with it.
+     *  If you need to operate on the values of this iterator with algorithms that relies on forward iterator
+     * functionalities, you should copy the index values in an STL-like container.
+     *
+     *  \warning This iterator object should never be duplicated, as it is a proxy that holds a reference to the actual
+     * data : The copy of this iterator would still point to the same KnnGraph reference. So, if the increment operator
+     * is used on the iterator, the duplicate will also have its state updated. If we then call the increment operator
+     * on the duplicate, the result will be an incorrect value.
+     *
+     *  \see KnnGraphRangeQuery
+     */
+    template <typename Traits>
+    class KnnGraphRangeIterator
+    {
+    protected:
+        friend class KnnGraphRangeQuery<Traits>;
+        using Index = typename Traits::IndexType;
 
-    /// \brief Equality operand
-    bool operator == (const KnnGraphRangeIterator& other) const {
-        return m_index == other.m_index;
-    }
+    public:
+        // Tagged as an input iterator, because the increment logic is shared between iterators of the same queries.
+        // Which makes the iterator not valid when duplicated (through postfix increment for example).
+        using iterator_category = std::input_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Index;
+        using pointer           = Index*;
+        using reference         = const Index&;
 
-    /// Prefix increment
-    inline KnnGraphRangeIterator& operator ++ (){
-        m_query->advance(*this);
-        return *this;
-    }
+        inline KnnGraphRangeIterator(KnnGraphRangeQuery<Traits>* query, Index index = Index(-1))
+            : m_query(query), m_index(index)
+        {
+        }
 
-    /// \brief Postfix increment
-    inline void operator++(value_type) { ++*this; }
+    public:
+        /// \brief Inequality operand
+        bool operator!=(const KnnGraphRangeIterator& other) const { return m_index != other.m_index; }
 
-    /// \brief Dereference operator
-    inline reference operator *() const {
-        return const_cast<reference>(m_index);
-    }
+        /// \brief Equality operand
+        bool operator==(const KnnGraphRangeIterator& other) const { return m_index == other.m_index; }
 
-protected:
-    KnnGraphRangeQuery<Traits>* m_query {nullptr};
-    value_type m_index {-1};
-};
+        /// Prefix increment
+        inline KnnGraphRangeIterator& operator++()
+        {
+            m_query->advance(*this);
+            return *this;
+        }
+
+        /// \brief Postfix increment
+        inline void operator++(value_type) { ++*this; }
+
+        /// \brief Dereference operator
+        inline reference operator*() const { return const_cast<reference>(m_index); }
+
+    protected:
+        KnnGraphRangeQuery<Traits>* m_query{nullptr};
+        value_type m_index{-1};
+    };
 
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KnnGraph/Query/knnGraphKNearestQuery.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/Query/knnGraphKNearestQuery.h
@@ -10,62 +10,59 @@
 #include "../Iterator/knnGraphRangeIterator.h"
 #include <vector>
 
-namespace Ponca {
+namespace Ponca
+{
 
-template <typename Traits>class KnnGraphBase; // Need forward declaration to avoid mutual inclusion
-
+    template <typename Traits>
+    class KnnGraphBase; // Need forward declaration to avoid mutual inclusion
 
 #ifndef PARSED_WITH_DOXYGEN
-struct KnnGraphQueryOutputType : public QueryOutputBase{
-    using OutputParameter = typename QueryOutputBase::DummyOutputParameter;
-};
+    struct KnnGraphQueryOutputType : public QueryOutputBase
+    {
+        using OutputParameter = typename QueryOutputBase::DummyOutputParameter;
+    };
 #endif
 
-/*!
- * \brief Extension of the Query class that allows to read the result of a k-nearest neighbors search on the KnnGraph.
- *
- *  Output result of a `KnnGraph::kNearestNeighbors` query request.
- *
- *  \see KnnGraphBase
- */
-template <typename Traits>class KnnGraphKNearestQuery
+    /*!
+     * \brief Extension of the Query class that allows to read the result of a k-nearest neighbors search on the
+     * KnnGraph.
+     *
+     *  Output result of a `KnnGraph::kNearestNeighbors` query request.
+     *
+     *  \see KnnGraphBase
+     */
+    template <typename Traits>
+    class KnnGraphKNearestQuery
 #ifdef PARSED_WITH_DOXYGEN
-: public KNearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>
+        : public KNearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>
 #else
-    // we skip output because we don't need it: k is static, and already stored in the index array
-: public Query<QueryInputIsIndex<typename Traits::IndexType>,KnnGraphQueryOutputType>
+        // we skip output because we don't need it: k is static, and already stored in the index array
+        : public Query<QueryInputIsIndex<typename Traits::IndexType>, KnnGraphQueryOutputType>
 #endif
-{
-public:
-    using Iterator = typename Traits::IndexContainer::const_iterator;
+    {
+    public:
+        using Iterator = typename Traits::IndexContainer::const_iterator;
 #ifdef PARSED_WITH_DOXYGEN
-    using QueryType = KNearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>;
+        using QueryType = KNearestIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>;
 #else
-    using QueryType = Query<QueryInputIsIndex<typename Traits::IndexType>,KnnGraphQueryOutputType>;
+        using QueryType = Query<QueryInputIsIndex<typename Traits::IndexType>, KnnGraphQueryOutputType>;
 #endif
-    using Self      = KnnGraphKNearestQuery<Traits>;
+        using Self = KnnGraphKNearestQuery<Traits>;
 
-public:
-    inline KnnGraphKNearestQuery(const KnnGraphBase<Traits>* graph, int index)
-        : QueryType(index), m_graph(graph){}
+    public:
+        inline KnnGraphKNearestQuery(const KnnGraphBase<Traits>* graph, int index) : QueryType(index), m_graph(graph) {}
 
-    /// \brief Call the k-nearest neighbors query with new input parameter.
-    inline Self& operator()(int index) {
-        return QueryType::template operator()<Self>(index);
-    }
+        /// \brief Call the k-nearest neighbors query with new input parameter.
+        inline Self& operator()(int index) { return QueryType::template operator()<Self>(index); }
 
-    /// \brief Returns an iterator to the beginning of the k-nearest neighbors query.
-    inline Iterator begin() const{
-        return m_graph->index_data().begin() + QueryType::input() * m_graph->k();
-    }
+        /// \brief Returns an iterator to the beginning of the k-nearest neighbors query.
+        inline Iterator begin() const { return m_graph->index_data().begin() + QueryType::input() * m_graph->k(); }
 
-    /// \brief Returns an iterator to the end of the k-nearest neighbors query.
-    inline Iterator end() const{
-        return m_graph->index_data().begin() + (QueryType::input()+1) * m_graph->k();
-    }
+        /// \brief Returns an iterator to the end of the k-nearest neighbors query.
+        inline Iterator end() const { return m_graph->index_data().begin() + (QueryType::input() + 1) * m_graph->k(); }
 
-protected:
-    const KnnGraphBase<Traits>* m_graph {nullptr};
-};
+    protected:
+        const KnnGraphBase<Traits>* m_graph{nullptr};
+    };
 
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KnnGraph/Query/knnGraphRangeQuery.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/Query/knnGraphRangeQuery.h
@@ -13,110 +13,114 @@
 #include <stack>
 #include <set>
 
-namespace Ponca {
-template <typename Traits> class KnnGraphBase;
-
-/*!
- * \brief Extension of the Query class that allows to read the result of a range neighbor search on the KnnGraph.
- *
- *  Output result of a `KnnGraph::rangeNeighbors` query request.
- *
- *  \see KnnGraphBase
- */
-template <typename Traits>
-class KnnGraphRangeQuery : public RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>
+namespace Ponca
 {
-protected:
-    using QueryType = RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>;
-    friend class KnnGraphRangeIterator<Traits>; // This type must be equal to KnnGraphRangeQuery::Iterator
+    template <typename Traits>
+    class KnnGraphBase;
 
-public:
-    using DataPoint  = typename Traits::DataPoint;
-    using IndexType  = typename Traits::IndexType;
-    using Scalar     = typename DataPoint::Scalar;
-    using VectorType = typename DataPoint::VectorType;
-    using Iterator   = KnnGraphRangeIterator<Traits>;
-    using Self       = KnnGraphRangeQuery<Traits>;
+    /*!
+     * \brief Extension of the Query class that allows to read the result of a range neighbor search on the KnnGraph.
+     *
+     *  Output result of a `KnnGraph::rangeNeighbors` query request.
+     *
+     *  \see KnnGraphBase
+     */
+    template <typename Traits>
+    class KnnGraphRangeQuery : public RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>
+    {
+    protected:
+        using QueryType = RangeIndexQuery<typename Traits::IndexType, typename Traits::DataPoint::Scalar>;
+        friend class KnnGraphRangeIterator<Traits>; // This type must be equal to KnnGraphRangeQuery::Iterator
 
-public:
-    inline KnnGraphRangeQuery(const KnnGraphBase<Traits>* graph, Scalar radius, int index):
-            QueryType(radius, index),
-            m_graph(graph),
-            m_flag(),
-            m_stack() {}
+    public:
+        using DataPoint  = typename Traits::DataPoint;
+        using IndexType  = typename Traits::IndexType;
+        using Scalar     = typename DataPoint::Scalar;
+        using VectorType = typename DataPoint::VectorType;
+        using Iterator   = KnnGraphRangeIterator<Traits>;
+        using Self       = KnnGraphRangeQuery<Traits>;
 
-    /// \brief Call the range neighbors query with new input and radius parameters.
-    inline Self& operator()(int index, Scalar radius) {
-        return QueryType::template operator()<Self>(index, radius);
-    }
-
-    /// \brief Call the range neighbors query with new input parameter.
-    inline Self& operator()(int index) {
-        return QueryType::template operator()<Self>(index);
-    }
-
-    /// \brief Returns an iterator to the beginning of the range neighbors query.
-    inline Iterator begin(){
-        QueryType::reset();
-        Iterator it(this);
-        this->initialize(it);
-        this->advance(it);
-        return it;
-    }
-
-    /// \brief Returns an iterator to the end of the range neighbors query.
-    inline Iterator end(){
-        return Iterator(this, static_cast<int>(m_graph->size()));
-    }
-
-protected:
-    inline void initialize(Iterator& iterator){
-        m_flag.clear();
-        m_flag.insert(QueryType::input());
-
-        PONCA_DEBUG_ASSERT(m_stack.empty());
-        m_stack.push(QueryType::input());
-
-        iterator.m_index = -1;
-    }
-
-    inline void advance(Iterator& iterator){
-        const auto& points  = m_graph->m_kdTreePoints;
-        const auto& point   = points[QueryType::input()].pos();
-
-        if(! (iterator != end())) return;
-
-        if(m_stack.empty())
+    public:
+        inline KnnGraphRangeQuery(const KnnGraphBase<Traits>* graph, Scalar radius, int index)
+            : QueryType(radius, index), m_graph(graph), m_flag(), m_stack()
         {
-            iterator = end();
         }
-        else
+
+        /// \brief Call the range neighbors query with new input and radius parameters.
+        inline Self& operator()(int index, Scalar radius)
         {
-            int idx_current = m_stack.top();
-            m_stack.pop();
+            return QueryType::template operator()<Self>(index, radius);
+        }
 
-            PONCA_DEBUG_ASSERT((point - points[idx_current].pos()).squaredNorm() < QueryType::squaredRadius());
+        /// \brief Call the range neighbors query with new input parameter.
+        inline Self& operator()(int index) { return QueryType::template operator()<Self>(index); }
 
-            iterator.m_index = idx_current;
+        /// \brief Returns an iterator to the beginning of the range neighbors query.
+        inline Iterator begin()
+        {
+            QueryType::reset();
+            Iterator it(this);
+            this->initialize(it);
+            this->advance(it);
+            return it;
+        }
 
-            for(int idx_nei : m_graph->kNearestNeighbors(idx_current))
+        /// \brief Returns an iterator to the end of the range neighbors query.
+        inline Iterator end() { return Iterator(this, static_cast<int>(m_graph->size())); }
+
+    protected:
+        inline void initialize(Iterator& iterator)
+        {
+            m_flag.clear();
+            m_flag.insert(QueryType::input());
+
+            PONCA_DEBUG_ASSERT(m_stack.empty());
+            m_stack.push(QueryType::input());
+
+            iterator.m_index = -1;
+        }
+
+        inline void advance(Iterator& iterator)
+        {
+            const auto& points = m_graph->m_kdTreePoints;
+            const auto& point  = points[QueryType::input()].pos();
+
+            if (!(iterator != end()))
+                return;
+
+            if (m_stack.empty())
             {
-                PONCA_DEBUG_ASSERT(idx_nei>=0);
-                Scalar d  = (point - points[idx_nei].pos()).squaredNorm();
-                Scalar th = QueryType::descentDistanceThreshold();
-                if((point - points[idx_nei].pos()).squaredNorm() < QueryType::descentDistanceThreshold() && m_flag.insert(idx_nei).second)
-                {
-                    m_stack.push(idx_nei);
-                }
+                iterator = end();
             }
-            if (iterator.m_index == QueryType::input()) advance(iterator); // query is not included in returned set
-        }
-    }
+            else
+            {
+                int idx_current = m_stack.top();
+                m_stack.pop();
 
-protected:
-    const KnnGraphBase<Traits>*   m_graph {nullptr};
-    std::set<int> m_flag;       ///< store visited ids
-    std::stack<int>   m_stack;  ///< hold ids (ids range from 0 to point cloud size)
-};
+                PONCA_DEBUG_ASSERT((point - points[idx_current].pos()).squaredNorm() < QueryType::squaredRadius());
+
+                iterator.m_index = idx_current;
+
+                for (int idx_nei : m_graph->kNearestNeighbors(idx_current))
+                {
+                    PONCA_DEBUG_ASSERT(idx_nei >= 0);
+                    Scalar d  = (point - points[idx_nei].pos()).squaredNorm();
+                    Scalar th = QueryType::descentDistanceThreshold();
+                    if ((point - points[idx_nei].pos()).squaredNorm() < QueryType::descentDistanceThreshold() &&
+                        m_flag.insert(idx_nei).second)
+                    {
+                        m_stack.push(idx_nei);
+                    }
+                }
+                if (iterator.m_index == QueryType::input())
+                    advance(iterator); // query is not included in returned set
+            }
+        }
+
+    protected:
+        const KnnGraphBase<Traits>* m_graph{nullptr};
+        std::set<int> m_flag;    ///< store visited ids
+        std::stack<int> m_stack; ///< hold ids (ids range from 0 to point cloud size)
+    };
 
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
@@ -15,167 +15,159 @@
 
 #include <memory>
 
-namespace Ponca {
-
-template <typename Traits> class KnnGraphBase;
-
-/*!
- * \brief Public interface for KnnGraph datastructure.
- *
- * Provides default implementation of the KnnGraph
- *
- * \see KnnGraphDefaultTraits for the default trait interface documentation.
- * \see KnnGraphBase for complete API
- */
-template <typename DataPoint>
-using KnnGraph = KnnGraphBase<KnnGraphDefaultTraits<DataPoint>>;
-
-/*!
- * \brief Customizable base class for KnnGraph datastructure
- *
- * \see Ponca::KnGraph
- *
- * \tparam Traits Traits type providing the types and constants used by the KnnGraph. Must have the
- * same interface as the default traits type.
- *
- * \see KnnGraphDefaultTraits for the trait interface documentation.
- *
- */
-template <typename Traits> class KnnGraphBase
+namespace Ponca
 {
-public:
-    using DataPoint  = typename Traits::DataPoint; ///< DataPoint given by user via Traits
-    using Scalar     = typename DataPoint::Scalar; ///< Scalar given by user via DataPoint
-    using VectorType = typename DataPoint::VectorType; ///< VectorType given by user via DataPoint
 
-    using IndexType      = typename Traits::IndexType;
-    using PointContainer = typename Traits::PointContainer; ///< Container for DataPoint used inside the KdTree
-    using IndexContainer = typename Traits::IndexContainer; ///< Container for indices used inside the KdTree
+    template <typename Traits>
+    class KnnGraphBase;
 
-    using KNearestIndexQuery = KnnGraphKNearestQuery<Traits>;
-    using RangeIndexQuery    = KnnGraphRangeQuery<Traits>;
+    /*!
+     * \brief Public interface for KnnGraph datastructure.
+     *
+     * Provides default implementation of the KnnGraph
+     *
+     * \see KnnGraphDefaultTraits for the default trait interface documentation.
+     * \see KnnGraphBase for complete API
+     */
+    template <typename DataPoint>
+    using KnnGraph = KnnGraphBase<KnnGraphDefaultTraits<DataPoint>>;
 
-    friend class KnnGraphKNearestQuery<Traits>; // This type must be equal to KnnGraphBase::KNearestIndexQuery
-    friend class KnnGraphRangeQuery<Traits>;    // This type must be equal to KnnGraphBase::RangeIndexQuery
-
-    // knnGraph ----------------------------------------------------------------
-public:
-    /// \brief Build a KnnGraph from a KdTreeDense
-    ///
-    /// \param k Number of requested neighbors. Might be reduced if k is larger than the kdtree size - 1
-    ///          (query point is not included in query output, thus -1)
-    ///
-    /// \warning Stores a const reference to kdtree.point_data()
-    /// \warning KdTreeTraits compatibility is checked with static assertion
-    template<typename KdTreeTraits>
-    inline KnnGraphBase(const KdTreeBase<KdTreeTraits>& kdtree, int k = 6)
-            : m_k(std::min(k,kdtree.sampleCount()-1)),
-              m_kdTreePoints(kdtree.points())
+    /*!
+     * \brief Customizable base class for KnnGraph datastructure
+     *
+     * \see Ponca::KnGraph
+     *
+     * \tparam Traits Traits type providing the types and constants used by the KnnGraph. Must have the
+     * same interface as the default traits type.
+     *
+     * \see KnnGraphDefaultTraits for the trait interface documentation.
+     *
+     */
+    template <typename Traits>
+    class KnnGraphBase
     {
-        static_assert( std::is_same<typename Traits::DataPoint, typename KdTreeTraits::DataPoint>::value,
-                       "KdTreeTraits::DataPoint is not equal to Traits::DataPoint" );
-        static_assert( std::is_same<typename Traits::PointContainer, typename KdTreeTraits::PointContainer>::value,
-                       "KdTreeTraits::PointContainer is not equal to Traits::PointContainer" );
-        static_assert( std::is_same<typename Traits::IndexContainer, typename KdTreeTraits::IndexContainer>::value,
-                       "KdTreeTraits::IndexContainer is not equal to Traits::IndexContainer" );
+    public:
+        using DataPoint  = typename Traits::DataPoint;     ///< DataPoint given by user via Traits
+        using Scalar     = typename DataPoint::Scalar;     ///< Scalar given by user via DataPoint
+        using VectorType = typename DataPoint::VectorType; ///< VectorType given by user via DataPoint
 
-        // We need to account for the entire point set, irrespectively of the sampling. This is because the kdtree
-        // (kNearestNeighbors) return ids of the entire point set, not it sub-sampled list of ids.
-        // \fixme Update API to properly handle kdtree subsampling
-        const int cloudSize   = kdtree.pointCount();
+        using IndexType      = typename Traits::IndexType;
+        using PointContainer = typename Traits::PointContainer; ///< Container for DataPoint used inside the KdTree
+        using IndexContainer = typename Traits::IndexContainer; ///< Container for indices used inside the KdTree
+
+        using KNearestIndexQuery = KnnGraphKNearestQuery<Traits>;
+        using RangeIndexQuery    = KnnGraphRangeQuery<Traits>;
+
+        friend class KnnGraphKNearestQuery<Traits>; // This type must be equal to KnnGraphBase::KNearestIndexQuery
+        friend class KnnGraphRangeQuery<Traits>;    // This type must be equal to KnnGraphBase::RangeIndexQuery
+
+        // knnGraph ----------------------------------------------------------------
+    public:
+        /// \brief Build a KnnGraph from a KdTreeDense
+        ///
+        /// \param k Number of requested neighbors. Might be reduced if k is larger than the kdtree size - 1
+        ///          (query point is not included in query output, thus -1)
+        ///
+        /// \warning Stores a const reference to kdtree.point_data()
+        /// \warning KdTreeTraits compatibility is checked with static assertion
+        template <typename KdTreeTraits>
+        inline KnnGraphBase(const KdTreeBase<KdTreeTraits>& kdtree, int k = 6)
+            : m_k(std::min(k, kdtree.sampleCount() - 1)), m_kdTreePoints(kdtree.points())
         {
-            const int samplesSize = kdtree.sampleCount();
-            eigen_assert(cloudSize == samplesSize);
-        }
+            static_assert(std::is_same<typename Traits::DataPoint, typename KdTreeTraits::DataPoint>::value,
+                          "KdTreeTraits::DataPoint is not equal to Traits::DataPoint");
+            static_assert(std::is_same<typename Traits::PointContainer, typename KdTreeTraits::PointContainer>::value,
+                          "KdTreeTraits::PointContainer is not equal to Traits::PointContainer");
+            static_assert(std::is_same<typename Traits::IndexContainer, typename KdTreeTraits::IndexContainer>::value,
+                          "KdTreeTraits::IndexContainer is not equal to Traits::IndexContainer");
 
-        m_indices.resize(cloudSize * m_k, -1);
+            // We need to account for the entire point set, irrespectively of the sampling. This is because the kdtree
+            // (kNearestNeighbors) return ids of the entire point set, not it sub-sampled list of ids.
+            // \fixme Update API to properly handle kdtree subsampling
+            const int cloudSize = kdtree.pointCount();
+            {
+                const int samplesSize = kdtree.sampleCount();
+                eigen_assert(cloudSize == samplesSize);
+            }
+
+            m_indices.resize(cloudSize * m_k, -1);
 
 #pragma omp parallel for shared(kdtree, cloudSize) default(none)
-        for(int i=0; i<cloudSize; ++i)
-        {
-            int j = 0;
-            for(auto n : kdtree.kNearestNeighbors(typename KdTreeTraits::IndexType(i),
-                                                   typename KdTreeTraits::IndexType(m_k)))
+            for (int i = 0; i < cloudSize; ++i)
             {
-                m_indices[i * m_k + j] = n;
-                ++j;
+                int j = 0;
+                for (auto n : kdtree.kNearestNeighbors(typename KdTreeTraits::IndexType(i),
+                                                       typename KdTreeTraits::IndexType(m_k)))
+                {
+                    m_indices[i * m_k + j] = n;
+                    ++j;
+                }
             }
         }
-    }
 
-    // Query -------------------------------------------------------------------
-public:
-    /// \brief Computes a Query object to iterate over the k-nearest neighbors of a point.
-    ///
-    /// As k was set during the construction of the \ref KnnGraphBase, it doesn't need to be provided.
-    ///
-    /// The returned object can be reset and reused with the () operator, to compute a new result
-    /// (also takes an index as parameter).
-    ///
-    /// \param index Index of the point that the query evaluates
-    /// \return The \ref KNearestIndexQuery mutable object to iterate over the search results.
-    inline KNearestIndexQuery kNearestNeighbors(int index) const{
-        return KNearestIndexQuery(this, index);
-    }
+        // Query -------------------------------------------------------------------
+    public:
+        /// \brief Computes a Query object to iterate over the k-nearest neighbors of a point.
+        ///
+        /// As k was set during the construction of the \ref KnnGraphBase, it doesn't need to be provided.
+        ///
+        /// The returned object can be reset and reused with the () operator, to compute a new result
+        /// (also takes an index as parameter).
+        ///
+        /// \param index Index of the point that the query evaluates
+        /// \return The \ref KNearestIndexQuery mutable object to iterate over the search results.
+        inline KNearestIndexQuery kNearestNeighbors(int index) const { return KNearestIndexQuery(this, index); }
 
-    /// \brief Computes a Query object to iterate over the neighbors that are inside a given radius.
-    ///
-    /// The returned object can be reset and reused with the () operator, to compute a new result
-    /// (also takes an index and a radius as parameters).
-    ///
-    /// \param index Index of the point that the query evaluates
-    /// \param r Radius around where to search the neighbors
-    /// \return The \ref RangeIndexQuery mutable object to iterate over the search results.
-    inline RangeIndexQuery    rangeNeighbors(int index, Scalar r) const{
-        return RangeIndexQuery(this, r, index);
-    }
+        /// \brief Computes a Query object to iterate over the neighbors that are inside a given radius.
+        ///
+        /// The returned object can be reset and reused with the () operator, to compute a new result
+        /// (also takes an index and a radius as parameters).
+        ///
+        /// \param index Index of the point that the query evaluates
+        /// \param r Radius around where to search the neighbors
+        /// \return The \ref RangeIndexQuery mutable object to iterate over the search results.
+        inline RangeIndexQuery rangeNeighbors(int index, Scalar r) const { return RangeIndexQuery(this, r, index); }
 
-    /// \brief Convenience function that provides a k-nearest neighbors Query object.
-    ///
-    /// Same as `KnnGraphBase::kNearestNeighbors (0)`.
-    ///
-    /// \warning Unlike `KdTreeBase::kNearestNeighborsIndexQuery`, this function doesn't really return an empty query.
-    /// This is due to the fact that the `KnnGraphBase::kNearestNeighbors` query can't set the `k` value to zero,
-    /// as it is a value that is managed by the KnnGraphBase structure.
-    /// Therefore, this function returns the k-nearest neighbors query made with the evaluation point set to 0.
-    ///
-    /// \return The \ref KNearestIndexQuery mutable object that can be called with the operator ()
-    /// with an index as argument, to fetch the k-nearest neighbors of a point.
-    /// \see #kNearestNeighbors
-    inline KNearestIndexQuery kNearestNeighborsIndexQuery() const
-    {
-        return KNearestIndexQuery(this, 0);
-    }
+        /// \brief Convenience function that provides a k-nearest neighbors Query object.
+        ///
+        /// Same as `KnnGraphBase::kNearestNeighbors (0)`.
+        ///
+        /// \warning Unlike `KdTreeBase::kNearestNeighborsIndexQuery`, this function doesn't really return an empty
+        /// query. This is due to the fact that the `KnnGraphBase::kNearestNeighbors` query can't set the `k` value to
+        /// zero, as it is a value that is managed by the KnnGraphBase structure. Therefore, this function returns the
+        /// k-nearest neighbors query made with the evaluation point set to 0.
+        ///
+        /// \return The \ref KNearestIndexQuery mutable object that can be called with the operator ()
+        /// with an index as argument, to fetch the k-nearest neighbors of a point.
+        /// \see #kNearestNeighbors
+        inline KNearestIndexQuery kNearestNeighborsIndexQuery() const { return KNearestIndexQuery(this, 0); }
 
-    /// \brief Convenience function that provides an empty range neighbors Query object.
-    ///
-    /// The returned object can be called with the arguments `(i, r)` to fetch the neighbors
-    /// that are in range `r` of the point of index `i`.
-    ///
-    /// Same as `KnnGraphBase::rangeNeighbors (0, 0)`.
-    ///
-    /// \return The empty \ref KNearestIndexQuery mutable object to iterate over the search results.
-    /// \see #rangeNeighbors
-    inline RangeIndexQuery rangeNeighborsIndexQuery() const
-    {
-        return RangeIndexQuery(this, 0, 0);
-    }
+        /// \brief Convenience function that provides an empty range neighbors Query object.
+        ///
+        /// The returned object can be called with the arguments `(i, r)` to fetch the neighbors
+        /// that are in range `r` of the point of index `i`.
+        ///
+        /// Same as `KnnGraphBase::rangeNeighbors (0, 0)`.
+        ///
+        /// \return The empty \ref KNearestIndexQuery mutable object to iterate over the search results.
+        /// \see #rangeNeighbors
+        inline RangeIndexQuery rangeNeighborsIndexQuery() const { return RangeIndexQuery(this, 0, 0); }
 
-    // Accessors ---------------------------------------------------------------
-public:
-    /// \brief Number of neighbor per vertex
-    [[nodiscard]] inline int k() const { return m_k; }
-    /// \brief Number of vertices in the neighborhood graph
-    [[nodiscard]] inline size_t size() const { return m_indices.size()/static_cast<size_t>(m_k); }
+        // Accessors ---------------------------------------------------------------
+    public:
+        /// \brief Number of neighbor per vertex
+        [[nodiscard]] inline int k() const { return m_k; }
+        /// \brief Number of vertices in the neighborhood graph
+        [[nodiscard]] inline size_t size() const { return m_indices.size() / static_cast<size_t>(m_k); }
 
-    // Data --------------------------------------------------------------------
-private:
-    const int m_k;
-    IndexContainer m_indices; ///< \brief Stores neighborhood relations
+        // Data --------------------------------------------------------------------
+    private:
+        const int m_k;
+        IndexContainer m_indices; ///< \brief Stores neighborhood relations
 
-protected: // for friends relations
-    const PointContainer& m_kdTreePoints;
-    inline const IndexContainer& index_data() const { return m_indices; };
-};
+    protected: // for friends relations
+        const PointContainer& m_kdTreePoints;
+        inline const IndexContainer& index_data() const { return m_indices; };
+    };
 
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KnnGraph/knnGraphTraits.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/knnGraphTraits.h
@@ -4,45 +4,45 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 #pragma once
 
 #include <Eigen/Geometry>
 
-namespace Ponca {
-
-/*!
- * \brief The default traits type used by the kd-tree.
- */
-template <typename _DataPoint>
-struct KnnGraphDefaultTraits
+namespace Ponca
 {
+
     /*!
-     * \brief The type used to store point data.
-     *
-     * Must provide `Scalar` and `VectorType` typedefs.
-     *
-     * `VectorType` must provide a `squaredNorm()` function returning a `Scalar`, as well as a
-     * `maxCoeff(int*)` function returning the dimension index of its largest scalar in its output
-     * parameter (e.g. 0 for *x*, 1 for *y*, etc.).
+     * \brief The default traits type used by the kd-tree.
      */
-    using DataPoint = _DataPoint;
+    template <typename _DataPoint>
+    struct KnnGraphDefaultTraits
+    {
+        /*!
+         * \brief The type used to store point data.
+         *
+         * Must provide `Scalar` and `VectorType` typedefs.
+         *
+         * `VectorType` must provide a `squaredNorm()` function returning a `Scalar`, as well as a
+         * `maxCoeff(int*)` function returning the dimension index of its largest scalar in its output
+         * parameter (e.g. 0 for *x*, 1 for *y*, etc.).
+         */
+        using DataPoint = _DataPoint;
 
-private:
-    using Scalar     = typename DataPoint::Scalar;
-    using VectorType = typename DataPoint::VectorType;
+    private:
+        using Scalar     = typename DataPoint::Scalar;
+        using VectorType = typename DataPoint::VectorType;
 
-public:
-    /*!
-     * \brief The type used to calculate node bounding boxes.
-     *
-     * Must provide `min()`, `max()`, and `center()` functions, all returning a `VectorType`.
-     */
-    using AabbType = Eigen::AlignedBox<Scalar, DataPoint::Dim>;
+    public:
+        /*!
+         * \brief The type used to calculate node bounding boxes.
+         *
+         * Must provide `min()`, `max()`, and `center()` functions, all returning a `VectorType`.
+         */
+        using AabbType = Eigen::AlignedBox<Scalar, DataPoint::Dim>;
 
-    // Containers
-    using IndexType      = int;
-    using PointContainer = std::vector<DataPoint>;
-    using IndexContainer = std::vector<IndexType>;
-};
+        // Containers
+        using IndexType      = int;
+        using PointContainer = std::vector<DataPoint>;
+        using IndexContainer = std::vector<IndexType>;
+    };
 } // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/defines.h
+++ b/Ponca/src/SpatialPartitioning/defines.h
@@ -4,18 +4,18 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 #pragma once
 
-namespace Ponca {
-/**
-  *
-  * \defgroup spatialpartitioning Spatial Partitioning module
-  * \brief This modules includes classes and methods for Spatial Partitioning and queries.
-  * \{
-  * \}
-  *
-  */
-}   
+namespace Ponca
+{
+    /**
+     *
+     * \defgroup spatialpartitioning Spatial Partitioning module
+     * \brief This modules includes classes and methods for Spatial Partitioning and queries.
+     * \{
+     * \}
+     *
+     */
+}
 
 #include "../Common/defines.h"

--- a/Ponca/src/SpatialPartitioning/defines.h
+++ b/Ponca/src/SpatialPartitioning/defines.h
@@ -12,8 +12,8 @@ namespace Ponca {
   *
   * \defgroup spatialpartitioning Spatial Partitioning module
   * \brief This modules includes classes and methods for Spatial Partitioning and queries.
-  * @{
-  * @}
+  * \{
+  * \}
   *
   */
 }   

--- a/Ponca/src/SpatialPartitioning/indexSquaredDistance.h
+++ b/Ponca/src/SpatialPartitioning/indexSquaredDistance.h
@@ -10,21 +10,24 @@
 #include PONCA_MULTIARCH_INCLUDE_CU_STD(limits)
 #include <type_traits>
 
-namespace Ponca {
-
-/// \brief Associates an index with a distance
-template<typename Index, typename Scalar>
-struct IndexSquaredDistance
+namespace Ponca
 {
-    //// Index of the closest point
-    Index index {-1};
 
-    /// Distance to the closest point
-    Scalar squared_distance { PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits)<Scalar>::max() };
+    /// \brief Associates an index with a distance
+    template <typename Index, typename Scalar>
+    struct IndexSquaredDistance
+    {
+        //// Index of the closest point
+        Index index{-1};
 
-    /// Comparison operator based on squared_distance
-    PONCA_MULTIARCH inline bool operator < (const IndexSquaredDistance& other) const
-    { return squared_distance < other.squared_distance; }
-};
+        /// Distance to the closest point
+        Scalar squared_distance{PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits) < Scalar > ::max()};
 
-}   
+        /// Comparison operator based on squared_distance
+        PONCA_MULTIARCH inline bool operator<(const IndexSquaredDistance& other) const
+        {
+            return squared_distance < other.squared_distance;
+        }
+    };
+
+} // namespace Ponca

--- a/Ponca/src/SpatialPartitioning/query.h
+++ b/Ponca/src/SpatialPartitioning/query.h
@@ -20,13 +20,13 @@ namespace Ponca
 /// \brief Macro generating code of the Query base classes inhering QueryInputIsIndex.
 /// \note For internal use only
 #define DECLARE_INDEX_QUERY_CLASS(OUT_TYPE)                                                                           \
-    /*! \brief Base Query class combining QueryInputIsIndex and QueryOutputIs##OUT_TYPE##. */                                                                                                                   \
-    /*! `IndexQuery` objects acts as a `Range` that can be iterated over. */                                                                                                                   \
-    /*! They are used as the return type for the index searches */                                                                                                                   \
-    /*! and they allow easy access to the result outputs. */                                                                                                                   \
+    /*! \brief Base Query class combining QueryInputIsIndex and QueryOutputIs##OUT_TYPE##. */                         \
+    /*! `IndexQuery` objects acts as a `Range` that can be iterated over. */                                          \
+    /*! They are used as the return type for the index searches */                                                    \
+    /*! and they allow easy access to the result outputs. */                                                          \
     /*! This specialization of the `IndexQuery` concept is used to iterate over the neighbors of a given point index, \
      */                                                                                                               \
-    /*! using a ##OUT_TYPE## Index Query request. */                                                                                                                   \
+    /*! using a ##OUT_TYPE## Index Query request. */                                                                  \
     template <typename Index, typename Scalar>                                                                        \
     struct OUT_TYPE##IndexQuery : Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>>             \
     {                                                                                                                 \
@@ -40,13 +40,13 @@ namespace Ponca
 /// \brief Macro generating code of the Query base classes inhering QueryInputIsPosition.
 /// \note For internal use only
 #define DECLARE_POINT_QUERY_CLASS(OUT_TYPE)                                                                     \
-    /*! \brief Base Query class combining QueryInputIsPosition and QueryOutputIs##OUT_TYPE##. */                                                                                                             \
-    /*! `PointQuery` objects acts as a `Range` that can be iterated over. */                                                                                                             \
-    /*! They are used as the return type for the index searches */                                                                                                             \
-    /*! and they allow easy access to the result outputs. */                                                                                                             \
+    /*! \brief Base Query class combining QueryInputIsPosition and QueryOutputIs##OUT_TYPE##. */                \
+    /*! `PointQuery` objects acts as a `Range` that can be iterated over. */                                    \
+    /*! They are used as the return type for the index searches */                                              \
+    /*! and they allow easy access to the result outputs. */                                                    \
     /*! This specialization of the `PointQuery` concept is used to iterate over the neighbors of a given point  \
      * position,*/                                                                                              \
-    /*! using a ##OUT_TYPE## Point Query request. */                                                                                                             \
+    /*! using a ##OUT_TYPE## Point Query request. */                                                            \
     template <typename Index, typename DataPoint>                                                               \
     struct OUT_TYPE##PointQuery                                                                                 \
         : Query<QueryInputIsPosition<DataPoint>, QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>>    \

--- a/Ponca/src/SpatialPartitioning/query.h
+++ b/Ponca/src/SpatialPartitioning/query.h
@@ -57,7 +57,7 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
 };
 
 /// \addtogroup spatialpartitioning
-/// @{
+/// \{
 
 ////////////////////////////////////////////////////////////////
 // Base classes
@@ -354,7 +354,7 @@ DECLARE_POINT_QUERY_CLASS(KNearest) //KNearestPointQuery
 DECLARE_POINT_QUERY_CLASS(Nearest)  //NearestPointQuery
 DECLARE_POINT_QUERY_CLASS(Range)    //RangePointQuery
 
-/// @}
+/// \}
 
 #undef DECLARE_INDEX_QUERY_CLASS
 #undef DECLARE_POINT_QUERY_CLASS

--- a/Ponca/src/SpatialPartitioning/query.h
+++ b/Ponca/src/SpatialPartitioning/query.h
@@ -13,58 +13,61 @@
 #include PONCA_MULTIARCH_INCLUDE_STD(cmath)
 #include PONCA_MULTIARCH_INCLUDE_STD(limits)
 
-namespace Ponca {
-
+namespace Ponca
+{
 
 /// \internal
 /// \brief Macro generating code of the Query base classes inhering QueryInputIsIndex.
 /// \note For internal use only
-#define DECLARE_INDEX_QUERY_CLASS(OUT_TYPE)                                                                            \
-/*! \brief Base Query class combining QueryInputIsIndex and QueryOutputIs##OUT_TYPE##.                              */ \
-/*! `IndexQuery` objects acts as a `Range` that can be iterated over.                                               */ \
-/*! They are used as the return type for the index searches                                                         */ \
-/*! and they allow easy access to the result outputs.                                                               */ \
-/*! This specialization of the `IndexQuery` concept is used to iterate over the neighbors of a given point index,   */ \
-/*! using a ##OUT_TYPE## Index Query request.                                                                       */ \
-template <typename Index, typename Scalar>                                                                             \
-struct  OUT_TYPE##IndexQuery : Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>>                 \
-{                                                                                                                      \
-    /*! \brief Alias to the inherited base Query  */                                                                   \
-    using Base = Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>>;                              \
-    /*! \brief Inherited default constructor  */                                                                       \
-    using Base::Base;                                                                                                  \
-};
-
+#define DECLARE_INDEX_QUERY_CLASS(OUT_TYPE)                                                                           \
+    /*! \brief Base Query class combining QueryInputIsIndex and QueryOutputIs##OUT_TYPE##. */                                                                                                                   \
+    /*! `IndexQuery` objects acts as a `Range` that can be iterated over. */                                                                                                                   \
+    /*! They are used as the return type for the index searches */                                                                                                                   \
+    /*! and they allow easy access to the result outputs. */                                                                                                                   \
+    /*! This specialization of the `IndexQuery` concept is used to iterate over the neighbors of a given point index, \
+     */                                                                                                               \
+    /*! using a ##OUT_TYPE## Index Query request. */                                                                                                                   \
+    template <typename Index, typename Scalar>                                                                        \
+    struct OUT_TYPE##IndexQuery : Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>>             \
+    {                                                                                                                 \
+        /*! \brief Alias to the inherited base Query  */                                                              \
+        using Base = Query<QueryInputIsIndex<Index>, QueryOutputIs##OUT_TYPE<Index, Scalar>>;                         \
+        /*! \brief Inherited default constructor  */                                                                  \
+        using Base::Base;                                                                                             \
+    };
 
 /// \internal
 /// \brief Macro generating code of the Query base classes inhering QueryInputIsPosition.
 /// \note For internal use only
-#define DECLARE_POINT_QUERY_CLASS(OUT_TYPE)                                                                            \
-/*! \brief Base Query class combining QueryInputIsPosition and QueryOutputIs##OUT_TYPE##.                           */ \
-/*! `PointQuery` objects acts as a `Range` that can be iterated over.                                               */ \
-/*! They are used as the return type for the index searches                                                         */ \
-/*! and they allow easy access to the result outputs.                                                               */ \
-/*! This specialization of the `PointQuery` concept is used to iterate over the neighbors of a given point position,*/ \
-/*! using a ##OUT_TYPE## Point Query request.                                                                       */ \
-template <typename Index, typename DataPoint>                                                                          \
-struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,                                                  \
-                                     QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>>                       \
-{                                                                                                                      \
-    /*! \brief Alias to the inherited base Query  */                                                                   \
-    using Base = Query<QueryInputIsPosition<DataPoint>, QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>>;   \
-    /*! \brief Inherited default constructor  */                                                                       \
-    using Base::Base;                                                                                                  \
-};
+#define DECLARE_POINT_QUERY_CLASS(OUT_TYPE)                                                                     \
+    /*! \brief Base Query class combining QueryInputIsPosition and QueryOutputIs##OUT_TYPE##. */                                                                                                             \
+    /*! `PointQuery` objects acts as a `Range` that can be iterated over. */                                                                                                             \
+    /*! They are used as the return type for the index searches */                                                                                                             \
+    /*! and they allow easy access to the result outputs. */                                                                                                             \
+    /*! This specialization of the `PointQuery` concept is used to iterate over the neighbors of a given point  \
+     * position,*/                                                                                              \
+    /*! using a ##OUT_TYPE## Point Query request. */                                                                                                             \
+    template <typename Index, typename DataPoint>                                                               \
+    struct OUT_TYPE##PointQuery                                                                                 \
+        : Query<QueryInputIsPosition<DataPoint>, QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>>    \
+    {                                                                                                           \
+        /*! \brief Alias to the inherited base Query  */                                                        \
+        using Base =                                                                                            \
+            Query<QueryInputIsPosition<DataPoint>, QueryOutputIs##OUT_TYPE<Index, typename DataPoint::Scalar>>; \
+        /*! \brief Inherited default constructor  */                                                            \
+        using Base::Base;                                                                                       \
+    };
 
-/// \addtogroup spatialpartitioning
-/// \{
+    /// \addtogroup spatialpartitioning
+    /// \{
 
-////////////////////////////////////////////////////////////////
-// Base classes
-////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////
+    // Base classes
+    ////////////////////////////////////////////////////////////////
 
-/// \brief Base class for queries input type
-    struct QueryInputBase {
+    /// \brief Base class for queries input type
+    struct QueryInputBase
+    {
     };
 
     /*!
@@ -76,8 +79,10 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * They are used for easy access to the result outputs.
      * (e.g. to iterate over the neighbors of the evaluated point using a `rangeNeighborsQuery` request).
      */
-    struct QueryOutputBase {
-        struct DummyOutputParameter {
+    struct QueryOutputBase
+    {
+        struct DummyOutputParameter
+        {
         };
     };
 
@@ -90,8 +95,9 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * \warning This class has to be specialized for a specific input type, and can't be used as is.
      * \see QueryInputIsIndex, QueryInputIsPosition
      */
-    template<typename InputType_>
-    struct QueryInput : public QueryInputBase {
+    template <typename InputType_>
+    struct QueryInput : public QueryInputBase
+    {
         /// \brief Alias to the templated input type
         using InputType = InputType_;
 
@@ -99,7 +105,8 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
         PONCA_MULTIARCH inline QueryInput(InputType input) : m_input(input) {}
 
         /// \brief Read access to the input
-        PONCA_MULTIARCH inline const InputType &input() const { return m_input; }
+        PONCA_MULTIARCH inline const InputType& input() const { return m_input; }
+
     protected:
         /*!
          * \brief Edit the input
@@ -110,12 +117,11 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
          * Usefull to avoid query reallocation between different requests.
          */
         PONCA_MULTIARCH inline void setInput(const InputType& input) { m_input = input; }
-    
+
     private:
         /// Index of the queried point
         InputType m_input;
     };
-
 
     /*!
      * \brief Extension of `QueryInput` that handles an **index** based search, in a partitioning structure.
@@ -124,28 +130,32 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * \see QueryInput
      */
     template <typename Index>
-    struct QueryInputIsIndex : public QueryInput<Index> {
+    struct QueryInputIsIndex : public QueryInput<Index>
+    {
         /// \brief Alias to the inherited type
         using Base = QueryInput<Index>;
         /// \brief Alias to the templated input type (Index)
         using InputType = typename Base::InputType;
 
         /// \brief Default constructor that initialize the input index
-        PONCA_MULTIARCH inline QueryInputIsIndex(const InputType &point = -1)
-                : Base(point) {}
+        PONCA_MULTIARCH inline QueryInputIsIndex(const InputType& point = -1) : Base(point) {}
 
         /// \brief Access operator that resets the input index
-        PONCA_MULTIARCH inline void operator()(const InputType &point = InputType::Zero()){
-            Base::setInput(point);
-        }
+        PONCA_MULTIARCH inline void operator()(const InputType& point = InputType::Zero()) { Base::setInput(point); }
+
     protected:
         /// Functor used to check if a given Idx must be skipped
         template <typename IndexType>
-        PONCA_MULTIARCH inline bool skipIndexFunctor(IndexType idx) const {return Base::input() == idx;};
+        PONCA_MULTIARCH inline bool skipIndexFunctor(IndexType idx) const
+        {
+            return Base::input() == idx;
+        };
         /// Generic method to access input position. The VectorType needs to be passed as a template argument.
         template <typename VectorType, typename Container>
-        PONCA_MULTIARCH inline const VectorType getInputPosition(const Container &c)
-        { return c[Base::input()].pos(); }
+        PONCA_MULTIARCH inline const VectorType getInputPosition(const Container& c)
+        {
+            return c[Base::input()].pos();
+        }
     };
 
     /*!
@@ -154,29 +164,33 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * Stores internally the position of the evaluated point.
      * \see QueryInput
      */
-    template<typename DataPoint>
-    struct QueryInputIsPosition : public QueryInput<typename DataPoint::VectorType> {
+    template <typename DataPoint>
+    struct QueryInputIsPosition : public QueryInput<typename DataPoint::VectorType>
+    {
         /// \brief Alias to the inherited type
         using Base = QueryInput<typename DataPoint::VectorType>;
         /// \brief Alias to the templated input type (Index)
         using InputType = typename Base::InputType;
 
         /// \brief Default constructor that initialize the input position
-        PONCA_MULTIARCH inline QueryInputIsPosition(const InputType &point = InputType::Zero())
-                : Base(point) {}
+        PONCA_MULTIARCH inline QueryInputIsPosition(const InputType& point = InputType::Zero()) : Base(point) {}
 
         /// \brief Access operator that resets the input point
-        PONCA_MULTIARCH inline void operator()(const InputType &point = InputType::Zero()){
-            Base::setInput( point );
-        }
+        PONCA_MULTIARCH inline void operator()(const InputType& point = InputType::Zero()) { Base::setInput(point); }
+
     protected:
         /// Functor used to check if a given Idx must be skipped
         template <typename IndexType>
-        PONCA_MULTIARCH inline bool skipIndexFunctor(IndexType idx) const {return false;};
+        PONCA_MULTIARCH inline bool skipIndexFunctor(IndexType idx) const
+        {
+            return false;
+        };
         /// Generic method to access input position. The VectorType needs to be passed as a template argument.
-        template <typename VectorType=typename DataPoint::VectorType, typename Container>
-        PONCA_MULTIARCH inline const VectorType getInputPosition(const Container &)
-        { return Base::input(); }
+        template <typename VectorType = typename DataPoint::VectorType, typename Container>
+        PONCA_MULTIARCH inline const VectorType getInputPosition(const Container&)
+        {
+            return Base::input();
+        }
     };
 
     /*!
@@ -185,19 +199,20 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * Stores internally the radius value of a range request.
      * \see QueryOutputBase
      */
-    template<typename Index, typename Scalar>
-    struct QueryOutputIsRange : public QueryOutputBase {
+    template <typename Index, typename Scalar>
+    struct QueryOutputIsRange : public QueryOutputBase
+    {
         /// \brief Alias to Output type
         using OutputParameter = Scalar;
 
         /// \brief Default constructor that initialize the output parameter value
         PONCA_MULTIARCH inline QueryOutputIsRange(OutputParameter radius = OutputParameter(0))
-                : m_squared_radius(PONCA_MULTIARCH_STD_MATH_NAMESPACE(pow)(radius, OutputParameter(2))) {}
+            : m_squared_radius(PONCA_MULTIARCH_STD_MATH_NAMESPACE(pow)(radius, OutputParameter(2)))
+        {
+        }
 
         /// \brief Access operator that resets the output parameter
-        PONCA_MULTIARCH inline void operator() (OutputParameter radius){
-            setRadius( radius );
-        }
+        PONCA_MULTIARCH inline void operator()(OutputParameter radius) { setRadius(radius); }
 
         /*!
          * \brief Generic method to access the radius.
@@ -209,7 +224,8 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
          * `squaredRadius` is overall better for distance comparison.
          * \see squaredRadius
          */
-        PONCA_MULTIARCH inline Scalar radius() const {
+        PONCA_MULTIARCH inline Scalar radius() const
+        {
             PONCA_MULTIARCH_STD_MATH(sqrt);
             return sqrt(m_squared_radius);
         }
@@ -222,16 +238,14 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
          *
          * \note Store internally the squared radius for faster distance comparison
          */
-        PONCA_MULTIARCH inline void setRadius(Scalar radius) {
-            setSquaredRadius (radius*radius);
-        }
+        PONCA_MULTIARCH inline void setRadius(Scalar radius) { setSquaredRadius(radius * radius); }
 
         /// \brief Set the squared radius distance of the query
         PONCA_MULTIARCH inline void setSquaredRadius(Scalar radius) { m_squared_radius = radius; }
 
     protected:
         /// \brief Reset Query for a new search
-        PONCA_MULTIARCH inline void reset() { }
+        PONCA_MULTIARCH inline void reset() {}
         /// \brief Distance threshold used during tree descent to select nodes to explore
         PONCA_MULTIARCH inline Scalar descentDistanceThreshold() const { return m_squared_radius; }
         /// \brief Radius used for the search
@@ -244,8 +258,9 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * Stores internally the nearest neighbor and the Distance threshold (for tree descent).
      * \see QueryOutputBase
      */
-    template<typename Index, typename Scalar>
-    struct QueryOutputIsNearest : public QueryOutputBase {
+    template <typename Index, typename Scalar>
+    struct QueryOutputIsNearest : public QueryOutputBase
+    {
         /// \brief Alias to Output type
         using OutputParameter = typename QueryOutputBase::DummyOutputParameter;
 
@@ -253,24 +268,25 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
         PONCA_MULTIARCH QueryOutputIsNearest() {}
 
         /// \brief Access operator
-        PONCA_MULTIARCH inline void operator() (){ }
+        PONCA_MULTIARCH inline void operator()() {}
 
         /// \brief Get the closest points
         PONCA_MULTIARCH Index get() const { return m_nearest; }
 
     protected:
         /// \brief Reset Query for a new search
-        PONCA_MULTIARCH void reset() {
-            m_nearest = -1;
+        PONCA_MULTIARCH void reset()
+        {
+            m_nearest          = -1;
             m_squared_distance = PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits)<Scalar>::max();
         }
         /// \brief Distance threshold used during tree descent to select nodes to explore
         PONCA_MULTIARCH inline Scalar descentDistanceThreshold() const { return m_squared_distance; }
 
         /// \brief Index of the nearest neighbor
-        Index m_nearest {-1};
+        Index m_nearest{-1};
         /// \brief Distance to the nearest neighbor
-        Scalar m_squared_distance {PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits)<Scalar>::max()};
+        Scalar m_squared_distance{PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits) < Scalar > ::max()};
     };
 
     /*! \brief Class to construct the knearest queries
@@ -278,8 +294,9 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      *  Stores internally the neighbors collection of the knn request and the Distance threshold (for tree descent).
      *  \see QueryOutputBase
      */
-    template<typename Index, typename Scalar>
-    struct QueryOutputIsKNearest : public QueryOutputBase {
+    template <typename Index, typename Scalar>
+    struct QueryOutputIsKNearest : public QueryOutputBase
+    {
         /// \brief Alias to Output type
         using OutputParameter = Index;
 
@@ -287,16 +304,20 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
         PONCA_MULTIARCH inline QueryOutputIsKNearest(OutputParameter k = 0) : m_queue(k) {}
 
         /// \brief Access operator that resets the output parameter
-        PONCA_MULTIARCH inline void operator() (OutputParameter k) { m_queue = limited_priority_queue<IndexSquaredDistance<Index, Scalar>>(k); }
+        PONCA_MULTIARCH inline void operator()(OutputParameter k)
+        {
+            m_queue = limited_priority_queue<IndexSquaredDistance<Index, Scalar>>(k);
+        }
 
         /// \brief Access to the priority queue storing the neighbors
-        PONCA_MULTIARCH inline limited_priority_queue<IndexSquaredDistance<Index, Scalar>> &queue() { return m_queue; }
+        PONCA_MULTIARCH inline limited_priority_queue<IndexSquaredDistance<Index, Scalar>>& queue() { return m_queue; }
 
     protected:
         /// \brief Reset Query for a new search
-        PONCA_MULTIARCH void reset() {
+        PONCA_MULTIARCH void reset()
+        {
             m_queue.clear();
-            m_queue.push({-1, PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits)<Scalar>::max()});
+            m_queue.push({-1, PONCA_MULTIARCH_CU_STD_NAMESPACE(numeric_limits) < Scalar > ::max()});
         }
         /// \brief Distance threshold used during tree descent to select nodes to explore
         PONCA_MULTIARCH inline Scalar descentDistanceThreshold() const { return m_queue.bottom().squared_distance; }
@@ -310,8 +331,9 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
      * \tparam Input_ The query input type corresponds to the value used for the search.
      * \tparam Output_ The query output type corresponds to the results of the search (it can be iterated over).
      */
-    template<typename Input_, typename Output_>
-    struct Query : public Input_, public Output_ {
+    template <typename Input_, typename Output_>
+    struct Query : public Input_, public Output_
+    {
         /// \brief Alias to the input type
         using QueryInType = Input_;
         /// \brief Alias to the output type
@@ -323,39 +345,42 @@ struct  OUT_TYPE##PointQuery : Query<QueryInputIsPosition<DataPoint>,           
                       "QueryInType must inherit Ponca::QueryInputBase");
 
         /// \brief Default constructor that initialize the input parameter only
-        PONCA_MULTIARCH inline Query(const typename QueryInType::InputType &in)
-                : QueryInType(in), QueryOutType() {}
+        PONCA_MULTIARCH inline Query(const typename QueryInType::InputType& in) : QueryInType(in), QueryOutType() {}
 
         /// \brief Default constructor that initialize the input and output parameters
-        PONCA_MULTIARCH inline Query(const typename QueryOutType::OutputParameter &outParam,
-                     const typename QueryInType::InputType &in)
-                : QueryOutType(outParam), QueryInType(in) {}
+        PONCA_MULTIARCH inline Query(const typename QueryOutType::OutputParameter& outParam,
+                                     const typename QueryInType::InputType& in)
+            : QueryOutType(outParam), QueryInType(in)
+        {
+        }
 
         /// \brief Access operator that resets the input and output parameters
-        template<typename Base, typename... outputType>
-        PONCA_MULTIARCH inline Base& operator()(const typename QueryInType::InputType &in, outputType&&... out){
-            QueryInType:: operator()(in);
+        template <typename Base, typename... outputType>
+        PONCA_MULTIARCH inline Base& operator()(const typename QueryInType::InputType& in, outputType&&... out)
+        {
+            QueryInType::operator()(in);
             QueryOutType::operator()(std::forward<outputType>(out)...);
             return *((Base*)(this));
         }
 
         /// \brief Access operator that resets the input parameter only
-        template<typename Base>
-        PONCA_MULTIARCH inline Base& operator()(const typename QueryInType::InputType &in){
-            QueryInType:: operator()(in);
+        template <typename Base>
+        PONCA_MULTIARCH inline Base& operator()(const typename QueryInType::InputType& in)
+        {
+            QueryInType::operator()(in);
             return *((Base*)(this));
         }
     };
 
-DECLARE_INDEX_QUERY_CLASS(KNearest) //KNearestIndexQuery
-DECLARE_INDEX_QUERY_CLASS(Nearest)  //NearestIndexQuery
-DECLARE_INDEX_QUERY_CLASS(Range)    //RangeIndexQuery
-DECLARE_POINT_QUERY_CLASS(KNearest) //KNearestPointQuery
-DECLARE_POINT_QUERY_CLASS(Nearest)  //NearestPointQuery
-DECLARE_POINT_QUERY_CLASS(Range)    //RangePointQuery
+    DECLARE_INDEX_QUERY_CLASS(KNearest) // KNearestIndexQuery
+    DECLARE_INDEX_QUERY_CLASS(Nearest)  // NearestIndexQuery
+    DECLARE_INDEX_QUERY_CLASS(Range)    // RangeIndexQuery
+    DECLARE_POINT_QUERY_CLASS(KNearest) // KNearestPointQuery
+    DECLARE_POINT_QUERY_CLASS(Nearest)  // NearestPointQuery
+    DECLARE_POINT_QUERY_CLASS(Range)    // RangePointQuery
 
-/// \}
+    /// \}
 
 #undef DECLARE_INDEX_QUERY_CLASS
 #undef DECLARE_POINT_QUERY_CLASS
-}
+} // namespace Ponca

--- a/doc/examples/concepts.hpp
+++ b/doc/examples/concepts.hpp
@@ -1,12 +1,16 @@
 // This file is expected to be compiled by doxygen only, for documentation purpose
 
-namespace Ponca {
-    namespace Concept {
-//! [PointConcept]
-        class PointConcept {
+namespace Ponca
+{
+    namespace Concept
+    {
+        //! [PointConcept]
+        class PointConcept
+        {
         public:
             /* \brief Defines the ambient space dimension, 3 in this example */
-            enum {
+            enum
+            {
                 Dim = 3
             };
             // \brief Defines the type used ton encode scalar values
@@ -18,30 +22,31 @@ namespace Ponca {
             PONCA_MULTIARCH inline PointConcept();
 
             // \brief Read access to the position property
-            // \note The return type should have the same API than VectorType (e.g. const Eigen::Map< const VectorType >&),
-            // or be implicitly convertible to VectorType
+            // \note The return type should have the same API than VectorType (e.g. const Eigen::Map< const VectorType
+            // >&), or be implicitly convertible to VectorType
             PONCA_MULTIARCH inline const VectorType& pos() const;
 
             // \brief Write access to the position property
             // \note Same constraints on return type
             PONCA_MULTIARCH inline VectorType& pos();
-        }; //class PointConcept
-//! [PointConcept]
+        }; // class PointConcept
+        //! [PointConcept]
 
-//! [ComputationalObjectConcept]
-        template < class DataPoint, class _NFilter, typename T = void  >
+        //! [ComputationalObjectConcept]
+        template <class DataPoint, class _NFilter, typename T = void>
         class ComputationalObjectConcept
         {
         protected:
-            enum {
-                Check = PROVIDES_CAPABILITY_1 && PROVIDES_CAPABILITY_2 //< List of required capabilities
-                PROVIDES_CAPABILITY,                                   //< List of provided capabilities
+            enum
+            {
+                Check = PROVIDES_CAPABILITY_1 && PROVIDES_CAPABILITY_2    //< List of required capabilities
+                                                     PROVIDES_CAPABILITY, //< List of provided capabilities
             };
 
         public:
             using Scalar         = typename DataPoint::Scalar;     //< Inherited scalar type
             using VectorType     = typename DataPoint::VectorType; //< Inherited vector type
-            using NeighborFilter = _NFilter;                      //< Filter applied on the neighbors
+            using NeighborFilter = _NFilter;                       //< Filter applied on the neighbors
 
         public:
             /**************************************************************************/
@@ -49,7 +54,7 @@ namespace Ponca {
             /**************************************************************************/
             // Init the WeightFunc, without changing the other internal states.
             // \warning Must be called be for any computation
-            PONCA_MULTIARCH inline void setNeighborFilter (const NeighborFilter& _w);
+            PONCA_MULTIARCH inline void setNeighborFilter(const NeighborFilter& _w);
 
             // Reset the internal states.
             // \warning Must be called be for any computation
@@ -60,28 +65,29 @@ namespace Ponca {
             /**************************************************************************/
             // Add a neighbor to perform the fit
             // \return false if param nei is not a valid neighbour (weight = 0)
-            PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar, const VectorType &, const DataPoint &);
+            PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar, const VectorType&, const DataPoint&);
             // Finalize the fitting procedure.
             // \return State of fitting
             // \warning Must be called be for any use of the fitting output
             PONCA_MULTIARCH inline FIT_RESULT finalize();
-        }; //class ComputationalObjectConcept
-//! [ComputationalObjectConcept]
+        }; // class ComputationalObjectConcept
+        //! [ComputationalObjectConcept]
 
-//! [ComputationalDerivativesConcept]
-        template < class DataPoint, class _NFilter, int Type, typename T>
+        //! [ComputationalDerivativesConcept]
+        template <class DataPoint, class _NFilter, int Type, typename T>
         class ComputationalDerivativesConcept
         {
         protected:
-            enum {
-                Check = PROVIDES_CAPABILITY_1 && PROVIDES_CAPABILITY_2 //< List of required capabilities
-                PROVIDES_CAPABILITY,                                   //< List of provided capabilities
+            enum
+            {
+                Check = PROVIDES_CAPABILITY_1 && PROVIDES_CAPABILITY_2    //< List of required capabilities
+                                                     PROVIDES_CAPABILITY, //< List of provided capabilities
             };
 
         public:
-            using Scalar     = typename DataPoint::Scalar;     //< Inherited scalar type
-            using VectorType = typename DataPoint::VectorType; //< Inherited vector type
-            using NeighborFilter = _NFilter;                  //< Filter applied on the neighbors
+            using Scalar         = typename DataPoint::Scalar;     //< Inherited scalar type
+            using VectorType     = typename DataPoint::VectorType; //< Inherited vector type
+            using NeighborFilter = _NFilter;                       //< Filter applied on the neighbors
             // Static array of scalars with a size adapted to the differentiation type
             using VectorArray = typename Base::VectorArray;
             // Static array of scalars with a size adapted to the differentiation type
@@ -93,7 +99,7 @@ namespace Ponca {
             /**************************************************************************/
             // Init the WeightFunc, without changing the other internal states.
             // \warning Must be called be for any computation
-            PONCA_MULTIARCH inline void setNeighborFilter (const NeighborFilter& _w);
+            PONCA_MULTIARCH inline void setNeighborFilter(const NeighborFilter& _w);
 
             // Set the evaluation position and reset the internal states.
             // \warning Must be called be for any computation
@@ -104,32 +110,31 @@ namespace Ponca {
             /**************************************************************************/
             // Add a neighbor to perform the fit
             // \return false if param nei is not a valid neighbour (weight = 0)
-            PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w,
-                                                         const VectorType &localQ,
-                                                         const DataPoint &attributes,
-                                                         ScalarArray &dw);
+            PONCA_MULTIARCH inline bool addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                         const DataPoint& attributes, ScalarArray& dw);
             // Finalize the fitting procedure.
             // \return State of fitting
             // \warning Must be called be for any use of the fitting output
             PONCA_MULTIARCH inline FIT_RESULT finalize();
-        }; //class ComputationalDerivativesConcept
-//! [ComputationalDerivativesConcept]
+        }; // class ComputationalDerivativesConcept
+        //! [ComputationalDerivativesConcept]
 
-//! [WeightKernelConcept]
+        //! [WeightKernelConcept]
         // \brief Concept of a 1D weighting function and its derivatives.
         template <typename _Scalar>
-        class WeightKernelConcept{
+        class WeightKernelConcept
+        {
         public:
             typedef _Scalar Scalar;
 
             // \brief Apply the weighting kernel to the scalar value f(x)
-            PONCA_MULTIARCH inline Scalar f  (const Scalar& x) const {}
+            PONCA_MULTIARCH inline Scalar f(const Scalar& x) const {}
             // \brief Apply the first derivative of the weighting kernel to the scalar value f'(x)
-            PONCA_MULTIARCH inline Scalar df (const Scalar& x) const {}
+            PONCA_MULTIARCH inline Scalar df(const Scalar& x) const {}
             // \brief Apply the second derivative of the weighting kernel to the scalar value f''(x)
             PONCA_MULTIARCH inline Scalar ddf(const Scalar& x) const {}
-        };// class WeightKernelConcept
-//! [WeightKernelConcept]
+        }; // class WeightKernelConcept
+        //! [WeightKernelConcept]
 
-    } //namespace Concept
-} //namespace Ponca
+    } // namespace Concept
+} // namespace Ponca

--- a/examples/cpp/nanoflann/nanoflann.hpp
+++ b/examples/cpp/nanoflann/nanoflann.hpp
@@ -48,12 +48,12 @@
 #include <array>
 #include <atomic>
 #include <cassert>
-#include <cmath>  // for abs()
-#include <cstdlib>  // for abs()
-#include <functional>  // std::reference_wrapper
+#include <cmath>      // for abs()
+#include <cstdlib>    // for abs()
+#include <functional> // std::reference_wrapper
 #include <future>
 #include <istream>
-#include <limits>  // std::numeric_limits
+#include <limits> // std::numeric_limits
 #include <ostream>
 #include <stdexcept>
 #include <unordered_set>
@@ -63,2524 +63,2391 @@
 #define NANOFLANN_VERSION 0x150
 
 // Avoid conflicting declaration of min/max macros in Windows headers
-#if !defined(NOMINMAX) && \
-    (defined(_WIN32) || defined(_WIN32_) || defined(WIN32) || defined(_WIN64))
-#define NOMINMAX
-#ifdef max
-#undef max
-#undef min
-#endif
+#if !defined(NOMINMAX) && (defined(_WIN32) || defined(_WIN32_) || defined(WIN32) || defined(_WIN64))
+#    define NOMINMAX
+#    ifdef max
+#        undef max
+#        undef min
+#    endif
 #endif
 // Avoid conflicts with X11 headers
 #ifdef None
-#undef None
+#    undef None
 #endif
 
 namespace nanoflann
 {
-/** @addtogroup nanoflann_grp nanoflann C++ library for KD-trees
- *  \{ */
+    /** @addtogroup nanoflann_grp nanoflann C++ library for KD-trees
+     *  \{ */
 
-/** the PI constant (required to avoid MSVC missing symbols) */
-template <typename T>
-T pi_const()
-{
-    return static_cast<T>(3.14159265358979323846);
-}
-
-/**
- * Traits if object is resizable and assignable (typically has a resize | assign
- * method)
- */
-template <typename T, typename = int>
-struct has_resize : std::false_type
-{
-};
-
-template <typename T>
-struct has_resize<T, decltype((void)std::declval<T>().resize(1), 0)>
-    : std::true_type
-{
-};
-
-template <typename T, typename = int>
-struct has_assign : std::false_type
-{
-};
-
-template <typename T>
-struct has_assign<T, decltype((void)std::declval<T>().assign(1, 0), 0)>
-    : std::true_type
-{
-};
-
-/**
- * Free function to resize a resizable object
- */
-template <typename Container>
-inline typename std::enable_if<has_resize<Container>::value, void>::type resize(
-    Container& c, const size_t nElements)
-{
-    c.resize(nElements);
-}
-
-/**
- * Free function that has no effects on non resizable containers (e.g.
- * std::array) It raises an exception if the expected size does not match
- */
-template <typename Container>
-inline typename std::enable_if<!has_resize<Container>::value, void>::type
-    resize(Container& c, const size_t nElements)
-{
-    if (nElements != c.size())
-        throw std::logic_error("Try to change the size of a std::array.");
-}
-
-/**
- * Free function to assign to a container
- */
-template <typename Container, typename T>
-inline typename std::enable_if<has_assign<Container>::value, void>::type assign(
-    Container& c, const size_t nElements, const T& value)
-{
-    c.assign(nElements, value);
-}
-
-/**
- * Free function to assign to a std::array
- */
-template <typename Container, typename T>
-inline typename std::enable_if<!has_assign<Container>::value, void>::type
-    assign(Container& c, const size_t nElements, const T& value)
-{
-    for (size_t i = 0; i < nElements; i++) c[i] = value;
-}
-
-/** @addtogroup result_sets_grp Result set classes
- *  \{ */
-template <
-    typename _DistanceType, typename _IndexType = size_t,
-    typename _CountType = size_t>
-class KNNResultSet
-{
-   public:
-    using DistanceType = _DistanceType;
-    using IndexType    = _IndexType;
-    using CountType    = _CountType;
-
-   private:
-    IndexType*    indices;
-    DistanceType* dists;
-    CountType     capacity;
-    CountType     count;
-
-   public:
-    explicit KNNResultSet(CountType capacity_)
-        : indices(nullptr), dists(nullptr), capacity(capacity_), count(0)
-    {
-    }
-
-    void init(IndexType* indices_, DistanceType* dists_)
-    {
-        indices = indices_;
-        dists   = dists_;
-        count   = 0;
-        if (capacity)
-            dists[capacity - 1] = (std::numeric_limits<DistanceType>::max)();
-    }
-
-    CountType size() const { return count; }
-
-    bool full() const { return count == capacity; }
-
-    /**
-     * Called during search to add an element matching the criteria.
-     * \return true if the search should be continued, false if the results are
-     * sufficient
-     */
-    bool addPoint(DistanceType dist, IndexType index)
-    {
-        CountType i;
-        for (i = count; i > 0; --i)
-        {
-            /** If defined and two points have the same distance, the one with
-             *  the lowest-index will be returned first. */
-#ifdef NANOFLANN_FIRST_MATCH
-            if ((dists[i - 1] > dist) ||
-                ((dist == dists[i - 1]) && (indices[i - 1] > index)))
-            {
-#else
-            if (dists[i - 1] > dist)
-            {
-#endif
-                if (i < capacity)
-                {
-                    dists[i]   = dists[i - 1];
-                    indices[i] = indices[i - 1];
-                }
-            }
-            else
-                break;
-        }
-        if (i < capacity)
-        {
-            dists[i]   = dist;
-            indices[i] = index;
-        }
-        if (count < capacity) count++;
-
-        // tell caller that the search shall continue
-        return true;
-    }
-
-    DistanceType worstDist() const { return dists[capacity - 1]; }
-};
-
-/** operator "<" for std::sort() */
-struct IndexDist_Sorter
-{
-    /** PairType will be typically: ResultItem<IndexType,DistanceType> */
-    template <typename PairType>
-    bool operator()(const PairType& p1, const PairType& p2) const
-    {
-        return p1.second < p2.second;
-    }
-};
-
-/**
- * Each result element in RadiusResultSet. Note that distances and indices
- * are named `first` and `second` to keep backward-compatibility with the
- * `std::pair<>` type used in the past. In contrast, this structure is ensured
- * to be `std::is_standard_layout` so it can be used in wrappers to other
- * languages.
- * See: https://github.com/jlblancoc/nanoflann/issues/166
- */
-template <typename IndexType = size_t, typename DistanceType = double>
-struct ResultItem
-{
-    ResultItem() = default;
-    ResultItem(const IndexType index, const DistanceType distance)
-        : first(index), second(distance)
-    {
-    }
-
-    IndexType    first;  //!< Index of the sample in the dataset
-    DistanceType second;  //!< Distance from sample to query point
-};
-
-/**
- * A result-set class used when performing a radius based search.
- */
-template <typename _DistanceType, typename _IndexType = size_t>
-class RadiusResultSet
-{
-   public:
-    using DistanceType = _DistanceType;
-    using IndexType    = _IndexType;
-
-   public:
-    const DistanceType radius;
-
-    std::vector<ResultItem<IndexType, DistanceType>>& m_indices_dists;
-
-    explicit RadiusResultSet(
-        DistanceType                                      radius_,
-        std::vector<ResultItem<IndexType, DistanceType>>& indices_dists)
-        : radius(radius_), m_indices_dists(indices_dists)
-    {
-        init();
-    }
-
-    void init() { clear(); }
-    void clear() { m_indices_dists.clear(); }
-
-    size_t size() const { return m_indices_dists.size(); }
-    size_t empty() const { return m_indices_dists.empty(); }
-
-    bool full() const { return true; }
-
-    /**
-     * Called during search to add an element matching the criteria.
-     * \return true if the search should be continued, false if the results are
-     * sufficient
-     */
-    bool addPoint(DistanceType dist, IndexType index)
-    {
-        if (dist < radius) m_indices_dists.emplace_back(index, dist);
-        return true;
-    }
-
-    DistanceType worstDist() const { return radius; }
-
-    /**
-     * Find the worst result (farthest neighbor) without copying or sorting
-     * Pre-conditions: size() > 0
-     */
-    ResultItem<IndexType, DistanceType> worst_item() const
-    {
-        if (m_indices_dists.empty())
-            throw std::runtime_error(
-                "Cannot invoke RadiusResultSet::worst_item() on "
-                "an empty list of results.");
-        auto it = std::max_element(
-            m_indices_dists.begin(), m_indices_dists.end(), IndexDist_Sorter());
-        return *it;
-    }
-};
-
-/** \} */
-
-/** @addtogroup loadsave_grp Load/save auxiliary functions
- * \{ */
-template <typename T>
-void save_value(std::ostream& stream, const T& value)
-{
-    stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
-}
-
-template <typename T>
-void save_value(std::ostream& stream, const std::vector<T>& value)
-{
-    size_t size = value.size();
-    stream.write(reinterpret_cast<const char*>(&size), sizeof(size_t));
-    stream.write(reinterpret_cast<const char*>(value.data()), sizeof(T) * size);
-}
-
-template <typename T>
-void load_value(std::istream& stream, T& value)
-{
-    stream.read(reinterpret_cast<char*>(&value), sizeof(T));
-}
-
-template <typename T>
-void load_value(std::istream& stream, std::vector<T>& value)
-{
-    size_t size;
-    stream.read(reinterpret_cast<char*>(&size), sizeof(size_t));
-    value.resize(size);
-    stream.read(reinterpret_cast<char*>(value.data()), sizeof(T) * size);
-}
-/** \} */
-
-/** @addtogroup metric_grp Metric (distance) classes
- * \{ */
-
-struct Metric
-{
-};
-
-/** Manhattan distance functor (generic version, optimized for
- * high-dimensionality data sets). Corresponding distance traits:
- * nanoflann::metric_L1
- *
- * \tparam T Type of the elements (e.g. double, float, uint8_t)
- * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed)
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    class T, class DataSource, typename _DistanceType = T,
-    typename IndexType = uint32_t>
-struct L1_Adaptor
-{
-    using ElementType  = T;
-    using DistanceType = _DistanceType;
-
-    const DataSource& data_source;
-
-    L1_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
-
-    DistanceType evalMetric(
-        const T* a, const IndexType b_idx, size_t size,
-        DistanceType worst_dist = -1) const
-    {
-        DistanceType result    = DistanceType();
-        const T*     last      = a + size;
-        const T*     lastgroup = last - 3;
-        size_t       d         = 0;
-
-        /* Process 4 items with each loop for efficiency. */
-        while (a < lastgroup)
-        {
-            const DistanceType diff0 =
-                std::abs(a[0] - data_source.kdtree_get_pt(b_idx, d++));
-            const DistanceType diff1 =
-                std::abs(a[1] - data_source.kdtree_get_pt(b_idx, d++));
-            const DistanceType diff2 =
-                std::abs(a[2] - data_source.kdtree_get_pt(b_idx, d++));
-            const DistanceType diff3 =
-                std::abs(a[3] - data_source.kdtree_get_pt(b_idx, d++));
-            result += diff0 + diff1 + diff2 + diff3;
-            a += 4;
-            if ((worst_dist > 0) && (result > worst_dist)) { return result; }
-        }
-        /* Process last 0-3 components.  Not needed for standard vector lengths.
-         */
-        while (a < last)
-        { result += std::abs(*a++ - data_source.kdtree_get_pt(b_idx, d++)); }
-        return result;
-    }
-
-    template <typename U, typename V>
-    DistanceType accum_dist(const U a, const V b, const size_t) const
-    {
-        return std::abs(a - b);
-    }
-};
-
-/** **Squared** Euclidean distance functor (generic version, optimized for
- * high-dimensionality data sets). Corresponding distance traits:
- * nanoflann::metric_L2
- *
- * \tparam T Type of the elements (e.g. double, float, uint8_t)
- * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed)
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    class T, class DataSource, typename _DistanceType = T,
-    typename IndexType = uint32_t>
-struct L2_Adaptor
-{
-    using ElementType  = T;
-    using DistanceType = _DistanceType;
-
-    const DataSource& data_source;
-
-    L2_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
-
-    DistanceType evalMetric(
-        const T* a, const IndexType b_idx, size_t size,
-        DistanceType worst_dist = -1) const
-    {
-        DistanceType result    = DistanceType();
-        const T*     last      = a + size;
-        const T*     lastgroup = last - 3;
-        size_t       d         = 0;
-
-        /* Process 4 items with each loop for efficiency. */
-        while (a < lastgroup)
-        {
-            const DistanceType diff0 =
-                a[0] - data_source.kdtree_get_pt(b_idx, d++);
-            const DistanceType diff1 =
-                a[1] - data_source.kdtree_get_pt(b_idx, d++);
-            const DistanceType diff2 =
-                a[2] - data_source.kdtree_get_pt(b_idx, d++);
-            const DistanceType diff3 =
-                a[3] - data_source.kdtree_get_pt(b_idx, d++);
-            result +=
-                diff0 * diff0 + diff1 * diff1 + diff2 * diff2 + diff3 * diff3;
-            a += 4;
-            if ((worst_dist > 0) && (result > worst_dist)) { return result; }
-        }
-        /* Process last 0-3 components.  Not needed for standard vector lengths.
-         */
-        while (a < last)
-        {
-            const DistanceType diff0 =
-                *a++ - data_source.kdtree_get_pt(b_idx, d++);
-            result += diff0 * diff0;
-        }
-        return result;
-    }
-
-    template <typename U, typename V>
-    DistanceType accum_dist(const U a, const V b, const size_t) const
-    {
-        return (a - b) * (a - b);
-    }
-};
-
-/** **Squared** Euclidean (L2) distance functor (suitable for low-dimensionality
- * datasets, like 2D or 3D point clouds) Corresponding distance traits:
- * nanoflann::metric_L2_Simple
- *
- * \tparam T Type of the elements (e.g. double, float, uint8_t)
- * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed)
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    class T, class DataSource, typename _DistanceType = T,
-    typename IndexType = uint32_t>
-struct L2_Simple_Adaptor
-{
-    using ElementType  = T;
-    using DistanceType = _DistanceType;
-
-    const DataSource& data_source;
-
-    L2_Simple_Adaptor(const DataSource& _data_source)
-        : data_source(_data_source)
-    {
-    }
-
-    DistanceType evalMetric(
-        const T* a, const IndexType b_idx, size_t size) const
-    {
-        DistanceType result = DistanceType();
-        for (size_t i = 0; i < size; ++i)
-        {
-            const DistanceType diff =
-                a[i] - data_source.kdtree_get_pt(b_idx, i);
-            result += diff * diff;
-        }
-        return result;
-    }
-
-    template <typename U, typename V>
-    DistanceType accum_dist(const U a, const V b, const size_t) const
-    {
-        return (a - b) * (a - b);
-    }
-};
-
-/** SO2 distance functor
- *  Corresponding distance traits: nanoflann::metric_SO2
- *
- * \tparam T Type of the elements (e.g. double, float, uint8_t)
- * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed) (e.g.
- * float, double) orientation is constrained to be in [-pi, pi]
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    class T, class DataSource, typename _DistanceType = T,
-    typename IndexType = uint32_t>
-struct SO2_Adaptor
-{
-    using ElementType  = T;
-    using DistanceType = _DistanceType;
-
-    const DataSource& data_source;
-
-    SO2_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
-
-    DistanceType evalMetric(
-        const T* a, const IndexType b_idx, size_t size) const
-    {
-        return accum_dist(
-            a[size - 1], data_source.kdtree_get_pt(b_idx, size - 1), size - 1);
-    }
-
-    /** Note: this assumes that input angles are already in the range [-pi,pi]
-     */
-    template <typename U, typename V>
-    DistanceType accum_dist(const U a, const V b, const size_t) const
-    {
-        DistanceType result = DistanceType();
-        DistanceType PI     = pi_const<DistanceType>();
-        result              = b - a;
-        if (result > PI)
-            result -= 2 * PI;
-        else if (result < -PI)
-            result += 2 * PI;
-        return result;
-    }
-};
-
-/** SO3 distance functor (Uses L2_Simple)
- *  Corresponding distance traits: nanoflann::metric_SO3
- *
- * \tparam T Type of the elements (e.g. double, float, uint8_t)
- * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed) (e.g.
- * float, double)
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    class T, class DataSource, typename _DistanceType = T,
-    typename IndexType = uint32_t>
-struct SO3_Adaptor
-{
-    using ElementType  = T;
-    using DistanceType = _DistanceType;
-
-    L2_Simple_Adaptor<T, DataSource, DistanceType, IndexType>
-        distance_L2_Simple;
-
-    SO3_Adaptor(const DataSource& _data_source)
-        : distance_L2_Simple(_data_source)
-    {
-    }
-
-    DistanceType evalMetric(
-        const T* a, const IndexType b_idx, size_t size) const
-    {
-        return distance_L2_Simple.evalMetric(a, b_idx, size);
-    }
-
-    template <typename U, typename V>
-    DistanceType accum_dist(const U a, const V b, const size_t idx) const
-    {
-        return distance_L2_Simple.accum_dist(a, b, idx);
-    }
-};
-
-/** Metaprogramming helper traits class for the L1 (Manhattan) metric */
-struct metric_L1 : public Metric
-{
-    template <class T, class DataSource, typename IndexType = uint32_t>
-    struct traits
-    {
-        using distance_t = L1_Adaptor<T, DataSource, T, IndexType>;
-    };
-};
-/** Metaprogramming helper traits class for the L2 (Euclidean) **squared**
- * distance metric */
-struct metric_L2 : public Metric
-{
-    template <class T, class DataSource, typename IndexType = uint32_t>
-    struct traits
-    {
-        using distance_t = L2_Adaptor<T, DataSource, T, IndexType>;
-    };
-};
-/** Metaprogramming helper traits class for the L2_simple (Euclidean)
- * **squared** distance metric */
-struct metric_L2_Simple : public Metric
-{
-    template <class T, class DataSource, typename IndexType = uint32_t>
-    struct traits
-    {
-        using distance_t = L2_Simple_Adaptor<T, DataSource, T, IndexType>;
-    };
-};
-/** Metaprogramming helper traits class for the SO3_InnerProdQuat metric */
-struct metric_SO2 : public Metric
-{
-    template <class T, class DataSource, typename IndexType = uint32_t>
-    struct traits
-    {
-        using distance_t = SO2_Adaptor<T, DataSource, T, IndexType>;
-    };
-};
-/** Metaprogramming helper traits class for the SO3_InnerProdQuat metric */
-struct metric_SO3 : public Metric
-{
-    template <class T, class DataSource, typename IndexType = uint32_t>
-    struct traits
-    {
-        using distance_t = SO3_Adaptor<T, DataSource, T, IndexType>;
-    };
-};
-
-/** \} */
-
-/** @addtogroup param_grp Parameter structs
- * \{ */
-
-enum class KDTreeSingleIndexAdaptorFlags
-{
-    None                  = 0,
-    SkipInitialBuildIndex = 1
-};
-
-inline std::underlying_type<KDTreeSingleIndexAdaptorFlags>::type operator&(
-    KDTreeSingleIndexAdaptorFlags lhs, KDTreeSingleIndexAdaptorFlags rhs)
-{
-    using underlying =
-        typename std::underlying_type<KDTreeSingleIndexAdaptorFlags>::type;
-    return static_cast<underlying>(lhs) & static_cast<underlying>(rhs);
-}
-
-/**  Parameters (see README.md) */
-struct KDTreeSingleIndexAdaptorParams
-{
-    KDTreeSingleIndexAdaptorParams(
-        size_t                        _leaf_max_size = 10,
-        KDTreeSingleIndexAdaptorFlags _flags =
-            KDTreeSingleIndexAdaptorFlags::None,
-        unsigned int _n_thread_build = 1)
-        : leaf_max_size(_leaf_max_size),
-          flags(_flags),
-          n_thread_build(_n_thread_build)
-    {
-    }
-
-    size_t                        leaf_max_size;
-    KDTreeSingleIndexAdaptorFlags flags;
-    unsigned int                  n_thread_build;
-};
-
-/** Search options for KDTreeSingleIndexAdaptor::findNeighbors() */
-struct SearchParameters
-{
-    SearchParameters(float eps_ = 0, bool sorted_ = true)
-        : eps(eps_), sorted(sorted_)
-    {
-    }
-
-    float eps;  //!< search for eps-approximate neighbours (default: 0)
-    bool  sorted;  //!< only for radius search, require neighbours sorted by
-                  //!< distance (default: true)
-};
-/** \} */
-
-/** @addtogroup memalloc_grp Memory allocation
- * \{ */
-
-/**
- * Pooled storage allocator
- *
- * The following routines allow for the efficient allocation of storage in
- * small chunks from a specified pool.  Rather than allowing each structure
- * to be freed individually, an entire pool of storage is freed at once.
- * This method has two advantages over just using malloc() and free().  First,
- * it is far more efficient for allocating small objects, as there is
- * no overhead for remembering all the information needed to free each
- * object or consolidating fragmented memory.  Second, the decision about
- * how long to keep an object is made at the time of allocation, and there
- * is no need to track down all the objects to free them.
- *
- */
-class PooledAllocator
-{
-    static constexpr size_t WORDSIZE  = 16;
-    static constexpr size_t BLOCKSIZE = 8192;
-
-    /* We maintain memory alignment to word boundaries by requiring that all
-        allocations be in multiples of the machine wordsize.  */
-    /* Size of machine word in bytes.  Must be power of 2. */
-    /* Minimum number of bytes requested at a time from	the system.  Must be
-     * multiple of WORDSIZE. */
-
-    using Offset    = uint32_t;
-    using Size      = uint32_t;
-    using Dimension = int32_t;
-
-    Size  remaining_ = 0;  //!< Number of bytes left in current block of storage
-    void* base_ = nullptr;  //!< Pointer to base of current block of storage
-    void* loc_  = nullptr;  //!< Current location in block to next allocate
-
-    void internal_init()
-    {
-        remaining_   = 0;
-        base_        = nullptr;
-        usedMemory   = 0;
-        wastedMemory = 0;
-    }
-
-   public:
-    Size usedMemory   = 0;
-    Size wastedMemory = 0;
-
-    /**
-        Default constructor. Initializes a new pool.
-     */
-    PooledAllocator() { internal_init(); }
-
-    /**
-     * Destructor. Frees all the memory allocated in this pool.
-     */
-    ~PooledAllocator() { free_all(); }
-
-    /** Frees all allocated memory chunks */
-    void free_all()
-    {
-        while (base_ != nullptr)
-        {
-            // Get pointer to prev block
-            void* prev = *(static_cast<void**>(base_));
-            ::free(base_);
-            base_ = prev;
-        }
-        internal_init();
-    }
-
-    /**
-     * Returns a pointer to a piece of new memory of the given size in bytes
-     * allocated from the pool.
-     */
-    void* malloc(const size_t req_size)
-    {
-        /* Round size up to a multiple of wordsize.  The following expression
-            only works for WORDSIZE that is a power of 2, by masking last bits
-           of incremented size to zero.
-         */
-        const Size size = (req_size + (WORDSIZE - 1)) & ~(WORDSIZE - 1);
-
-        /* Check whether a new block must be allocated.  Note that the first
-           word of a block is reserved for a pointer to the previous block.
-         */
-        if (size > remaining_)
-        {
-            wastedMemory += remaining_;
-
-            /* Allocate new storage. */
-            const Size blocksize =
-                (size + sizeof(void*) + (WORDSIZE - 1) > BLOCKSIZE)
-                    ? size + sizeof(void*) + (WORDSIZE - 1)
-                    : BLOCKSIZE;
-
-            // use the standard C malloc to allocate memory
-            void* m = ::malloc(blocksize);
-            if (!m)
-            {
-                fprintf(stderr, "Failed to allocate memory.\n");
-                throw std::bad_alloc();
-            }
-
-            /* Fill first word of new block with pointer to previous block. */
-            static_cast<void**>(m)[0] = base_;
-            base_                     = m;
-
-            Size shift = 0;
-            // int size_t = (WORDSIZE - ( (((size_t)m) + sizeof(void*)) &
-            // (WORDSIZE-1))) & (WORDSIZE-1);
-
-            remaining_ = blocksize - sizeof(void*) - shift;
-            loc_       = (static_cast<char*>(m) + sizeof(void*) + shift);
-        }
-        void* rloc = loc_;
-        loc_       = static_cast<char*>(loc_) + size;
-        remaining_ -= size;
-
-        usedMemory += size;
-
-        return rloc;
-    }
-
-    /**
-     * Allocates (using this pool) a generic type T.
-     *
-     * Params:
-     *     count = number of instances to allocate.
-     * Returns: pointer (of type T*) to memory buffer
-     */
+    /** the PI constant (required to avoid MSVC missing symbols) */
     template <typename T>
-    T* allocate(const size_t count = 1)
+    T pi_const()
     {
-        T* mem = static_cast<T*>(this->malloc(sizeof(T) * count));
-        return mem;
+        return static_cast<T>(3.14159265358979323846);
     }
-};
-/** \} */
-
-/** @addtogroup nanoflann_metaprog_grp Auxiliary metaprogramming stuff
- * \{ */
-
-/** Used to declare fixed-size arrays when DIM>0, dynamically-allocated vectors
- * when DIM=-1. Fixed size version for a generic DIM:
- */
-template <int32_t DIM, typename T>
-struct array_or_vector
-{
-    using type = std::array<T, DIM>;
-};
-/** Dynamic size version */
-template <typename T>
-struct array_or_vector<-1, T>
-{
-    using type = std::vector<T>;
-};
-
-/** \} */
-
-/** kd-tree base-class
- *
- * Contains the member functions common to the classes KDTreeSingleIndexAdaptor
- * and KDTreeSingleIndexDynamicAdaptor_.
- *
- * \tparam Derived The name of the class which inherits this class.
- * \tparam DatasetAdaptor The user-provided adaptor, which must be ensured to
- *         have a lifetime equal or longer than the instance of this class.
- * \tparam Distance The distance metric to use, these are all classes derived
- * from nanoflann::Metric
- * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    class Derived, typename Distance, class DatasetAdaptor, int32_t DIM = -1,
-    typename IndexType = uint32_t>
-class KDTreeBaseClass
-{
-   public:
-    /** Frees the previously-built index. Automatically called within
-     * buildIndex(). */
-    void freeIndex(Derived& obj)
-    {
-        obj.pool_.free_all();
-        obj.root_node_           = nullptr;
-        obj.size_at_index_build_ = 0;
-    }
-
-    using ElementType  = typename Distance::ElementType;
-    using DistanceType = typename Distance::DistanceType;
 
     /**
-     *  Array of indices to vectors in the dataset_.
+     * Traits if object is resizable and assignable (typically has a resize | assign
+     * method)
      */
-    std::vector<IndexType> vAcc_;
-
-    using Offset    = typename decltype(vAcc_)::size_type;
-    using Size      = typename decltype(vAcc_)::size_type;
-    using Dimension = int32_t;
-
-    /*---------------------------
-     * Internal Data Structures
-     * --------------------------*/
-    struct Node
+    template <typename T, typename = int>
+    struct has_resize : std::false_type
     {
-        /** Union used because a node can be either a LEAF node or a non-leaf
-         * node, so both data fields are never used simultaneously */
-        union
-        {
-            struct leaf
-            {
-                Offset left, right;  //!< Indices of points in leaf node
-            } lr;
-            struct nonleaf
-            {
-                Dimension divfeat;  //!< Dimension used for subdivision.
-                /// The values used for subdivision.
-                DistanceType divlow, divhigh;
-            } sub;
-        } node_type;
-
-        /** Child nodes (both=nullptr mean its a leaf node) */
-        Node *child1 = nullptr, *child2 = nullptr;
     };
 
-    using NodePtr      = Node*;
-    using NodeConstPtr = const Node*;
-
-    struct Interval
+    template <typename T>
+    struct has_resize<T, decltype((void)std::declval<T>().resize(1), 0)> : std::true_type
     {
-        ElementType low, high;
     };
 
-    NodePtr root_node_ = nullptr;
+    template <typename T, typename = int>
+    struct has_assign : std::false_type
+    {
+    };
 
-    Size leaf_max_size_ = 0;
-
-    /// Number of thread for concurrent tree build
-    Size n_thread_build_ = 1;
-    /// Number of current points in the dataset
-    Size size_ = 0;
-    /// Number of points in the dataset when the index was built
-    Size      size_at_index_build_ = 0;
-    Dimension dim_                 = 0;  //!< Dimensionality of each data point
-
-    /** Define "BoundingBox" as a fixed-size or variable-size container
-     * depending on "DIM" */
-    using BoundingBox = typename array_or_vector<DIM, Interval>::type;
-
-    /** Define "distance_vector_t" as a fixed-size or variable-size container
-     * depending on "DIM" */
-    using distance_vector_t = typename array_or_vector<DIM, DistanceType>::type;
-
-    /** The KD-tree used to find neighbours */
-    BoundingBox root_bbox_;
+    template <typename T>
+    struct has_assign<T, decltype((void)std::declval<T>().assign(1, 0), 0)> : std::true_type
+    {
+    };
 
     /**
-     * Pooled memory allocator.
-     *
-     * Using a pooled memory allocator is more efficient
-     * than allocating memory directly when there is a large
-     * number small of memory allocations.
+     * Free function to resize a resizable object
      */
-    PooledAllocator pool_;
-
-    /** Returns number of points in dataset  */
-    Size size(const Derived& obj) const { return obj.size_; }
-
-    /** Returns the length of each point in the dataset */
-    Size veclen(const Derived& obj) { return DIM > 0 ? DIM : obj.dim; }
-
-    /// Helper accessor to the dataset points:
-    ElementType dataset_get(
-        const Derived& obj, IndexType element, Dimension component) const
+    template <typename Container>
+    inline typename std::enable_if<has_resize<Container>::value, void>::type resize(Container& c,
+                                                                                    const size_t nElements)
     {
-        return obj.dataset_.kdtree_get_pt(element, component);
+        c.resize(nElements);
     }
 
     /**
-     * Computes the inde memory usage
-     * Returns: memory used by the index
+     * Free function that has no effects on non resizable containers (e.g.
+     * std::array) It raises an exception if the expected size does not match
      */
-    Size usedMemory(Derived& obj)
+    template <typename Container>
+    inline typename std::enable_if<!has_resize<Container>::value, void>::type resize(Container& c,
+                                                                                     const size_t nElements)
     {
-        return obj.pool_.usedMemory + obj.pool_.wastedMemory +
-               obj.dataset_.kdtree_get_point_count() *
-                   sizeof(IndexType);  // pool memory and vind array memory
-    }
-
-    void computeMinMax(
-        const Derived& obj, Offset ind, Size count, Dimension element,
-        ElementType& min_elem, ElementType& max_elem)
-    {
-        min_elem = dataset_get(obj, vAcc_[ind], element);
-        max_elem = min_elem;
-        for (Offset i = 1; i < count; ++i)
-        {
-            ElementType val = dataset_get(obj, vAcc_[ind + i], element);
-            if (val < min_elem) min_elem = val;
-            if (val > max_elem) max_elem = val;
-        }
+        if (nElements != c.size())
+            throw std::logic_error("Try to change the size of a std::array.");
     }
 
     /**
-     * Create a tree node that subdivides the list of vecs from vind[first]
-     * to vind[last].  The routine is called recursively on each sublist.
-     *
-     * \param left index of the first vector
-     * \param right index of the last vector
+     * Free function to assign to a container
      */
-    NodePtr divideTree(
-        Derived& obj, const Offset left, const Offset right, BoundingBox& bbox)
+    template <typename Container, typename T>
+    inline typename std::enable_if<has_assign<Container>::value, void>::type assign(Container& c,
+                                                                                    const size_t nElements,
+                                                                                    const T& value)
     {
-        NodePtr node = obj.pool_.template allocate<Node>();  // allocate memory
-        const auto dims = (DIM > 0 ? DIM : obj.dim_);
-
-        /* If too few exemplars remain, then make this a leaf node. */
-        if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
-        {
-            node->child1 = node->child2 = nullptr; /* Mark as leaf node. */
-            node->node_type.lr.left     = left;
-            node->node_type.lr.right    = right;
-
-            // compute bounding-box of leaf points
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                bbox[i].low  = dataset_get(obj, obj.vAcc_[left], i);
-                bbox[i].high = dataset_get(obj, obj.vAcc_[left], i);
-            }
-            for (Offset k = left + 1; k < right; ++k)
-            {
-                for (Dimension i = 0; i < dims; ++i)
-                {
-                    const auto val = dataset_get(obj, obj.vAcc_[k], i);
-                    if (bbox[i].low > val) bbox[i].low = val;
-                    if (bbox[i].high < val) bbox[i].high = val;
-                }
-            }
-        }
-        else
-        {
-            Offset       idx;
-            Dimension    cutfeat;
-            DistanceType cutval;
-            middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
-
-            node->node_type.sub.divfeat = cutfeat;
-
-            BoundingBox left_bbox(bbox);
-            left_bbox[cutfeat].high = cutval;
-            node->child1 = this->divideTree(obj, left, left + idx, left_bbox);
-
-            BoundingBox right_bbox(bbox);
-            right_bbox[cutfeat].low = cutval;
-            node->child2 = this->divideTree(obj, left + idx, right, right_bbox);
-
-            node->node_type.sub.divlow  = left_bbox[cutfeat].high;
-            node->node_type.sub.divhigh = right_bbox[cutfeat].low;
-
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                bbox[i].low  = std::min(left_bbox[i].low, right_bbox[i].low);
-                bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
-            }
-        }
-
-        return node;
+        c.assign(nElements, value);
     }
 
     /**
-     * Create a tree node that subdivides the list of vecs from vind[first] to
-     * vind[last] concurrently.  The routine is called recursively on each
-     * sublist.
-     *
-     * \param left index of the first vector
-     * \param right index of the last vector
-     * \param thread_count count of std::async threads
-     * \param mutex mutex for mempool allocation
+     * Free function to assign to a std::array
      */
-    NodePtr divideTreeConcurrent(
-        Derived& obj, const Offset left, const Offset right, BoundingBox& bbox,
-        std::atomic<unsigned int>& thread_count, std::mutex& mutex)
+    template <typename Container, typename T>
+    inline typename std::enable_if<!has_assign<Container>::value, void>::type assign(Container& c,
+                                                                                     const size_t nElements,
+                                                                                     const T& value)
     {
-        std::unique_lock<std::mutex> lock(mutex);
-        NodePtr node = obj.pool_.template allocate<Node>();  // allocate memory
-        lock.unlock();
-
-        const auto dims = (DIM > 0 ? DIM : obj.dim_);
-
-        /* If too few exemplars remain, then make this a leaf node. */
-        if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
-        {
-            node->child1 = node->child2 = nullptr; /* Mark as leaf node. */
-            node->node_type.lr.left     = left;
-            node->node_type.lr.right    = right;
-
-            // compute bounding-box of leaf points
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                bbox[i].low  = dataset_get(obj, obj.vAcc_[left], i);
-                bbox[i].high = dataset_get(obj, obj.vAcc_[left], i);
-            }
-            for (Offset k = left + 1; k < right; ++k)
-            {
-                for (Dimension i = 0; i < dims; ++i)
-                {
-                    const auto val = dataset_get(obj, obj.vAcc_[k], i);
-                    if (bbox[i].low > val) bbox[i].low = val;
-                    if (bbox[i].high < val) bbox[i].high = val;
-                }
-            }
-        }
-        else
-        {
-            Offset       idx;
-            Dimension    cutfeat;
-            DistanceType cutval;
-            middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
-
-            node->node_type.sub.divfeat = cutfeat;
-
-            std::future<NodePtr> left_future, right_future;
-
-            BoundingBox left_bbox(bbox);
-            left_bbox[cutfeat].high = cutval;
-            if (++thread_count < n_thread_build_)
-            {
-                left_future = std::async(
-                    std::launch::async, &KDTreeBaseClass::divideTreeConcurrent,
-                    this, std::ref(obj), left, left + idx, std::ref(left_bbox),
-                    std::ref(thread_count), std::ref(mutex));
-            }
-            else
-            {
-                --thread_count;
-                node->child1 = this->divideTreeConcurrent(
-                    obj, left, left + idx, left_bbox, thread_count, mutex);
-            }
-
-            BoundingBox right_bbox(bbox);
-            right_bbox[cutfeat].low = cutval;
-            if (++thread_count < n_thread_build_)
-            {
-                right_future = std::async(
-                    std::launch::async, &KDTreeBaseClass::divideTreeConcurrent,
-                    this, std::ref(obj), left + idx, right,
-                    std::ref(right_bbox), std::ref(thread_count),
-                    std::ref(mutex));
-            }
-            else
-            {
-                --thread_count;
-                node->child2 = this->divideTreeConcurrent(
-                    obj, left + idx, right, right_bbox, thread_count, mutex);
-            }
-
-            if (left_future.valid())
-            {
-                node->child1 = left_future.get();
-                --thread_count;
-            }
-            if (right_future.valid())
-            {
-                node->child2 = right_future.get();
-                --thread_count;
-            }
-
-            node->node_type.sub.divlow  = left_bbox[cutfeat].high;
-            node->node_type.sub.divhigh = right_bbox[cutfeat].low;
-
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                bbox[i].low  = std::min(left_bbox[i].low, right_bbox[i].low);
-                bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
-            }
-        }
-
-        return node;
+        for (size_t i = 0; i < nElements; i++)
+            c[i] = value;
     }
 
-    void middleSplit_(
-        const Derived& obj, const Offset ind, const Size count, Offset& index,
-        Dimension& cutfeat, DistanceType& cutval, const BoundingBox& bbox)
+    /** @addtogroup result_sets_grp Result set classes
+     *  \{ */
+    template <typename _DistanceType, typename _IndexType = size_t, typename _CountType = size_t>
+    class KNNResultSet
     {
-        const auto  dims     = (DIM > 0 ? DIM : obj.dim_);
-        const auto  EPS      = static_cast<DistanceType>(0.00001);
-        ElementType max_span = bbox[0].high - bbox[0].low;
-        for (Dimension i = 1; i < dims; ++i)
+    public:
+        using DistanceType = _DistanceType;
+        using IndexType    = _IndexType;
+        using CountType    = _CountType;
+
+    private:
+        IndexType* indices;
+        DistanceType* dists;
+        CountType capacity;
+        CountType count;
+
+    public:
+        explicit KNNResultSet(CountType capacity_) : indices(nullptr), dists(nullptr), capacity(capacity_), count(0) {}
+
+        void init(IndexType* indices_, DistanceType* dists_)
         {
-            ElementType span = bbox[i].high - bbox[i].low;
-            if (span > max_span) { max_span = span; }
+            indices = indices_;
+            dists   = dists_;
+            count   = 0;
+            if (capacity)
+                dists[capacity - 1] = (std::numeric_limits<DistanceType>::max)();
         }
-        ElementType max_spread = -1;
-        cutfeat                = 0;
-        for (Dimension i = 0; i < dims; ++i)
-        {
-            ElementType span = bbox[i].high - bbox[i].low;
-            if (span > (1 - EPS) * max_span)
-            {
-                ElementType min_elem, max_elem;
-                computeMinMax(obj, ind, count, i, min_elem, max_elem);
-                ElementType spread = max_elem - min_elem;
-                if (spread > max_spread)
-                {
-                    cutfeat    = i;
-                    max_spread = spread;
-                }
-            }
-        }
-        // split in the middle
-        DistanceType split_val = (bbox[cutfeat].low + bbox[cutfeat].high) / 2;
-        ElementType  min_elem, max_elem;
-        computeMinMax(obj, ind, count, cutfeat, min_elem, max_elem);
 
-        if (split_val < min_elem)
-            cutval = min_elem;
-        else if (split_val > max_elem)
-            cutval = max_elem;
-        else
-            cutval = split_val;
+        CountType size() const { return count; }
 
-        Offset lim1, lim2;
-        planeSplit(obj, ind, count, cutfeat, cutval, lim1, lim2);
+        bool full() const { return count == capacity; }
 
-        if (lim1 > count / 2)
-            index = lim1;
-        else if (lim2 < count / 2)
-            index = lim2;
-        else
-            index = count / 2;
-    }
-
-    /**
-     *  Subdivide the list of points by a plane perpendicular on the axis
-     * corresponding to the 'cutfeat' dimension at 'cutval' position.
-     *
-     *  On return:
-     *  dataset[ind[0..lim1-1]][cutfeat]<cutval
-     *  dataset[ind[lim1..lim2-1]][cutfeat]==cutval
-     *  dataset[ind[lim2..count]][cutfeat]>cutval
-     */
-    void planeSplit(
-        const Derived& obj, const Offset ind, const Size count,
-        const Dimension cutfeat, const DistanceType& cutval, Offset& lim1,
-        Offset& lim2)
-    {
-        /* Move vector indices for left subtree to front of list. */
-        Offset left  = 0;
-        Offset right = count - 1;
-        for (;;)
-        {
-            while (left <= right &&
-                   dataset_get(obj, vAcc_[ind + left], cutfeat) < cutval)
-                ++left;
-            while (right && left <= right &&
-                   dataset_get(obj, vAcc_[ind + right], cutfeat) >= cutval)
-                --right;
-            if (left > right || !right)
-                break;  // "!right" was added to support unsigned Index types
-            std::swap(vAcc_[ind + left], vAcc_[ind + right]);
-            ++left;
-            --right;
-        }
-        /* If either list is empty, it means that all remaining features
-         * are identical. Split in the middle to maintain a balanced tree.
+        /**
+         * Called during search to add an element matching the criteria.
+         * \return true if the search should be continued, false if the results are
+         * sufficient
          */
-        lim1  = left;
-        right = count - 1;
-        for (;;)
+        bool addPoint(DistanceType dist, IndexType index)
         {
-            while (left <= right &&
-                   dataset_get(obj, vAcc_[ind + left], cutfeat) <= cutval)
-                ++left;
-            while (right && left <= right &&
-                   dataset_get(obj, vAcc_[ind + right], cutfeat) > cutval)
-                --right;
-            if (left > right || !right)
-                break;  // "!right" was added to support unsigned Index types
-            std::swap(vAcc_[ind + left], vAcc_[ind + right]);
-            ++left;
-            --right;
-        }
-        lim2 = left;
-    }
-
-    DistanceType computeInitialDistances(
-        const Derived& obj, const ElementType* vec,
-        distance_vector_t& dists) const
-    {
-        assert(vec);
-        DistanceType dist = DistanceType();
-
-        for (Dimension i = 0; i < (DIM > 0 ? DIM : obj.dim_); ++i)
-        {
-            if (vec[i] < obj.root_bbox_[i].low)
+            CountType i;
+            for (i = count; i > 0; --i)
             {
-                dists[i] =
-                    obj.distance_.accum_dist(vec[i], obj.root_bbox_[i].low, i);
-                dist += dists[i];
-            }
-            if (vec[i] > obj.root_bbox_[i].high)
-            {
-                dists[i] =
-                    obj.distance_.accum_dist(vec[i], obj.root_bbox_[i].high, i);
-                dist += dists[i];
-            }
-        }
-        return dist;
-    }
-
-    static void save_tree(
-        const Derived& obj, std::ostream& stream, const NodeConstPtr tree)
-    {
-        save_value(stream, *tree);
-        if (tree->child1 != nullptr) { save_tree(obj, stream, tree->child1); }
-        if (tree->child2 != nullptr) { save_tree(obj, stream, tree->child2); }
-    }
-
-    static void load_tree(Derived& obj, std::istream& stream, NodePtr& tree)
-    {
-        tree = obj.pool_.template allocate<Node>();
-        load_value(stream, *tree);
-        if (tree->child1 != nullptr) { load_tree(obj, stream, tree->child1); }
-        if (tree->child2 != nullptr) { load_tree(obj, stream, tree->child2); }
-    }
-
-    /**  Stores the index in a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * when loading the index object it must be constructed associated to the
-     * same source of data points used while building it. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
-    void saveIndex(const Derived& obj, std::ostream& stream) const
-    {
-        save_value(stream, obj.size_);
-        save_value(stream, obj.dim_);
-        save_value(stream, obj.root_bbox_);
-        save_value(stream, obj.leaf_max_size_);
-        save_value(stream, obj.vAcc_);
-        save_tree(obj, stream, obj.root_node_);
-    }
-
-    /**  Loads a previous index from a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * the index object must be constructed associated to the same source of
-     * data points used while building the index. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
-    void loadIndex(Derived& obj, std::istream& stream)
-    {
-        load_value(stream, obj.size_);
-        load_value(stream, obj.dim_);
-        load_value(stream, obj.root_bbox_);
-        load_value(stream, obj.leaf_max_size_);
-        load_value(stream, obj.vAcc_);
-        load_tree(obj, stream, obj.root_node_);
-    }
-};
-
-/** @addtogroup kdtrees_grp KD-tree classes and adaptors
- * \{ */
-
-/** kd-tree static index
- *
- * Contains the k-d trees and other information for indexing a set of points
- * for nearest-neighbor matching.
- *
- *  The class "DatasetAdaptor" must provide the following interface (can be
- * non-virtual, inlined methods):
- *
- *  \code
- *   // Must return the number of data poins
- *   size_t kdtree_get_point_count() const { ... }
- *
- *
- *   // Must return the dim'th component of the idx'th point in the class:
- *   T kdtree_get_pt(const size_t idx, const size_t dim) const { ... }
- *
- *   // Optional bounding-box computation: return false to default to a standard
- * bbox computation loop.
- *   //   Return true if the BBOX was already computed by the class and returned
- * in "bb" so it can be avoided to redo it again.
- *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3
- * for point clouds) template <class BBOX> bool kdtree_get_bbox(BBOX &bb) const
- *   {
- *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
- *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
- *      ...
- *      return true;
- *   }
- *
- *  \endcode
- *
- * \tparam DatasetAdaptor The user-provided adaptor, which must be ensured to
- *         have a lifetime equal or longer than the instance of this class.
- * \tparam Distance The distance metric to use: nanoflann::metric_L1,
- * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc. \tparam DIM
- * Dimensionality of data points (e.g. 3 for 3D points) \tparam IndexType Will
- * be typically size_t or int
- */
-template <
-    typename Distance, class DatasetAdaptor, int32_t DIM = -1,
-    typename IndexType = uint32_t>
-class KDTreeSingleIndexAdaptor
-    : public KDTreeBaseClass<
-          KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>,
-          Distance, DatasetAdaptor, DIM, IndexType>
-{
-   public:
-    /** Deleted copy constructor*/
-    explicit KDTreeSingleIndexAdaptor(
-        const KDTreeSingleIndexAdaptor<
-            Distance, DatasetAdaptor, DIM, IndexType>&) = delete;
-
-    /** The data source used by this index */
-    const DatasetAdaptor& dataset_;
-
-    const KDTreeSingleIndexAdaptorParams indexParams;
-
-    Distance distance_;
-
-    using Base = typename nanoflann::KDTreeBaseClass<
-        nanoflann::KDTreeSingleIndexAdaptor<
-            Distance, DatasetAdaptor, DIM, IndexType>,
-        Distance, DatasetAdaptor, DIM, IndexType>;
-
-    using Offset    = typename Base::Offset;
-    using Size      = typename Base::Size;
-    using Dimension = typename Base::Dimension;
-
-    using ElementType  = typename Base::ElementType;
-    using DistanceType = typename Base::DistanceType;
-
-    using Node    = typename Base::Node;
-    using NodePtr = Node*;
-
-    using Interval = typename Base::Interval;
-
-    /** Define "BoundingBox" as a fixed-size or variable-size container
-     * depending on "DIM" */
-    using BoundingBox = typename Base::BoundingBox;
-
-    /** Define "distance_vector_t" as a fixed-size or variable-size container
-     * depending on "DIM" */
-    using distance_vector_t = typename Base::distance_vector_t;
-
-    /**
-     * KDTree constructor
-     *
-     * Refer to docs in README.md or online in
-     * https://github.com/jlblancoc/nanoflann
-     *
-     * The KD-Tree point dimension (the length of each point in the datase, e.g.
-     * 3 for 3D points) is determined by means of:
-     *  - The \a DIM template parameter if >0 (highest priority)
-     *  - Otherwise, the \a dimensionality parameter of this constructor.
-     *
-     * \param inputData Dataset with the input features. Its lifetime must be
-     *  equal or longer than that of the instance of this class.
-     * \param params Basically, the maximum leaf node size
-     *
-     * Note that there is a variable number of optional additional parameters
-     * which will be forwarded to the metric class constructor. Refer to example
-     * `examples/pointcloud_custom_metric.cpp` for a use case.
-     *
-     */
-    template <class... Args>
-    explicit KDTreeSingleIndexAdaptor(
-        const Dimension dimensionality, const DatasetAdaptor& inputData,
-        const KDTreeSingleIndexAdaptorParams& params, Args&&... args)
-        : dataset_(inputData),
-          indexParams(params),
-          distance_(inputData, std::forward<Args>(args)...)
-    {
-        init(dimensionality, params);
-    }
-
-    explicit KDTreeSingleIndexAdaptor(
-        const Dimension dimensionality, const DatasetAdaptor& inputData,
-        const KDTreeSingleIndexAdaptorParams& params = {})
-        : dataset_(inputData), indexParams(params), distance_(inputData)
-    {
-        init(dimensionality, params);
-    }
-
-   private:
-    void init(
-        const Dimension                       dimensionality,
-        const KDTreeSingleIndexAdaptorParams& params)
-    {
-        Base::size_                = dataset_.kdtree_get_point_count();
-        Base::size_at_index_build_ = Base::size_;
-        Base::dim_                 = dimensionality;
-        if (DIM > 0) Base::dim_ = DIM;
-        Base::leaf_max_size_ = params.leaf_max_size;
-        if (params.n_thread_build > 0)
-        {
-            Base::n_thread_build_ = params.n_thread_build;
-        }
-        else
-        {
-            Base::n_thread_build_ =
-                std::max(std::thread::hardware_concurrency(), 1u);
-        }
-
-        if (!(params.flags &
-              KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex))
-        {
-            // Build KD-tree:
-            buildIndex();
-        }
-    }
-
-   public:
-    /**
-     * Builds the index
-     */
-    void buildIndex()
-    {
-        Base::size_                = dataset_.kdtree_get_point_count();
-        Base::size_at_index_build_ = Base::size_;
-        init_vind();
-        this->freeIndex(*this);
-        Base::size_at_index_build_ = Base::size_;
-        if (Base::size_ == 0) return;
-        computeBoundingBox(Base::root_bbox_);
-        // construct the tree
-        if (Base::n_thread_build_ == 1)
-        {
-            Base::root_node_ =
-                this->divideTree(*this, 0, Base::size_, Base::root_bbox_);
-        }
-        else
-        {
-            std::atomic<unsigned int> thread_count(0u);
-            std::mutex                mutex;
-            Base::root_node_ = this->divideTreeConcurrent(
-                *this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
-        }
-    }
-
-    /** \name Query methods
-     * \{ */
-
-    /**
-     * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
-     * inside the result object.
-     *
-     * Params:
-     *     result = the result object in which the indices of the
-     * nearest-neighbors are stored vec = the vector for which to search the
-     * nearest neighbors
-     *
-     * \tparam RESULTSET Should be any ResultSet<DistanceType>
-     * \return  True if the requested neighbors could be found.
-     * \sa knnSearch, radiusSearch
-     *
-     * \note If L2 norms are used, all returned distances are actually squared
-     *       distances.
-     */
-    template <typename RESULTSET>
-    bool findNeighbors(
-        RESULTSET& result, const ElementType* vec,
-        const SearchParameters& searchParams = {}) const
-    {
-        assert(vec);
-        if (this->size(*this) == 0) return false;
-        if (!Base::root_node_)
-            throw std::runtime_error(
-                "[nanoflann] findNeighbors() called before building the "
-                "index.");
-        float epsError = 1 + searchParams.eps;
-
-        // fixed or variable-sized container (depending on DIM)
-        distance_vector_t dists;
-        // Fill it with zeros.
-        auto zero = static_cast<decltype(result.worstDist())>(0);
-        assign(dists, (DIM > 0 ? DIM : Base::dim_), zero);
-        DistanceType dist = this->computeInitialDistances(*this, vec, dists);
-        searchLevel(result, vec, Base::root_node_, dist, dists, epsError);
-        return result.full();
-    }
-
-    /**
-     * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1].
-     * Their indices and distances are stored in the provided pointers to
-     * array/vector.
-     *
-     * \sa radiusSearch, findNeighbors
-     * \return Number `N` of valid points in the result set.
-     *
-     * \note If L2 norms are used, all returned distances are actually squared
-     *       distances.
-     *
-     * \note Only the first `N` entries in `out_indices` and `out_distances`
-     *       will be valid. Return is less than `num_closest` only if the
-     *       number of elements in the tree is less than `num_closest`.
-     */
-    Size knnSearch(
-        const ElementType* query_point, const Size num_closest,
-        IndexType* out_indices, DistanceType* out_distances) const
-    {
-        nanoflann::KNNResultSet<DistanceType, IndexType> resultSet(num_closest);
-        resultSet.init(out_indices, out_distances);
-        findNeighbors(resultSet, query_point);
-        return resultSet.size();
-    }
-
-    /**
-     * Find all the neighbors to \a query_point[0:dim-1] within a maximum
-     * radius. The output is given as a vector of pairs, of which the first
-     * element is a point index and the second the corresponding distance.
-     * Previous contents of \a IndicesDists are cleared.
-     *
-     *  If searchParams.sorted==true, the output list is sorted by ascending
-     * distances.
-     *
-     *  For a better performance, it is advisable to do a .reserve() on the
-     * vector if you have any wild guess about the number of expected matches.
-     *
-     *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
-     * \return The number of points within the given radius (i.e. indices.size()
-     * or dists.size() )
-     *
-     * \note If L2 norms are used, search radius and all returned distances
-     *       are actually squared distances.
-     */
-    Size radiusSearch(
-        const ElementType* query_point, const DistanceType& radius,
-        std::vector<ResultItem<IndexType, DistanceType>>& IndicesDists,
-        const SearchParameters& searchParams = {}) const
-    {
-        RadiusResultSet<DistanceType, IndexType> resultSet(
-            radius, IndicesDists);
-        const Size nFound =
-            radiusSearchCustomCallback(query_point, resultSet, searchParams);
-        if (searchParams.sorted)
-            std::sort(
-                IndicesDists.begin(), IndicesDists.end(), IndexDist_Sorter());
-        return nFound;
-    }
-
-    /**
-     * Just like radiusSearch() but with a custom callback class for each point
-     * found in the radius of the query. See the source of RadiusResultSet<> as
-     * a start point for your own classes. \sa radiusSearch
-     */
-    template <class SEARCH_CALLBACK>
-    Size radiusSearchCustomCallback(
-        const ElementType* query_point, SEARCH_CALLBACK& resultSet,
-        const SearchParameters& searchParams = {}) const
-    {
-        findNeighbors(resultSet, query_point, searchParams);
-        return resultSet.size();
-    }
-
-    /** \} */
-
-   public:
-    /** Make sure the auxiliary list \a vind has the same size than the current
-     * dataset, and re-generate if size has changed. */
-    void init_vind()
-    {
-        // Create a permutable array of indices to the input vectors.
-        Base::size_ = dataset_.kdtree_get_point_count();
-        if (Base::vAcc_.size() != Base::size_) Base::vAcc_.resize(Base::size_);
-        for (Size i = 0; i < Base::size_; i++)
-            Base::vAcc_[i] = static_cast<IndexType>(i);
-    }
-
-    void computeBoundingBox(BoundingBox& bbox)
-    {
-        const auto dims = (DIM > 0 ? DIM : Base::dim_);
-        resize(bbox, dims);
-        if (dataset_.kdtree_get_bbox(bbox))
-        {
-            // Done! It was implemented in derived class
-        }
-        else
-        {
-            const Size N = dataset_.kdtree_get_point_count();
-            if (!N)
-                throw std::runtime_error(
-                    "[nanoflann] computeBoundingBox() called but "
-                    "no data points found.");
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                bbox[i].low = bbox[i].high =
-                    this->dataset_get(*this, Base::vAcc_[0], i);
-            }
-            for (Offset k = 1; k < N; ++k)
-            {
-                for (Dimension i = 0; i < dims; ++i)
+                /** If defined and two points have the same distance, the one with
+                 *  the lowest-index will be returned first. */
+#ifdef NANOFLANN_FIRST_MATCH
+                if ((dists[i - 1] > dist) || ((dist == dists[i - 1]) && (indices[i - 1] > index)))
                 {
-                    const auto val =
-                        this->dataset_get(*this, Base::vAcc_[k], i);
-                    if (val < bbox[i].low) bbox[i].low = val;
-                    if (val > bbox[i].high) bbox[i].high = val;
-                }
-            }
-        }
-    }
-
-    /**
-     * Performs an exact search in the tree starting from a node.
-     * \tparam RESULTSET Should be any ResultSet<DistanceType>
-     * \return true if the search should be continued, false if the results are
-     * sufficient
-     */
-    template <class RESULTSET>
-    bool searchLevel(
-        RESULTSET& result_set, const ElementType* vec, const NodePtr node,
-        DistanceType mindist, distance_vector_t& dists,
-        const float epsError) const
-    {
-        /* If this is a leaf node, then do check and return. */
-        if ((node->child1 == nullptr) && (node->child2 == nullptr))
-        {
-            DistanceType worst_dist = result_set.worstDist();
-            for (Offset i = node->node_type.lr.left;
-                 i < node->node_type.lr.right; ++i)
-            {
-                const IndexType accessor = Base::vAcc_[i];  // reorder... : i;
-                DistanceType    dist     = distance_.evalMetric(
-                    vec, accessor, (DIM > 0 ? DIM : Base::dim_));
-                if (dist < worst_dist)
+#else
+                if (dists[i - 1] > dist)
                 {
-                    if (!result_set.addPoint(dist, Base::vAcc_[i]))
+#endif
+                    if (i < capacity)
                     {
-                        // the resultset doesn't want to receive any more
-                        // points, we're done searching!
-                        return false;
+                        dists[i]   = dists[i - 1];
+                        indices[i] = indices[i - 1];
                     }
                 }
+                else
+                    break;
             }
+            if (i < capacity)
+            {
+                dists[i]   = dist;
+                indices[i] = index;
+            }
+            if (count < capacity)
+                count++;
+
+            // tell caller that the search shall continue
             return true;
         }
 
-        /* Which child branch should be taken first? */
-        Dimension    idx   = node->node_type.sub.divfeat;
-        ElementType  val   = vec[idx];
-        DistanceType diff1 = val - node->node_type.sub.divlow;
-        DistanceType diff2 = val - node->node_type.sub.divhigh;
+        DistanceType worstDist() const { return dists[capacity - 1]; }
+    };
 
-        NodePtr      bestChild;
-        NodePtr      otherChild;
-        DistanceType cut_dist;
-        if ((diff1 + diff2) < 0)
-        {
-            bestChild  = node->child1;
-            otherChild = node->child2;
-            cut_dist =
-                distance_.accum_dist(val, node->node_type.sub.divhigh, idx);
-        }
-        else
-        {
-            bestChild  = node->child2;
-            otherChild = node->child1;
-            cut_dist =
-                distance_.accum_dist(val, node->node_type.sub.divlow, idx);
-        }
-
-        /* Call recursively to search next level down. */
-        if (!searchLevel(
-                result_set, vec, bestChild, mindist, dists, epsError))
-        {
-            // the resultset doesn't want to receive any more points, we're done
-            // searching!
-            return false;
-        }
-
-        DistanceType dst = dists[idx];
-        mindist        = mindist + cut_dist - dst;
-        dists[idx]       = cut_dist;
-        if (mindist * epsError <= result_set.worstDist())
-        {
-            if (!searchLevel(
-                    result_set, vec, otherChild, mindist, dists, epsError))
-            {
-                // the resultset doesn't want to receive any more points, we're
-                // done searching!
-                return false;
-            }
-        }
-        dists[idx] = dst;
-        return true;
-    }
-
-   public:
-    /**  Stores the index in a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * when loading the index object it must be constructed associated to the
-     * same source of data points used while building it. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
-    void saveIndex(std::ostream& stream) const
+    /** operator "<" for std::sort() */
+    struct IndexDist_Sorter
     {
-        Base::saveIndex(*this, stream);
-    }
-
-    /**  Loads a previous index from a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * the index object must be constructed associated to the same source of
-     * data points used while building the index. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
-    void loadIndex(std::istream& stream) { Base::loadIndex(*this, stream); }
-
-};  // class KDTree
-
-/** kd-tree dynamic index
- *
- * Contains the k-d trees and other information for indexing a set of points
- * for nearest-neighbor matching.
- *
- * The class "DatasetAdaptor" must provide the following interface (can be
- * non-virtual, inlined methods):
- *
- *  \code
- *   // Must return the number of data poins
- *   size_t kdtree_get_point_count() const { ... }
- *
- *   // Must return the dim'th component of the idx'th point in the class:
- *   T kdtree_get_pt(const size_t idx, const size_t dim) const { ... }
- *
- *   // Optional bounding-box computation: return false to default to a standard
- * bbox computation loop.
- *   //   Return true if the BBOX was already computed by the class and returned
- * in "bb" so it can be avoided to redo it again.
- *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3
- * for point clouds) template <class BBOX> bool kdtree_get_bbox(BBOX &bb) const
- *   {
- *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
- *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
- *      ...
- *      return true;
- *   }
- *
- *  \endcode
- *
- * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
- * \tparam Distance The distance metric to use: nanoflann::metric_L1,
- * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
- * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
- * \tparam IndexType Type of the arguments with which the data can be
- * accessed (e.g. float, double, int64_t, T*)
- */
-template <
-    typename Distance, class DatasetAdaptor, int32_t DIM = -1,
-    typename IndexType = uint32_t>
-class KDTreeSingleIndexDynamicAdaptor_
-    : public KDTreeBaseClass<
-          KDTreeSingleIndexDynamicAdaptor_<
-              Distance, DatasetAdaptor, DIM, IndexType>,
-          Distance, DatasetAdaptor, DIM, IndexType>
-{
-   public:
-    /**
-     * The dataset used by this index
-     */
-    const DatasetAdaptor& dataset_;  //!< The source of our data
-
-    KDTreeSingleIndexAdaptorParams index_params_;
-
-    std::vector<int>& treeIndex_;
-
-    Distance distance_;
-
-    using Base = typename nanoflann::KDTreeBaseClass<
-        nanoflann::KDTreeSingleIndexDynamicAdaptor_<
-            Distance, DatasetAdaptor, DIM, IndexType>,
-        Distance, DatasetAdaptor, DIM, IndexType>;
-
-    using ElementType  = typename Base::ElementType;
-    using DistanceType = typename Base::DistanceType;
-
-    using Offset    = typename Base::Offset;
-    using Size      = typename Base::Size;
-    using Dimension = typename Base::Dimension;
-
-    using Node    = typename Base::Node;
-    using NodePtr = Node*;
-
-    using Interval = typename Base::Interval;
-    /** Define "BoundingBox" as a fixed-size or variable-size container
-     * depending on "DIM" */
-    using BoundingBox = typename Base::BoundingBox;
-
-    /** Define "distance_vector_t" as a fixed-size or variable-size container
-     * depending on "DIM" */
-    using distance_vector_t = typename Base::distance_vector_t;
+        /** PairType will be typically: ResultItem<IndexType,DistanceType> */
+        template <typename PairType>
+        bool operator()(const PairType& p1, const PairType& p2) const
+        {
+            return p1.second < p2.second;
+        }
+    };
 
     /**
-     * KDTree constructor
-     *
-     * Refer to docs in README.md or online in
-     * https://github.com/jlblancoc/nanoflann
-     *
-     * The KD-Tree point dimension (the length of each point in the datase, e.g.
-     * 3 for 3D points) is determined by means of:
-     *  - The \a DIM template parameter if >0 (highest priority)
-     *  - Otherwise, the \a dimensionality parameter of this constructor.
-     *
-     * \param inputData Dataset with the input features. Its lifetime must be
-     *  equal or longer than that of the instance of this class.
-     * \param params Basically, the maximum leaf node size
+     * Each result element in RadiusResultSet. Note that distances and indices
+     * are named `first` and `second` to keep backward-compatibility with the
+     * `std::pair<>` type used in the past. In contrast, this structure is ensured
+     * to be `std::is_standard_layout` so it can be used in wrappers to other
+     * languages.
+     * See: https://github.com/jlblancoc/nanoflann/issues/166
      */
-    KDTreeSingleIndexDynamicAdaptor_(
-        const Dimension dimensionality, const DatasetAdaptor& inputData,
-        std::vector<int>&                     treeIndex,
-        const KDTreeSingleIndexAdaptorParams& params =
-            KDTreeSingleIndexAdaptorParams())
-        : dataset_(inputData),
-          index_params_(params),
-          treeIndex_(treeIndex),
-          distance_(inputData)
+    template <typename IndexType = size_t, typename DistanceType = double>
+    struct ResultItem
     {
-        Base::size_                = 0;
-        Base::size_at_index_build_ = 0;
-        for (auto& v : Base::root_bbox_) v = {};
-        Base::dim_ = dimensionality;
-        if (DIM > 0) Base::dim_ = DIM;
-        Base::leaf_max_size_ = params.leaf_max_size;
-        if (params.n_thread_build > 0)
+        ResultItem() = default;
+        ResultItem(const IndexType index, const DistanceType distance) : first(index), second(distance) {}
+
+        IndexType first;     //!< Index of the sample in the dataset
+        DistanceType second; //!< Distance from sample to query point
+    };
+
+    /**
+     * A result-set class used when performing a radius based search.
+     */
+    template <typename _DistanceType, typename _IndexType = size_t>
+    class RadiusResultSet
+    {
+    public:
+        using DistanceType = _DistanceType;
+        using IndexType    = _IndexType;
+
+    public:
+        const DistanceType radius;
+
+        std::vector<ResultItem<IndexType, DistanceType>>& m_indices_dists;
+
+        explicit RadiusResultSet(DistanceType radius_, std::vector<ResultItem<IndexType, DistanceType>>& indices_dists)
+            : radius(radius_), m_indices_dists(indices_dists)
         {
-            Base::n_thread_build_ = params.n_thread_build;
+            init();
         }
-        else
+
+        void init() { clear(); }
+        void clear() { m_indices_dists.clear(); }
+
+        size_t size() const { return m_indices_dists.size(); }
+        size_t empty() const { return m_indices_dists.empty(); }
+
+        bool full() const { return true; }
+
+        /**
+         * Called during search to add an element matching the criteria.
+         * \return true if the search should be continued, false if the results are
+         * sufficient
+         */
+        bool addPoint(DistanceType dist, IndexType index)
         {
-            Base::n_thread_build_ =
-                std::max(std::thread::hardware_concurrency(), 1u);
+            if (dist < radius)
+                m_indices_dists.emplace_back(index, dist);
+            return true;
         }
-    }
 
-    /** Explicitly default the copy constructor */
-    KDTreeSingleIndexDynamicAdaptor_(
-        const KDTreeSingleIndexDynamicAdaptor_& rhs) = default;
+        DistanceType worstDist() const { return radius; }
 
-    /** Assignment operator definiton */
-    KDTreeSingleIndexDynamicAdaptor_ operator=(
-        const KDTreeSingleIndexDynamicAdaptor_& rhs)
-    {
-        KDTreeSingleIndexDynamicAdaptor_ tmp(rhs);
-        std::swap(Base::vAcc_, tmp.Base::vAcc_);
-        std::swap(Base::leaf_max_size_, tmp.Base::leaf_max_size_);
-        std::swap(index_params_, tmp.index_params_);
-        std::swap(treeIndex_, tmp.treeIndex_);
-        std::swap(Base::size_, tmp.Base::size_);
-        std::swap(Base::size_at_index_build_, tmp.Base::size_at_index_build_);
-        std::swap(Base::root_node_, tmp.Base::root_node_);
-        std::swap(Base::root_bbox_, tmp.Base::root_bbox_);
-        std::swap(Base::pool_, tmp.Base::pool_);
-        return *this;
-    }
-
-    /**
-     * Builds the index
-     */
-    void buildIndex()
-    {
-        Base::size_ = Base::vAcc_.size();
-        this->freeIndex(*this);
-        Base::size_at_index_build_ = Base::size_;
-        if (Base::size_ == 0) return;
-        computeBoundingBox(Base::root_bbox_);
-        // construct the tree
-        if (Base::n_thread_build_ == 1)
+        /**
+         * Find the worst result (farthest neighbor) without copying or sorting
+         * Pre-conditions: size() > 0
+         */
+        ResultItem<IndexType, DistanceType> worst_item() const
         {
-            Base::root_node_ =
-                this->divideTree(*this, 0, Base::size_, Base::root_bbox_);
+            if (m_indices_dists.empty())
+                throw std::runtime_error("Cannot invoke RadiusResultSet::worst_item() on "
+                                         "an empty list of results.");
+            auto it = std::max_element(m_indices_dists.begin(), m_indices_dists.end(), IndexDist_Sorter());
+            return *it;
         }
-        else
-        {
-            std::atomic<unsigned int> thread_count(0u);
-            std::mutex                mutex;
-            Base::root_node_ = this->divideTreeConcurrent(
-                *this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
-        }
-    }
-
-    /** \name Query methods
-     * \{ */
-
-    /**
-     * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
-     * inside the result object.
-     * This is the core search function, all others are wrappers around this
-     * one.
-     *
-     * \param result The result object in which the indices of the
-     *               nearest-neighbors are stored.
-     * \param vec    The vector of the query point for which to search the
-     *               nearest neighbors.
-     * \param searchParams Optional parameters for the search.
-     *
-     * \tparam RESULTSET Should be any ResultSet<DistanceType>
-     * \return True if the requested neighbors could be found.
-     *
-     * \sa knnSearch(), radiusSearch(), radiusSearchCustomCallback()
-     *
-     * \note If L2 norms are used, all returned distances are actually squared
-     *       distances.
-     */
-    template <typename RESULTSET>
-    bool findNeighbors(
-        RESULTSET& result, const ElementType* vec,
-        const SearchParameters& searchParams = {}) const
-    {
-        assert(vec);
-        if (this->size(*this) == 0) return false;
-        if (!Base::root_node_) return false;
-        float epsError = 1 + searchParams.eps;
-
-        // fixed or variable-sized container (depending on DIM)
-        distance_vector_t dists;
-        // Fill it with zeros.
-        assign(
-            dists, (DIM > 0 ? DIM : Base::dim_),
-            static_cast<typename distance_vector_t::value_type>(0));
-        DistanceType dist = this->computeInitialDistances(*this, vec, dists);
-        searchLevel(result, vec, Base::root_node_, dist, dists, epsError);
-        return result.full();
-    }
-
-    /**
-     * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1].
-     * Their indices are stored inside the result object. \sa radiusSearch,
-     * findNeighbors
-     * \return Number `N` of valid points in
-     * the result set.
-     *
-     * \note If L2 norms are used, all returned distances are actually squared
-     *       distances.
-     *
-     * \note Only the first `N` entries in `out_indices` and `out_distances`
-     *       will be valid. Return may be less than `num_closest` only if the
-     *       number of elements in the tree is less than `num_closest`.
-     */
-    Size knnSearch(
-        const ElementType* query_point, const Size num_closest,
-        IndexType* out_indices, DistanceType* out_distances) const
-    {
-        nanoflann::KNNResultSet<DistanceType, IndexType> resultSet(num_closest);
-        resultSet.init(out_indices, out_distances);
-        findNeighbors(resultSet, query_point);
-        return resultSet.size();
-    }
-
-    /**
-     * Find all the neighbors to \a query_point[0:dim-1] within a maximum
-     * radius. The output is given as a vector of pairs, of which the first
-     * element is a point index and the second the corresponding distance.
-     * Previous contents of \a IndicesDists are cleared.
-     *
-     * If searchParams.sorted==true, the output list is sorted by ascending
-     * distances.
-     *
-     * For a better performance, it is advisable to do a .reserve() on the
-     * vector if you have any wild guess about the number of expected matches.
-     *
-     *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
-     * \return The number of points within the given radius (i.e. indices.size()
-     * or dists.size() )
-     *
-     * \note If L2 norms are used, search radius and all returned distances
-     *       are actually squared distances.
-     */
-    Size radiusSearch(
-        const ElementType* query_point, const DistanceType& radius,
-        std::vector<ResultItem<IndexType, DistanceType>>& IndicesDists,
-        const SearchParameters& searchParams = {}) const
-    {
-        RadiusResultSet<DistanceType, IndexType> resultSet(
-            radius, IndicesDists);
-        const size_t nFound =
-            radiusSearchCustomCallback(query_point, resultSet, searchParams);
-        if (searchParams.sorted)
-            std::sort(
-                IndicesDists.begin(), IndicesDists.end(), IndexDist_Sorter());
-        return nFound;
-    }
-
-    /**
-     * Just like radiusSearch() but with a custom callback class for each point
-     * found in the radius of the query. See the source of RadiusResultSet<> as
-     * a start point for your own classes. \sa radiusSearch
-     */
-    template <class SEARCH_CALLBACK>
-    Size radiusSearchCustomCallback(
-        const ElementType* query_point, SEARCH_CALLBACK& resultSet,
-        const SearchParameters& searchParams = {}) const
-    {
-        findNeighbors(resultSet, query_point, searchParams);
-        return resultSet.size();
-    }
+    };
 
     /** \} */
 
-   public:
-    void computeBoundingBox(BoundingBox& bbox)
+    /** @addtogroup loadsave_grp Load/save auxiliary functions
+     * \{ */
+    template <typename T>
+    void save_value(std::ostream& stream, const T& value)
     {
-        const auto dims = (DIM > 0 ? DIM : Base::dim_);
-        resize(bbox, dims);
-
-        if (dataset_.kdtree_get_bbox(bbox))
-        {
-            // Done! It was implemented in derived class
-        }
-        else
-        {
-            const Size N = Base::size_;
-            if (!N)
-                throw std::runtime_error(
-                    "[nanoflann] computeBoundingBox() called but "
-                    "no data points found.");
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                bbox[i].low = bbox[i].high =
-                    this->dataset_get(*this, Base::vAcc_[0], i);
-            }
-            for (Offset k = 1; k < N; ++k)
-            {
-                for (Dimension i = 0; i < dims; ++i)
-                {
-                    const auto val =
-                        this->dataset_get(*this, Base::vAcc_[k], i);
-                    if (val < bbox[i].low) bbox[i].low = val;
-                    if (val > bbox[i].high) bbox[i].high = val;
-                }
-            }
-        }
+        stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
     }
 
-    /**
-     * Performs an exact search in the tree starting from a node.
-     * \tparam RESULTSET Should be any ResultSet<DistanceType>
-     */
-    template <class RESULTSET>
-    void searchLevel(
-        RESULTSET& result_set, const ElementType* vec, const NodePtr node,
-        DistanceType mindist, distance_vector_t& dists,
-        const float epsError) const
+    template <typename T>
+    void save_value(std::ostream& stream, const std::vector<T>& value)
     {
-        /* If this is a leaf node, then do check and return. */
-        if ((node->child1 == nullptr) && (node->child2 == nullptr))
+        size_t size = value.size();
+        stream.write(reinterpret_cast<const char*>(&size), sizeof(size_t));
+        stream.write(reinterpret_cast<const char*>(value.data()), sizeof(T) * size);
+    }
+
+    template <typename T>
+    void load_value(std::istream& stream, T& value)
+    {
+        stream.read(reinterpret_cast<char*>(&value), sizeof(T));
+    }
+
+    template <typename T>
+    void load_value(std::istream& stream, std::vector<T>& value)
+    {
+        size_t size;
+        stream.read(reinterpret_cast<char*>(&size), sizeof(size_t));
+        value.resize(size);
+        stream.read(reinterpret_cast<char*>(value.data()), sizeof(T) * size);
+    }
+    /** \} */
+
+    /** @addtogroup metric_grp Metric (distance) classes
+     * \{ */
+
+    struct Metric
+    {
+    };
+
+    /** Manhattan distance functor (generic version, optimized for
+     * high-dimensionality data sets). Corresponding distance traits:
+     * nanoflann::metric_L1
+     *
+     * \tparam T Type of the elements (e.g. double, float, uint8_t)
+     * \tparam DataSource Source of the data, i.e. where the vectors are stored
+     * \tparam _DistanceType Type of distance variables (must be signed)
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <class T, class DataSource, typename _DistanceType = T, typename IndexType = uint32_t>
+    struct L1_Adaptor
+    {
+        using ElementType  = T;
+        using DistanceType = _DistanceType;
+
+        const DataSource& data_source;
+
+        L1_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
+
+        DistanceType evalMetric(const T* a, const IndexType b_idx, size_t size, DistanceType worst_dist = -1) const
         {
-            DistanceType worst_dist = result_set.worstDist();
-            for (Offset i = node->node_type.lr.left;
-                 i < node->node_type.lr.right; ++i)
+            DistanceType result = DistanceType();
+            const T* last       = a + size;
+            const T* lastgroup  = last - 3;
+            size_t d            = 0;
+
+            /* Process 4 items with each loop for efficiency. */
+            while (a < lastgroup)
             {
-                const IndexType index = Base::vAcc_[i];  // reorder... : i;
-                if (treeIndex_[index] == -1) continue;
-                DistanceType dist = distance_.evalMetric(
-                    vec, index, (DIM > 0 ? DIM : Base::dim_));
-                if (dist < worst_dist)
+                const DistanceType diff0 = std::abs(a[0] - data_source.kdtree_get_pt(b_idx, d++));
+                const DistanceType diff1 = std::abs(a[1] - data_source.kdtree_get_pt(b_idx, d++));
+                const DistanceType diff2 = std::abs(a[2] - data_source.kdtree_get_pt(b_idx, d++));
+                const DistanceType diff3 = std::abs(a[3] - data_source.kdtree_get_pt(b_idx, d++));
+                result += diff0 + diff1 + diff2 + diff3;
+                a += 4;
+                if ((worst_dist > 0) && (result > worst_dist))
                 {
-                    if (!result_set.addPoint(
-                            static_cast<typename RESULTSET::DistanceType>(dist),
-                            static_cast<typename RESULTSET::IndexType>(
-                                Base::vAcc_[i])))
+                    return result;
+                }
+            }
+            /* Process last 0-3 components.  Not needed for standard vector lengths.
+             */
+            while (a < last)
+            {
+                result += std::abs(*a++ - data_source.kdtree_get_pt(b_idx, d++));
+            }
+            return result;
+        }
+
+        template <typename U, typename V>
+        DistanceType accum_dist(const U a, const V b, const size_t) const
+        {
+            return std::abs(a - b);
+        }
+    };
+
+    /** **Squared** Euclidean distance functor (generic version, optimized for
+     * high-dimensionality data sets). Corresponding distance traits:
+     * nanoflann::metric_L2
+     *
+     * \tparam T Type of the elements (e.g. double, float, uint8_t)
+     * \tparam DataSource Source of the data, i.e. where the vectors are stored
+     * \tparam _DistanceType Type of distance variables (must be signed)
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <class T, class DataSource, typename _DistanceType = T, typename IndexType = uint32_t>
+    struct L2_Adaptor
+    {
+        using ElementType  = T;
+        using DistanceType = _DistanceType;
+
+        const DataSource& data_source;
+
+        L2_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
+
+        DistanceType evalMetric(const T* a, const IndexType b_idx, size_t size, DistanceType worst_dist = -1) const
+        {
+            DistanceType result = DistanceType();
+            const T* last       = a + size;
+            const T* lastgroup  = last - 3;
+            size_t d            = 0;
+
+            /* Process 4 items with each loop for efficiency. */
+            while (a < lastgroup)
+            {
+                const DistanceType diff0 = a[0] - data_source.kdtree_get_pt(b_idx, d++);
+                const DistanceType diff1 = a[1] - data_source.kdtree_get_pt(b_idx, d++);
+                const DistanceType diff2 = a[2] - data_source.kdtree_get_pt(b_idx, d++);
+                const DistanceType diff3 = a[3] - data_source.kdtree_get_pt(b_idx, d++);
+                result += diff0 * diff0 + diff1 * diff1 + diff2 * diff2 + diff3 * diff3;
+                a += 4;
+                if ((worst_dist > 0) && (result > worst_dist))
+                {
+                    return result;
+                }
+            }
+            /* Process last 0-3 components.  Not needed for standard vector lengths.
+             */
+            while (a < last)
+            {
+                const DistanceType diff0 = *a++ - data_source.kdtree_get_pt(b_idx, d++);
+                result += diff0 * diff0;
+            }
+            return result;
+        }
+
+        template <typename U, typename V>
+        DistanceType accum_dist(const U a, const V b, const size_t) const
+        {
+            return (a - b) * (a - b);
+        }
+    };
+
+    /** **Squared** Euclidean (L2) distance functor (suitable for low-dimensionality
+     * datasets, like 2D or 3D point clouds) Corresponding distance traits:
+     * nanoflann::metric_L2_Simple
+     *
+     * \tparam T Type of the elements (e.g. double, float, uint8_t)
+     * \tparam DataSource Source of the data, i.e. where the vectors are stored
+     * \tparam _DistanceType Type of distance variables (must be signed)
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <class T, class DataSource, typename _DistanceType = T, typename IndexType = uint32_t>
+    struct L2_Simple_Adaptor
+    {
+        using ElementType  = T;
+        using DistanceType = _DistanceType;
+
+        const DataSource& data_source;
+
+        L2_Simple_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
+
+        DistanceType evalMetric(const T* a, const IndexType b_idx, size_t size) const
+        {
+            DistanceType result = DistanceType();
+            for (size_t i = 0; i < size; ++i)
+            {
+                const DistanceType diff = a[i] - data_source.kdtree_get_pt(b_idx, i);
+                result += diff * diff;
+            }
+            return result;
+        }
+
+        template <typename U, typename V>
+        DistanceType accum_dist(const U a, const V b, const size_t) const
+        {
+            return (a - b) * (a - b);
+        }
+    };
+
+    /** SO2 distance functor
+     *  Corresponding distance traits: nanoflann::metric_SO2
+     *
+     * \tparam T Type of the elements (e.g. double, float, uint8_t)
+     * \tparam DataSource Source of the data, i.e. where the vectors are stored
+     * \tparam _DistanceType Type of distance variables (must be signed) (e.g.
+     * float, double) orientation is constrained to be in [-pi, pi]
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <class T, class DataSource, typename _DistanceType = T, typename IndexType = uint32_t>
+    struct SO2_Adaptor
+    {
+        using ElementType  = T;
+        using DistanceType = _DistanceType;
+
+        const DataSource& data_source;
+
+        SO2_Adaptor(const DataSource& _data_source) : data_source(_data_source) {}
+
+        DistanceType evalMetric(const T* a, const IndexType b_idx, size_t size) const
+        {
+            return accum_dist(a[size - 1], data_source.kdtree_get_pt(b_idx, size - 1), size - 1);
+        }
+
+        /** Note: this assumes that input angles are already in the range [-pi,pi]
+         */
+        template <typename U, typename V>
+        DistanceType accum_dist(const U a, const V b, const size_t) const
+        {
+            DistanceType result = DistanceType();
+            DistanceType PI     = pi_const<DistanceType>();
+            result              = b - a;
+            if (result > PI)
+                result -= 2 * PI;
+            else if (result < -PI)
+                result += 2 * PI;
+            return result;
+        }
+    };
+
+    /** SO3 distance functor (Uses L2_Simple)
+     *  Corresponding distance traits: nanoflann::metric_SO3
+     *
+     * \tparam T Type of the elements (e.g. double, float, uint8_t)
+     * \tparam DataSource Source of the data, i.e. where the vectors are stored
+     * \tparam _DistanceType Type of distance variables (must be signed) (e.g.
+     * float, double)
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <class T, class DataSource, typename _DistanceType = T, typename IndexType = uint32_t>
+    struct SO3_Adaptor
+    {
+        using ElementType  = T;
+        using DistanceType = _DistanceType;
+
+        L2_Simple_Adaptor<T, DataSource, DistanceType, IndexType> distance_L2_Simple;
+
+        SO3_Adaptor(const DataSource& _data_source) : distance_L2_Simple(_data_source) {}
+
+        DistanceType evalMetric(const T* a, const IndexType b_idx, size_t size) const
+        {
+            return distance_L2_Simple.evalMetric(a, b_idx, size);
+        }
+
+        template <typename U, typename V>
+        DistanceType accum_dist(const U a, const V b, const size_t idx) const
+        {
+            return distance_L2_Simple.accum_dist(a, b, idx);
+        }
+    };
+
+    /** Metaprogramming helper traits class for the L1 (Manhattan) metric */
+    struct metric_L1 : public Metric
+    {
+        template <class T, class DataSource, typename IndexType = uint32_t>
+        struct traits
+        {
+            using distance_t = L1_Adaptor<T, DataSource, T, IndexType>;
+        };
+    };
+    /** Metaprogramming helper traits class for the L2 (Euclidean) **squared**
+     * distance metric */
+    struct metric_L2 : public Metric
+    {
+        template <class T, class DataSource, typename IndexType = uint32_t>
+        struct traits
+        {
+            using distance_t = L2_Adaptor<T, DataSource, T, IndexType>;
+        };
+    };
+    /** Metaprogramming helper traits class for the L2_simple (Euclidean)
+     * **squared** distance metric */
+    struct metric_L2_Simple : public Metric
+    {
+        template <class T, class DataSource, typename IndexType = uint32_t>
+        struct traits
+        {
+            using distance_t = L2_Simple_Adaptor<T, DataSource, T, IndexType>;
+        };
+    };
+    /** Metaprogramming helper traits class for the SO3_InnerProdQuat metric */
+    struct metric_SO2 : public Metric
+    {
+        template <class T, class DataSource, typename IndexType = uint32_t>
+        struct traits
+        {
+            using distance_t = SO2_Adaptor<T, DataSource, T, IndexType>;
+        };
+    };
+    /** Metaprogramming helper traits class for the SO3_InnerProdQuat metric */
+    struct metric_SO3 : public Metric
+    {
+        template <class T, class DataSource, typename IndexType = uint32_t>
+        struct traits
+        {
+            using distance_t = SO3_Adaptor<T, DataSource, T, IndexType>;
+        };
+    };
+
+    /** \} */
+
+    /** @addtogroup param_grp Parameter structs
+     * \{ */
+
+    enum class KDTreeSingleIndexAdaptorFlags
+    {
+        None                  = 0,
+        SkipInitialBuildIndex = 1
+    };
+
+    inline std::underlying_type<KDTreeSingleIndexAdaptorFlags>::type operator&(KDTreeSingleIndexAdaptorFlags lhs,
+                                                                               KDTreeSingleIndexAdaptorFlags rhs)
+    {
+        using underlying = typename std::underlying_type<KDTreeSingleIndexAdaptorFlags>::type;
+        return static_cast<underlying>(lhs) & static_cast<underlying>(rhs);
+    }
+
+    /**  Parameters (see README.md) */
+    struct KDTreeSingleIndexAdaptorParams
+    {
+        KDTreeSingleIndexAdaptorParams(size_t _leaf_max_size                = 10,
+                                       KDTreeSingleIndexAdaptorFlags _flags = KDTreeSingleIndexAdaptorFlags::None,
+                                       unsigned int _n_thread_build         = 1)
+            : leaf_max_size(_leaf_max_size), flags(_flags), n_thread_build(_n_thread_build)
+        {
+        }
+
+        size_t leaf_max_size;
+        KDTreeSingleIndexAdaptorFlags flags;
+        unsigned int n_thread_build;
+    };
+
+    /** Search options for KDTreeSingleIndexAdaptor::findNeighbors() */
+    struct SearchParameters
+    {
+        SearchParameters(float eps_ = 0, bool sorted_ = true) : eps(eps_), sorted(sorted_) {}
+
+        float eps;   //!< search for eps-approximate neighbours (default: 0)
+        bool sorted; //!< only for radius search, require neighbours sorted by
+                     //!< distance (default: true)
+    };
+    /** \} */
+
+    /** @addtogroup memalloc_grp Memory allocation
+     * \{ */
+
+    /**
+     * Pooled storage allocator
+     *
+     * The following routines allow for the efficient allocation of storage in
+     * small chunks from a specified pool.  Rather than allowing each structure
+     * to be freed individually, an entire pool of storage is freed at once.
+     * This method has two advantages over just using malloc() and free().  First,
+     * it is far more efficient for allocating small objects, as there is
+     * no overhead for remembering all the information needed to free each
+     * object or consolidating fragmented memory.  Second, the decision about
+     * how long to keep an object is made at the time of allocation, and there
+     * is no need to track down all the objects to free them.
+     *
+     */
+    class PooledAllocator
+    {
+        static constexpr size_t WORDSIZE  = 16;
+        static constexpr size_t BLOCKSIZE = 8192;
+
+        /* We maintain memory alignment to word boundaries by requiring that all
+            allocations be in multiples of the machine wordsize.  */
+        /* Size of machine word in bytes.  Must be power of 2. */
+        /* Minimum number of bytes requested at a time from	the system.  Must be
+         * multiple of WORDSIZE. */
+
+        using Offset    = uint32_t;
+        using Size      = uint32_t;
+        using Dimension = int32_t;
+
+        Size remaining_ = 0;       //!< Number of bytes left in current block of storage
+        void* base_     = nullptr; //!< Pointer to base of current block of storage
+        void* loc_      = nullptr; //!< Current location in block to next allocate
+
+        void internal_init()
+        {
+            remaining_   = 0;
+            base_        = nullptr;
+            usedMemory   = 0;
+            wastedMemory = 0;
+        }
+
+    public:
+        Size usedMemory   = 0;
+        Size wastedMemory = 0;
+
+        /**
+            Default constructor. Initializes a new pool.
+         */
+        PooledAllocator() { internal_init(); }
+
+        /**
+         * Destructor. Frees all the memory allocated in this pool.
+         */
+        ~PooledAllocator() { free_all(); }
+
+        /** Frees all allocated memory chunks */
+        void free_all()
+        {
+            while (base_ != nullptr)
+            {
+                // Get pointer to prev block
+                void* prev = *(static_cast<void**>(base_));
+                ::free(base_);
+                base_ = prev;
+            }
+            internal_init();
+        }
+
+        /**
+         * Returns a pointer to a piece of new memory of the given size in bytes
+         * allocated from the pool.
+         */
+        void* malloc(const size_t req_size)
+        {
+            /* Round size up to a multiple of wordsize.  The following expression
+                only works for WORDSIZE that is a power of 2, by masking last bits
+               of incremented size to zero.
+             */
+            const Size size = (req_size + (WORDSIZE - 1)) & ~(WORDSIZE - 1);
+
+            /* Check whether a new block must be allocated.  Note that the first
+               word of a block is reserved for a pointer to the previous block.
+             */
+            if (size > remaining_)
+            {
+                wastedMemory += remaining_;
+
+                /* Allocate new storage. */
+                const Size blocksize = (size + sizeof(void*) + (WORDSIZE - 1) > BLOCKSIZE)
+                                           ? size + sizeof(void*) + (WORDSIZE - 1)
+                                           : BLOCKSIZE;
+
+                // use the standard C malloc to allocate memory
+                void* m = ::malloc(blocksize);
+                if (!m)
+                {
+                    fprintf(stderr, "Failed to allocate memory.\n");
+                    throw std::bad_alloc();
+                }
+
+                /* Fill first word of new block with pointer to previous block. */
+                static_cast<void**>(m)[0] = base_;
+                base_                     = m;
+
+                Size shift = 0;
+                // int size_t = (WORDSIZE - ( (((size_t)m) + sizeof(void*)) &
+                // (WORDSIZE-1))) & (WORDSIZE-1);
+
+                remaining_ = blocksize - sizeof(void*) - shift;
+                loc_       = (static_cast<char*>(m) + sizeof(void*) + shift);
+            }
+            void* rloc = loc_;
+            loc_       = static_cast<char*>(loc_) + size;
+            remaining_ -= size;
+
+            usedMemory += size;
+
+            return rloc;
+        }
+
+        /**
+         * Allocates (using this pool) a generic type T.
+         *
+         * Params:
+         *     count = number of instances to allocate.
+         * Returns: pointer (of type T*) to memory buffer
+         */
+        template <typename T>
+        T* allocate(const size_t count = 1)
+        {
+            T* mem = static_cast<T*>(this->malloc(sizeof(T) * count));
+            return mem;
+        }
+    };
+    /** \} */
+
+    /** @addtogroup nanoflann_metaprog_grp Auxiliary metaprogramming stuff
+     * \{ */
+
+    /** Used to declare fixed-size arrays when DIM>0, dynamically-allocated vectors
+     * when DIM=-1. Fixed size version for a generic DIM:
+     */
+    template <int32_t DIM, typename T>
+    struct array_or_vector
+    {
+        using type = std::array<T, DIM>;
+    };
+    /** Dynamic size version */
+    template <typename T>
+    struct array_or_vector<-1, T>
+    {
+        using type = std::vector<T>;
+    };
+
+    /** \} */
+
+    /** kd-tree base-class
+     *
+     * Contains the member functions common to the classes KDTreeSingleIndexAdaptor
+     * and KDTreeSingleIndexDynamicAdaptor_.
+     *
+     * \tparam Derived The name of the class which inherits this class.
+     * \tparam DatasetAdaptor The user-provided adaptor, which must be ensured to
+     *         have a lifetime equal or longer than the instance of this class.
+     * \tparam Distance The distance metric to use, these are all classes derived
+     * from nanoflann::Metric
+     * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <class Derived, typename Distance, class DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+    class KDTreeBaseClass
+    {
+    public:
+        /** Frees the previously-built index. Automatically called within
+         * buildIndex(). */
+        void freeIndex(Derived& obj)
+        {
+            obj.pool_.free_all();
+            obj.root_node_           = nullptr;
+            obj.size_at_index_build_ = 0;
+        }
+
+        using ElementType  = typename Distance::ElementType;
+        using DistanceType = typename Distance::DistanceType;
+
+        /**
+         *  Array of indices to vectors in the dataset_.
+         */
+        std::vector<IndexType> vAcc_;
+
+        using Offset    = typename decltype(vAcc_)::size_type;
+        using Size      = typename decltype(vAcc_)::size_type;
+        using Dimension = int32_t;
+
+        /*---------------------------
+         * Internal Data Structures
+         * --------------------------*/
+        struct Node
+        {
+            /** Union used because a node can be either a LEAF node or a non-leaf
+             * node, so both data fields are never used simultaneously */
+            union {
+                struct leaf
+                {
+                    Offset left, right; //!< Indices of points in leaf node
+                } lr;
+                struct nonleaf
+                {
+                    Dimension divfeat; //!< Dimension used for subdivision.
+                    /// The values used for subdivision.
+                    DistanceType divlow, divhigh;
+                } sub;
+            } node_type;
+
+            /** Child nodes (both=nullptr mean its a leaf node) */
+            Node *child1 = nullptr, *child2 = nullptr;
+        };
+
+        using NodePtr      = Node*;
+        using NodeConstPtr = const Node*;
+
+        struct Interval
+        {
+            ElementType low, high;
+        };
+
+        NodePtr root_node_ = nullptr;
+
+        Size leaf_max_size_ = 0;
+
+        /// Number of thread for concurrent tree build
+        Size n_thread_build_ = 1;
+        /// Number of current points in the dataset
+        Size size_ = 0;
+        /// Number of points in the dataset when the index was built
+        Size size_at_index_build_ = 0;
+        Dimension dim_            = 0; //!< Dimensionality of each data point
+
+        /** Define "BoundingBox" as a fixed-size or variable-size container
+         * depending on "DIM" */
+        using BoundingBox = typename array_or_vector<DIM, Interval>::type;
+
+        /** Define "distance_vector_t" as a fixed-size or variable-size container
+         * depending on "DIM" */
+        using distance_vector_t = typename array_or_vector<DIM, DistanceType>::type;
+
+        /** The KD-tree used to find neighbours */
+        BoundingBox root_bbox_;
+
+        /**
+         * Pooled memory allocator.
+         *
+         * Using a pooled memory allocator is more efficient
+         * than allocating memory directly when there is a large
+         * number small of memory allocations.
+         */
+        PooledAllocator pool_;
+
+        /** Returns number of points in dataset  */
+        Size size(const Derived& obj) const { return obj.size_; }
+
+        /** Returns the length of each point in the dataset */
+        Size veclen(const Derived& obj) { return DIM > 0 ? DIM : obj.dim; }
+
+        /// Helper accessor to the dataset points:
+        ElementType dataset_get(const Derived& obj, IndexType element, Dimension component) const
+        {
+            return obj.dataset_.kdtree_get_pt(element, component);
+        }
+
+        /**
+         * Computes the inde memory usage
+         * Returns: memory used by the index
+         */
+        Size usedMemory(Derived& obj)
+        {
+            return obj.pool_.usedMemory + obj.pool_.wastedMemory +
+                   obj.dataset_.kdtree_get_point_count() * sizeof(IndexType); // pool memory and vind array memory
+        }
+
+        void computeMinMax(const Derived& obj, Offset ind, Size count, Dimension element, ElementType& min_elem,
+                           ElementType& max_elem)
+        {
+            min_elem = dataset_get(obj, vAcc_[ind], element);
+            max_elem = min_elem;
+            for (Offset i = 1; i < count; ++i)
+            {
+                ElementType val = dataset_get(obj, vAcc_[ind + i], element);
+                if (val < min_elem)
+                    min_elem = val;
+                if (val > max_elem)
+                    max_elem = val;
+            }
+        }
+
+        /**
+         * Create a tree node that subdivides the list of vecs from vind[first]
+         * to vind[last].  The routine is called recursively on each sublist.
+         *
+         * \param left index of the first vector
+         * \param right index of the last vector
+         */
+        NodePtr divideTree(Derived& obj, const Offset left, const Offset right, BoundingBox& bbox)
+        {
+            NodePtr node    = obj.pool_.template allocate<Node>(); // allocate memory
+            const auto dims = (DIM > 0 ? DIM : obj.dim_);
+
+            /* If too few exemplars remain, then make this a leaf node. */
+            if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
+            {
+                node->child1 = node->child2 = nullptr; /* Mark as leaf node. */
+                node->node_type.lr.left     = left;
+                node->node_type.lr.right    = right;
+
+                // compute bounding-box of leaf points
+                for (Dimension i = 0; i < dims; ++i)
+                {
+                    bbox[i].low  = dataset_get(obj, obj.vAcc_[left], i);
+                    bbox[i].high = dataset_get(obj, obj.vAcc_[left], i);
+                }
+                for (Offset k = left + 1; k < right; ++k)
+                {
+                    for (Dimension i = 0; i < dims; ++i)
                     {
-                        // the resultset doesn't want to receive any more
-                        // points, we're done searching!
-                        return;  // false;
+                        const auto val = dataset_get(obj, obj.vAcc_[k], i);
+                        if (bbox[i].low > val)
+                            bbox[i].low = val;
+                        if (bbox[i].high < val)
+                            bbox[i].high = val;
                     }
                 }
             }
-            return;
-        }
-
-        /* Which child branch should be taken first? */
-        Dimension    idx   = node->node_type.sub.divfeat;
-        ElementType  val   = vec[idx];
-        DistanceType diff1 = val - node->node_type.sub.divlow;
-        DistanceType diff2 = val - node->node_type.sub.divhigh;
-
-        NodePtr      bestChild;
-        NodePtr      otherChild;
-        DistanceType cut_dist;
-        if ((diff1 + diff2) < 0)
-        {
-            bestChild  = node->child1;
-            otherChild = node->child2;
-            cut_dist =
-                distance_.accum_dist(val, node->node_type.sub.divhigh, idx);
-        }
-        else
-        {
-            bestChild  = node->child2;
-            otherChild = node->child1;
-            cut_dist =
-                distance_.accum_dist(val, node->node_type.sub.divlow, idx);
-        }
-
-        /* Call recursively to search next level down. */
-        searchLevel(result_set, vec, bestChild, mindist, dists, epsError);
-
-        DistanceType dst = dists[idx];
-        mindist        = mindist + cut_dist - dst;
-        dists[idx]       = cut_dist;
-        if (mindist * epsError <= result_set.worstDist())
-        {
-            searchLevel(
-                result_set, vec, otherChild, mindist, dists, epsError);
-        }
-        dists[idx] = dst;
-    }
-
-   public:
-    /**  Stores the index in a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * when loading the index object it must be constructed associated to the
-     * same source of data points used while building it. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
-    void saveIndex(std::ostream& stream) { saveIndex(*this, stream); }
-
-    /**  Loads a previous index from a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * the index object must be constructed associated to the same source of
-     * data points used while building the index. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
-    void loadIndex(std::istream& stream) { loadIndex(*this, stream); }
-};
-
-/** kd-tree dynaimic index
- *
- * class to create multiple static index and merge their results to behave as
- * single dynamic index as proposed in Logarithmic Approach.
- *
- *  Example of usage:
- *  examples/dynamic_pointcloud_example.cpp
- *
- * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
- * \tparam Distance The distance metric to use: nanoflann::metric_L1,
- * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc. \tparam DIM
- * Dimensionality of data points (e.g. 3 for 3D points) \tparam IndexType
- * Will be typically size_t or int
- */
-template <
-    typename Distance, class DatasetAdaptor, int32_t DIM = -1,
-    typename IndexType = uint32_t>
-class KDTreeSingleIndexDynamicAdaptor
-{
-   public:
-    using ElementType  = typename Distance::ElementType;
-    using DistanceType = typename Distance::DistanceType;
-
-    using Offset = typename KDTreeSingleIndexDynamicAdaptor_<
-        Distance, DatasetAdaptor, DIM>::Offset;
-    using Size = typename KDTreeSingleIndexDynamicAdaptor_<
-        Distance, DatasetAdaptor, DIM>::Size;
-    using Dimension = typename KDTreeSingleIndexDynamicAdaptor_<
-        Distance, DatasetAdaptor, DIM>::Dimension;
-
-   protected:
-    Size leaf_max_size_;
-    Size treeCount_;
-    Size pointCount_;
-
-    /**
-     * The dataset used by this index
-     */
-    const DatasetAdaptor& dataset_;  //!< The source of our data
-
-    /** treeIndex[idx] is the index of tree in which point at idx is stored.
-     * treeIndex[idx]=-1 means that point has been removed. */
-    std::vector<int>        treeIndex_;
-    std::unordered_set<int> removedPoints_;
-
-    KDTreeSingleIndexAdaptorParams index_params_;
-
-    Dimension dim_;  //!< Dimensionality of each data point
-
-    using index_container_t = KDTreeSingleIndexDynamicAdaptor_<
-        Distance, DatasetAdaptor, DIM, IndexType>;
-    std::vector<index_container_t> index_;
-
-   public:
-    /** Get a const ref to the internal list of indices; the number of indices
-     * is adapted dynamically as the dataset grows in size. */
-    const std::vector<index_container_t>& getAllIndices() const
-    {
-        return index_;
-    }
-
-   private:
-    /** finds position of least significant unset bit */
-    int First0Bit(IndexType num)
-    {
-        int pos = 0;
-        while (num & 1)
-        {
-            num = num >> 1;
-            pos++;
-        }
-        return pos;
-    }
-
-    /** Creates multiple empty trees to handle dynamic support */
-    void init()
-    {
-        using my_kd_tree_t = KDTreeSingleIndexDynamicAdaptor_<
-            Distance, DatasetAdaptor, DIM, IndexType>;
-        std::vector<my_kd_tree_t> index(
-            treeCount_,
-            my_kd_tree_t(dim_ /*dim*/, dataset_, treeIndex_, index_params_));
-        index_ = index;
-    }
-
-   public:
-    Distance distance_;
-
-    /**
-     * KDTree constructor
-     *
-     * Refer to docs in README.md or online in
-     * https://github.com/jlblancoc/nanoflann
-     *
-     * The KD-Tree point dimension (the length of each point in the datase, e.g.
-     * 3 for 3D points) is determined by means of:
-     *  - The \a DIM template parameter if >0 (highest priority)
-     *  - Otherwise, the \a dimensionality parameter of this constructor.
-     *
-     * \param inputData Dataset with the input features. Its lifetime must be
-     *  equal or longer than that of the instance of this class.
-     * \param params Basically, the maximum leaf node size
-     */
-    explicit KDTreeSingleIndexDynamicAdaptor(
-        const int dimensionality, const DatasetAdaptor& inputData,
-        const KDTreeSingleIndexAdaptorParams& params =
-            KDTreeSingleIndexAdaptorParams(),
-        const size_t maximumPointCount = 1000000000U)
-        : dataset_(inputData), index_params_(params), distance_(inputData)
-    {
-        treeCount_  = static_cast<size_t>(std::log2(maximumPointCount)) + 1;
-        pointCount_ = 0U;
-        dim_        = dimensionality;
-        treeIndex_.clear();
-        if (DIM > 0) dim_ = DIM;
-        leaf_max_size_ = params.leaf_max_size;
-        init();
-        const size_t num_initial_points = dataset_.kdtree_get_point_count();
-        if (num_initial_points > 0) { addPoints(0, num_initial_points - 1); }
-    }
-
-    /** Deleted copy constructor*/
-    explicit KDTreeSingleIndexDynamicAdaptor(
-        const KDTreeSingleIndexDynamicAdaptor<
-            Distance, DatasetAdaptor, DIM, IndexType>&) = delete;
-
-    /** Add points to the set, Inserts all points from [start, end] */
-    void addPoints(IndexType start, IndexType end)
-    {
-        const Size count    = end - start + 1;
-        int        maxIndex = 0;
-        treeIndex_.resize(treeIndex_.size() + count);
-        for (IndexType idx = start; idx <= end; idx++)
-        {
-            const int pos           = First0Bit(pointCount_);
-            maxIndex                = std::max(pos, maxIndex);
-            treeIndex_[pointCount_] = pos;
-
-            const auto it = removedPoints_.find(idx);
-            if (it != removedPoints_.end())
+            else
             {
-                removedPoints_.erase(it);
-                treeIndex_[idx] = pos;
-            }
+                Offset idx;
+                Dimension cutfeat;
+                DistanceType cutval;
+                middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
 
-            for (int i = 0; i < pos; i++)
-            {
-                for (int j = 0; j < static_cast<int>(index_[i].vAcc_.size());
-                     j++)
+                node->node_type.sub.divfeat = cutfeat;
+
+                BoundingBox left_bbox(bbox);
+                left_bbox[cutfeat].high = cutval;
+                node->child1            = this->divideTree(obj, left, left + idx, left_bbox);
+
+                BoundingBox right_bbox(bbox);
+                right_bbox[cutfeat].low = cutval;
+                node->child2            = this->divideTree(obj, left + idx, right, right_bbox);
+
+                node->node_type.sub.divlow  = left_bbox[cutfeat].high;
+                node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+
+                for (Dimension i = 0; i < dims; ++i)
                 {
-                    index_[pos].vAcc_.push_back(index_[i].vAcc_[j]);
-                    if (treeIndex_[index_[i].vAcc_[j]] != -1)
-                        treeIndex_[index_[i].vAcc_[j]] = pos;
+                    bbox[i].low  = std::min(left_bbox[i].low, right_bbox[i].low);
+                    bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
                 }
-                index_[i].vAcc_.clear();
             }
-            index_[pos].vAcc_.push_back(idx);
-            pointCount_++;
+
+            return node;
         }
 
-        for (int i = 0; i <= maxIndex; ++i)
+        /**
+         * Create a tree node that subdivides the list of vecs from vind[first] to
+         * vind[last] concurrently.  The routine is called recursively on each
+         * sublist.
+         *
+         * \param left index of the first vector
+         * \param right index of the last vector
+         * \param thread_count count of std::async threads
+         * \param mutex mutex for mempool allocation
+         */
+        NodePtr divideTreeConcurrent(Derived& obj, const Offset left, const Offset right, BoundingBox& bbox,
+                                     std::atomic<unsigned int>& thread_count, std::mutex& mutex)
         {
-            index_[i].freeIndex(index_[i]);
-            if (!index_[i].vAcc_.empty()) index_[i].buildIndex();
+            std::unique_lock<std::mutex> lock(mutex);
+            NodePtr node = obj.pool_.template allocate<Node>(); // allocate memory
+            lock.unlock();
+
+            const auto dims = (DIM > 0 ? DIM : obj.dim_);
+
+            /* If too few exemplars remain, then make this a leaf node. */
+            if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
+            {
+                node->child1 = node->child2 = nullptr; /* Mark as leaf node. */
+                node->node_type.lr.left     = left;
+                node->node_type.lr.right    = right;
+
+                // compute bounding-box of leaf points
+                for (Dimension i = 0; i < dims; ++i)
+                {
+                    bbox[i].low  = dataset_get(obj, obj.vAcc_[left], i);
+                    bbox[i].high = dataset_get(obj, obj.vAcc_[left], i);
+                }
+                for (Offset k = left + 1; k < right; ++k)
+                {
+                    for (Dimension i = 0; i < dims; ++i)
+                    {
+                        const auto val = dataset_get(obj, obj.vAcc_[k], i);
+                        if (bbox[i].low > val)
+                            bbox[i].low = val;
+                        if (bbox[i].high < val)
+                            bbox[i].high = val;
+                    }
+                }
+            }
+            else
+            {
+                Offset idx;
+                Dimension cutfeat;
+                DistanceType cutval;
+                middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
+
+                node->node_type.sub.divfeat = cutfeat;
+
+                std::future<NodePtr> left_future, right_future;
+
+                BoundingBox left_bbox(bbox);
+                left_bbox[cutfeat].high = cutval;
+                if (++thread_count < n_thread_build_)
+                {
+                    left_future =
+                        std::async(std::launch::async, &KDTreeBaseClass::divideTreeConcurrent, this, std::ref(obj),
+                                   left, left + idx, std::ref(left_bbox), std::ref(thread_count), std::ref(mutex));
+                }
+                else
+                {
+                    --thread_count;
+                    node->child1 = this->divideTreeConcurrent(obj, left, left + idx, left_bbox, thread_count, mutex);
+                }
+
+                BoundingBox right_bbox(bbox);
+                right_bbox[cutfeat].low = cutval;
+                if (++thread_count < n_thread_build_)
+                {
+                    right_future =
+                        std::async(std::launch::async, &KDTreeBaseClass::divideTreeConcurrent, this, std::ref(obj),
+                                   left + idx, right, std::ref(right_bbox), std::ref(thread_count), std::ref(mutex));
+                }
+                else
+                {
+                    --thread_count;
+                    node->child2 = this->divideTreeConcurrent(obj, left + idx, right, right_bbox, thread_count, mutex);
+                }
+
+                if (left_future.valid())
+                {
+                    node->child1 = left_future.get();
+                    --thread_count;
+                }
+                if (right_future.valid())
+                {
+                    node->child2 = right_future.get();
+                    --thread_count;
+                }
+
+                node->node_type.sub.divlow  = left_bbox[cutfeat].high;
+                node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+
+                for (Dimension i = 0; i < dims; ++i)
+                {
+                    bbox[i].low  = std::min(left_bbox[i].low, right_bbox[i].low);
+                    bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
+                }
+            }
+
+            return node;
         }
-    }
 
-    /** Remove a point from the set (Lazy Deletion) */
-    void removePoint(size_t idx)
-    {
-        if (idx >= pointCount_) return;
-        removedPoints_.insert(idx);
-        treeIndex_[idx] = -1;
-    }
+        void middleSplit_(const Derived& obj, const Offset ind, const Size count, Offset& index, Dimension& cutfeat,
+                          DistanceType& cutval, const BoundingBox& bbox)
+        {
+            const auto dims      = (DIM > 0 ? DIM : obj.dim_);
+            const auto EPS       = static_cast<DistanceType>(0.00001);
+            ElementType max_span = bbox[0].high - bbox[0].low;
+            for (Dimension i = 1; i < dims; ++i)
+            {
+                ElementType span = bbox[i].high - bbox[i].low;
+                if (span > max_span)
+                {
+                    max_span = span;
+                }
+            }
+            ElementType max_spread = -1;
+            cutfeat                = 0;
+            for (Dimension i = 0; i < dims; ++i)
+            {
+                ElementType span = bbox[i].high - bbox[i].low;
+                if (span > (1 - EPS) * max_span)
+                {
+                    ElementType min_elem, max_elem;
+                    computeMinMax(obj, ind, count, i, min_elem, max_elem);
+                    ElementType spread = max_elem - min_elem;
+                    if (spread > max_spread)
+                    {
+                        cutfeat    = i;
+                        max_spread = spread;
+                    }
+                }
+            }
+            // split in the middle
+            DistanceType split_val = (bbox[cutfeat].low + bbox[cutfeat].high) / 2;
+            ElementType min_elem, max_elem;
+            computeMinMax(obj, ind, count, cutfeat, min_elem, max_elem);
 
-    /**
-     * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
-     * inside the result object.
-     *
-     * Params:
-     *     result = the result object in which the indices of the
-     * nearest-neighbors are stored vec = the vector for which to search the
-     * nearest neighbors
-     *
-     * \tparam RESULTSET Should be any ResultSet<DistanceType>
-     * \return  True if the requested neighbors could be found.
-     * \sa knnSearch, radiusSearch
-     *
-     * \note If L2 norms are used, all returned distances are actually squared
-     *       distances.
-     */
-    template <typename RESULTSET>
-    bool findNeighbors(
-        RESULTSET& result, const ElementType* vec,
-        const SearchParameters& searchParams = {}) const
-    {
-        for (size_t i = 0; i < treeCount_; i++)
-        { index_[i].findNeighbors(result, &vec[0], searchParams); }
-        return result.full();
-    }
-};
+            if (split_val < min_elem)
+                cutval = min_elem;
+            else if (split_val > max_elem)
+                cutval = max_elem;
+            else
+                cutval = split_val;
 
-/** An L2-metric KD-tree adaptor for working with data directly stored in an
- * Eigen Matrix, without duplicating the data storage. You can select whether a
- * row or column in the matrix represents a point in the state space.
- *
- * Example of usage:
- * \code
- * Eigen::Matrix<num_t,Eigen::Dynamic,Eigen::Dynamic>  mat;
- *
- * // Fill out "mat"...
- * using my_kd_tree_t = nanoflann::KDTreeEigenMatrixAdaptor<
- *   Eigen::Matrix<num_t,Dynamic,Dynamic>>;
- *
- * const int max_leaf = 10;
- * my_kd_tree_t mat_index(mat, max_leaf);
- * mat_index.index->...
- * \endcode
- *
- *  \tparam DIM If set to >0, it specifies a compile-time fixed dimensionality
- * for the points in the data set, allowing more compiler optimizations.
- * \tparam Distance The distance metric to use: nanoflann::metric_L1,
- * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
- * \tparam row_major If set to true the rows of the matrix are used as the
- *         points, if set to false  the columns of the matrix are used as the
- *         points.
- */
-template <
-    class MatrixType, int32_t DIM = -1, class Distance = nanoflann::metric_L2,
-    bool row_major = true>
-struct KDTreeEigenMatrixAdaptor
-{
-    using self_t =
-        KDTreeEigenMatrixAdaptor<MatrixType, DIM, Distance, row_major>;
-    using num_t     = typename MatrixType::Scalar;
-    using IndexType = typename MatrixType::Index;
-    using metric_t  = typename Distance::template traits<
-        num_t, self_t, IndexType>::distance_t;
+            Offset lim1, lim2;
+            planeSplit(obj, ind, count, cutfeat, cutval, lim1, lim2);
 
-    using index_t = KDTreeSingleIndexAdaptor<
-        metric_t, self_t,
-        row_major ? MatrixType::ColsAtCompileTime
-                  : MatrixType::RowsAtCompileTime,
-        IndexType>;
+            if (lim1 > count / 2)
+                index = lim1;
+            else if (lim2 < count / 2)
+                index = lim2;
+            else
+                index = count / 2;
+        }
 
-    index_t* index_;  //! The kd-tree index for the user to call its methods as
-                      //! usual with any other FLANN index.
+        /**
+         *  Subdivide the list of points by a plane perpendicular on the axis
+         * corresponding to the 'cutfeat' dimension at 'cutval' position.
+         *
+         *  On return:
+         *  dataset[ind[0..lim1-1]][cutfeat]<cutval
+         *  dataset[ind[lim1..lim2-1]][cutfeat]==cutval
+         *  dataset[ind[lim2..count]][cutfeat]>cutval
+         */
+        void planeSplit(const Derived& obj, const Offset ind, const Size count, const Dimension cutfeat,
+                        const DistanceType& cutval, Offset& lim1, Offset& lim2)
+        {
+            /* Move vector indices for left subtree to front of list. */
+            Offset left  = 0;
+            Offset right = count - 1;
+            for (;;)
+            {
+                while (left <= right && dataset_get(obj, vAcc_[ind + left], cutfeat) < cutval)
+                    ++left;
+                while (right && left <= right && dataset_get(obj, vAcc_[ind + right], cutfeat) >= cutval)
+                    --right;
+                if (left > right || !right)
+                    break; // "!right" was added to support unsigned Index types
+                std::swap(vAcc_[ind + left], vAcc_[ind + right]);
+                ++left;
+                --right;
+            }
+            /* If either list is empty, it means that all remaining features
+             * are identical. Split in the middle to maintain a balanced tree.
+             */
+            lim1  = left;
+            right = count - 1;
+            for (;;)
+            {
+                while (left <= right && dataset_get(obj, vAcc_[ind + left], cutfeat) <= cutval)
+                    ++left;
+                while (right && left <= right && dataset_get(obj, vAcc_[ind + right], cutfeat) > cutval)
+                    --right;
+                if (left > right || !right)
+                    break; // "!right" was added to support unsigned Index types
+                std::swap(vAcc_[ind + left], vAcc_[ind + right]);
+                ++left;
+                --right;
+            }
+            lim2 = left;
+        }
 
-    using Offset    = typename index_t::Offset;
-    using Size      = typename index_t::Size;
-    using Dimension = typename index_t::Dimension;
+        DistanceType computeInitialDistances(const Derived& obj, const ElementType* vec, distance_vector_t& dists) const
+        {
+            assert(vec);
+            DistanceType dist = DistanceType();
 
-    /// Constructor: takes a const ref to the matrix object with the data points
-    explicit KDTreeEigenMatrixAdaptor(
-        const Dimension                                 dimensionality,
-        const std::reference_wrapper<const MatrixType>& mat,
-        const int                                       leaf_max_size = 10)
-        : m_data_matrix(mat)
-    {
-        const auto dims = row_major ? mat.get().cols() : mat.get().rows();
-        if (static_cast<Dimension>(dims) != dimensionality)
-            throw std::runtime_error(
-                "Error: 'dimensionality' must match column count in data "
-                "matrix");
-        if (DIM > 0 && static_cast<int32_t>(dims) != DIM)
-            throw std::runtime_error(
-                "Data set dimensionality does not match the 'DIM' template "
-                "argument");
-        index_ = new index_t(
-            dims, *this /* adaptor */,
-            nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size));
-    }
+            for (Dimension i = 0; i < (DIM > 0 ? DIM : obj.dim_); ++i)
+            {
+                if (vec[i] < obj.root_bbox_[i].low)
+                {
+                    dists[i] = obj.distance_.accum_dist(vec[i], obj.root_bbox_[i].low, i);
+                    dist += dists[i];
+                }
+                if (vec[i] > obj.root_bbox_[i].high)
+                {
+                    dists[i] = obj.distance_.accum_dist(vec[i], obj.root_bbox_[i].high, i);
+                    dist += dists[i];
+                }
+            }
+            return dist;
+        }
 
-   public:
-    /** Deleted copy constructor */
-    KDTreeEigenMatrixAdaptor(const self_t&) = delete;
+        static void save_tree(const Derived& obj, std::ostream& stream, const NodeConstPtr tree)
+        {
+            save_value(stream, *tree);
+            if (tree->child1 != nullptr)
+            {
+                save_tree(obj, stream, tree->child1);
+            }
+            if (tree->child2 != nullptr)
+            {
+                save_tree(obj, stream, tree->child2);
+            }
+        }
 
-    ~KDTreeEigenMatrixAdaptor() { delete index_; }
+        static void load_tree(Derived& obj, std::istream& stream, NodePtr& tree)
+        {
+            tree = obj.pool_.template allocate<Node>();
+            load_value(stream, *tree);
+            if (tree->child1 != nullptr)
+            {
+                load_tree(obj, stream, tree->child1);
+            }
+            if (tree->child2 != nullptr)
+            {
+                load_tree(obj, stream, tree->child2);
+            }
+        }
 
-    const std::reference_wrapper<const MatrixType> m_data_matrix;
+        /**  Stores the index in a binary file.
+         *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
+         * when loading the index object it must be constructed associated to the
+         * same source of data points used while building it. See the example:
+         * examples/saveload_example.cpp \sa loadIndex  */
+        void saveIndex(const Derived& obj, std::ostream& stream) const
+        {
+            save_value(stream, obj.size_);
+            save_value(stream, obj.dim_);
+            save_value(stream, obj.root_bbox_);
+            save_value(stream, obj.leaf_max_size_);
+            save_value(stream, obj.vAcc_);
+            save_tree(obj, stream, obj.root_node_);
+        }
 
-    /** Query for the \a num_closest closest points to a given point (entered as
-     * query_point[0:dim-1]). Note that this is a short-cut method for
-     * index->findNeighbors(). The user can also call index->... methods as
-     * desired.
-     *
-     * \note If L2 norms are used, all returned distances are actually squared
-     *       distances.
-     */
-    void query(
-        const num_t* query_point, const Size num_closest,
-        IndexType* out_indices, num_t* out_distances) const
-    {
-        nanoflann::KNNResultSet<num_t, IndexType> resultSet(num_closest);
-        resultSet.init(out_indices, out_distances);
-        index_->findNeighbors(resultSet, query_point);
-    }
+        /**  Loads a previous index from a binary file.
+         *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
+         * the index object must be constructed associated to the same source of
+         * data points used while building the index. See the example:
+         * examples/saveload_example.cpp \sa loadIndex  */
+        void loadIndex(Derived& obj, std::istream& stream)
+        {
+            load_value(stream, obj.size_);
+            load_value(stream, obj.dim_);
+            load_value(stream, obj.root_bbox_);
+            load_value(stream, obj.leaf_max_size_);
+            load_value(stream, obj.vAcc_);
+            load_tree(obj, stream, obj.root_node_);
+        }
+    };
 
-    /** \name Interface expected by KDTreeSingleIndexAdaptor
+    /** @addtogroup kdtrees_grp KD-tree classes and adaptors
      * \{ */
 
-    const self_t& derived() const { return *this; }
-    self_t&       derived() { return *this; }
-
-    // Must return the number of data points
-    Size kdtree_get_point_count() const
+    /** kd-tree static index
+     *
+     * Contains the k-d trees and other information for indexing a set of points
+     * for nearest-neighbor matching.
+     *
+     *  The class "DatasetAdaptor" must provide the following interface (can be
+     * non-virtual, inlined methods):
+     *
+     *  \code
+     *   // Must return the number of data poins
+     *   size_t kdtree_get_point_count() const { ... }
+     *
+     *
+     *   // Must return the dim'th component of the idx'th point in the class:
+     *   T kdtree_get_pt(const size_t idx, const size_t dim) const { ... }
+     *
+     *   // Optional bounding-box computation: return false to default to a standard
+     * bbox computation loop.
+     *   //   Return true if the BBOX was already computed by the class and returned
+     * in "bb" so it can be avoided to redo it again.
+     *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3
+     * for point clouds) template <class BBOX> bool kdtree_get_bbox(BBOX &bb) const
+     *   {
+     *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
+     *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
+     *      ...
+     *      return true;
+     *   }
+     *
+     *  \endcode
+     *
+     * \tparam DatasetAdaptor The user-provided adaptor, which must be ensured to
+     *         have a lifetime equal or longer than the instance of this class.
+     * \tparam Distance The distance metric to use: nanoflann::metric_L1,
+     * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc. \tparam DIM
+     * Dimensionality of data points (e.g. 3 for 3D points) \tparam IndexType Will
+     * be typically size_t or int
+     */
+    template <typename Distance, class DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+    class KDTreeSingleIndexAdaptor
+        : public KDTreeBaseClass<KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>, Distance,
+                                 DatasetAdaptor, DIM, IndexType>
     {
-        if (row_major)
-            return m_data_matrix.get().rows();
-        else
-            return m_data_matrix.get().cols();
-    }
+    public:
+        /** Deleted copy constructor*/
+        explicit KDTreeSingleIndexAdaptor(const KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>&) =
+            delete;
 
-    // Returns the dim'th component of the idx'th point in the class:
-    num_t kdtree_get_pt(const IndexType idx, size_t dim) const
+        /** The data source used by this index */
+        const DatasetAdaptor& dataset_;
+
+        const KDTreeSingleIndexAdaptorParams indexParams;
+
+        Distance distance_;
+
+        using Base = typename nanoflann::KDTreeBaseClass<
+            nanoflann::KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>, Distance, DatasetAdaptor,
+            DIM, IndexType>;
+
+        using Offset    = typename Base::Offset;
+        using Size      = typename Base::Size;
+        using Dimension = typename Base::Dimension;
+
+        using ElementType  = typename Base::ElementType;
+        using DistanceType = typename Base::DistanceType;
+
+        using Node    = typename Base::Node;
+        using NodePtr = Node*;
+
+        using Interval = typename Base::Interval;
+
+        /** Define "BoundingBox" as a fixed-size or variable-size container
+         * depending on "DIM" */
+        using BoundingBox = typename Base::BoundingBox;
+
+        /** Define "distance_vector_t" as a fixed-size or variable-size container
+         * depending on "DIM" */
+        using distance_vector_t = typename Base::distance_vector_t;
+
+        /**
+         * KDTree constructor
+         *
+         * Refer to docs in README.md or online in
+         * https://github.com/jlblancoc/nanoflann
+         *
+         * The KD-Tree point dimension (the length of each point in the datase, e.g.
+         * 3 for 3D points) is determined by means of:
+         *  - The \a DIM template parameter if >0 (highest priority)
+         *  - Otherwise, the \a dimensionality parameter of this constructor.
+         *
+         * \param inputData Dataset with the input features. Its lifetime must be
+         *  equal or longer than that of the instance of this class.
+         * \param params Basically, the maximum leaf node size
+         *
+         * Note that there is a variable number of optional additional parameters
+         * which will be forwarded to the metric class constructor. Refer to example
+         * `examples/pointcloud_custom_metric.cpp` for a use case.
+         *
+         */
+        template <class... Args>
+        explicit KDTreeSingleIndexAdaptor(const Dimension dimensionality, const DatasetAdaptor& inputData,
+                                          const KDTreeSingleIndexAdaptorParams& params, Args&&... args)
+            : dataset_(inputData), indexParams(params), distance_(inputData, std::forward<Args>(args)...)
+        {
+            init(dimensionality, params);
+        }
+
+        explicit KDTreeSingleIndexAdaptor(const Dimension dimensionality, const DatasetAdaptor& inputData,
+                                          const KDTreeSingleIndexAdaptorParams& params = {})
+            : dataset_(inputData), indexParams(params), distance_(inputData)
+        {
+            init(dimensionality, params);
+        }
+
+    private:
+        void init(const Dimension dimensionality, const KDTreeSingleIndexAdaptorParams& params)
+        {
+            Base::size_                = dataset_.kdtree_get_point_count();
+            Base::size_at_index_build_ = Base::size_;
+            Base::dim_                 = dimensionality;
+            if (DIM > 0)
+                Base::dim_ = DIM;
+            Base::leaf_max_size_ = params.leaf_max_size;
+            if (params.n_thread_build > 0)
+            {
+                Base::n_thread_build_ = params.n_thread_build;
+            }
+            else
+            {
+                Base::n_thread_build_ = std::max(std::thread::hardware_concurrency(), 1u);
+            }
+
+            if (!(params.flags & KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex))
+            {
+                // Build KD-tree:
+                buildIndex();
+            }
+        }
+
+    public:
+        /**
+         * Builds the index
+         */
+        void buildIndex()
+        {
+            Base::size_                = dataset_.kdtree_get_point_count();
+            Base::size_at_index_build_ = Base::size_;
+            init_vind();
+            this->freeIndex(*this);
+            Base::size_at_index_build_ = Base::size_;
+            if (Base::size_ == 0)
+                return;
+            computeBoundingBox(Base::root_bbox_);
+            // construct the tree
+            if (Base::n_thread_build_ == 1)
+            {
+                Base::root_node_ = this->divideTree(*this, 0, Base::size_, Base::root_bbox_);
+            }
+            else
+            {
+                std::atomic<unsigned int> thread_count(0u);
+                std::mutex mutex;
+                Base::root_node_ =
+                    this->divideTreeConcurrent(*this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
+            }
+        }
+
+        /** \name Query methods
+         * \{ */
+
+        /**
+         * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
+         * inside the result object.
+         *
+         * Params:
+         *     result = the result object in which the indices of the
+         * nearest-neighbors are stored vec = the vector for which to search the
+         * nearest neighbors
+         *
+         * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return  True if the requested neighbors could be found.
+         * \sa knnSearch, radiusSearch
+         *
+         * \note If L2 norms are used, all returned distances are actually squared
+         *       distances.
+         */
+        template <typename RESULTSET>
+        bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParameters& searchParams = {}) const
+        {
+            assert(vec);
+            if (this->size(*this) == 0)
+                return false;
+            if (!Base::root_node_)
+                throw std::runtime_error("[nanoflann] findNeighbors() called before building the "
+                                         "index.");
+            float epsError = 1 + searchParams.eps;
+
+            // fixed or variable-sized container (depending on DIM)
+            distance_vector_t dists;
+            // Fill it with zeros.
+            auto zero = static_cast<decltype(result.worstDist())>(0);
+            assign(dists, (DIM > 0 ? DIM : Base::dim_), zero);
+            DistanceType dist = this->computeInitialDistances(*this, vec, dists);
+            searchLevel(result, vec, Base::root_node_, dist, dists, epsError);
+            return result.full();
+        }
+
+        /**
+         * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1].
+         * Their indices and distances are stored in the provided pointers to
+         * array/vector.
+         *
+         * \sa radiusSearch, findNeighbors
+         * \return Number `N` of valid points in the result set.
+         *
+         * \note If L2 norms are used, all returned distances are actually squared
+         *       distances.
+         *
+         * \note Only the first `N` entries in `out_indices` and `out_distances`
+         *       will be valid. Return is less than `num_closest` only if the
+         *       number of elements in the tree is less than `num_closest`.
+         */
+        Size knnSearch(const ElementType* query_point, const Size num_closest, IndexType* out_indices,
+                       DistanceType* out_distances) const
+        {
+            nanoflann::KNNResultSet<DistanceType, IndexType> resultSet(num_closest);
+            resultSet.init(out_indices, out_distances);
+            findNeighbors(resultSet, query_point);
+            return resultSet.size();
+        }
+
+        /**
+         * Find all the neighbors to \a query_point[0:dim-1] within a maximum
+         * radius. The output is given as a vector of pairs, of which the first
+         * element is a point index and the second the corresponding distance.
+         * Previous contents of \a IndicesDists are cleared.
+         *
+         *  If searchParams.sorted==true, the output list is sorted by ascending
+         * distances.
+         *
+         *  For a better performance, it is advisable to do a .reserve() on the
+         * vector if you have any wild guess about the number of expected matches.
+         *
+         *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
+         * \return The number of points within the given radius (i.e. indices.size()
+         * or dists.size() )
+         *
+         * \note If L2 norms are used, search radius and all returned distances
+         *       are actually squared distances.
+         */
+        Size radiusSearch(const ElementType* query_point, const DistanceType& radius,
+                          std::vector<ResultItem<IndexType, DistanceType>>& IndicesDists,
+                          const SearchParameters& searchParams = {}) const
+        {
+            RadiusResultSet<DistanceType, IndexType> resultSet(radius, IndicesDists);
+            const Size nFound = radiusSearchCustomCallback(query_point, resultSet, searchParams);
+            if (searchParams.sorted)
+                std::sort(IndicesDists.begin(), IndicesDists.end(), IndexDist_Sorter());
+            return nFound;
+        }
+
+        /**
+         * Just like radiusSearch() but with a custom callback class for each point
+         * found in the radius of the query. See the source of RadiusResultSet<> as
+         * a start point for your own classes. \sa radiusSearch
+         */
+        template <class SEARCH_CALLBACK>
+        Size radiusSearchCustomCallback(const ElementType* query_point, SEARCH_CALLBACK& resultSet,
+                                        const SearchParameters& searchParams = {}) const
+        {
+            findNeighbors(resultSet, query_point, searchParams);
+            return resultSet.size();
+        }
+
+        /** \} */
+
+    public:
+        /** Make sure the auxiliary list \a vind has the same size than the current
+         * dataset, and re-generate if size has changed. */
+        void init_vind()
+        {
+            // Create a permutable array of indices to the input vectors.
+            Base::size_ = dataset_.kdtree_get_point_count();
+            if (Base::vAcc_.size() != Base::size_)
+                Base::vAcc_.resize(Base::size_);
+            for (Size i = 0; i < Base::size_; i++)
+                Base::vAcc_[i] = static_cast<IndexType>(i);
+        }
+
+        void computeBoundingBox(BoundingBox& bbox)
+        {
+            const auto dims = (DIM > 0 ? DIM : Base::dim_);
+            resize(bbox, dims);
+            if (dataset_.kdtree_get_bbox(bbox))
+            {
+                // Done! It was implemented in derived class
+            }
+            else
+            {
+                const Size N = dataset_.kdtree_get_point_count();
+                if (!N)
+                    throw std::runtime_error("[nanoflann] computeBoundingBox() called but "
+                                             "no data points found.");
+                for (Dimension i = 0; i < dims; ++i)
+                {
+                    bbox[i].low = bbox[i].high = this->dataset_get(*this, Base::vAcc_[0], i);
+                }
+                for (Offset k = 1; k < N; ++k)
+                {
+                    for (Dimension i = 0; i < dims; ++i)
+                    {
+                        const auto val = this->dataset_get(*this, Base::vAcc_[k], i);
+                        if (val < bbox[i].low)
+                            bbox[i].low = val;
+                        if (val > bbox[i].high)
+                            bbox[i].high = val;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Performs an exact search in the tree starting from a node.
+         * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return true if the search should be continued, false if the results are
+         * sufficient
+         */
+        template <class RESULTSET>
+        bool searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType mindist,
+                         distance_vector_t& dists, const float epsError) const
+        {
+            /* If this is a leaf node, then do check and return. */
+            if ((node->child1 == nullptr) && (node->child2 == nullptr))
+            {
+                DistanceType worst_dist = result_set.worstDist();
+                for (Offset i = node->node_type.lr.left; i < node->node_type.lr.right; ++i)
+                {
+                    const IndexType accessor = Base::vAcc_[i]; // reorder... : i;
+                    DistanceType dist        = distance_.evalMetric(vec, accessor, (DIM > 0 ? DIM : Base::dim_));
+                    if (dist < worst_dist)
+                    {
+                        if (!result_set.addPoint(dist, Base::vAcc_[i]))
+                        {
+                            // the resultset doesn't want to receive any more
+                            // points, we're done searching!
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+
+            /* Which child branch should be taken first? */
+            Dimension idx      = node->node_type.sub.divfeat;
+            ElementType val    = vec[idx];
+            DistanceType diff1 = val - node->node_type.sub.divlow;
+            DistanceType diff2 = val - node->node_type.sub.divhigh;
+
+            NodePtr bestChild;
+            NodePtr otherChild;
+            DistanceType cut_dist;
+            if ((diff1 + diff2) < 0)
+            {
+                bestChild  = node->child1;
+                otherChild = node->child2;
+                cut_dist   = distance_.accum_dist(val, node->node_type.sub.divhigh, idx);
+            }
+            else
+            {
+                bestChild  = node->child2;
+                otherChild = node->child1;
+                cut_dist   = distance_.accum_dist(val, node->node_type.sub.divlow, idx);
+            }
+
+            /* Call recursively to search next level down. */
+            if (!searchLevel(result_set, vec, bestChild, mindist, dists, epsError))
+            {
+                // the resultset doesn't want to receive any more points, we're done
+                // searching!
+                return false;
+            }
+
+            DistanceType dst = dists[idx];
+            mindist          = mindist + cut_dist - dst;
+            dists[idx]       = cut_dist;
+            if (mindist * epsError <= result_set.worstDist())
+            {
+                if (!searchLevel(result_set, vec, otherChild, mindist, dists, epsError))
+                {
+                    // the resultset doesn't want to receive any more points, we're
+                    // done searching!
+                    return false;
+                }
+            }
+            dists[idx] = dst;
+            return true;
+        }
+
+    public:
+        /**  Stores the index in a binary file.
+         *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
+         * when loading the index object it must be constructed associated to the
+         * same source of data points used while building it. See the example:
+         * examples/saveload_example.cpp \sa loadIndex  */
+        void saveIndex(std::ostream& stream) const { Base::saveIndex(*this, stream); }
+
+        /**  Loads a previous index from a binary file.
+         *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
+         * the index object must be constructed associated to the same source of
+         * data points used while building the index. See the example:
+         * examples/saveload_example.cpp \sa loadIndex  */
+        void loadIndex(std::istream& stream) { Base::loadIndex(*this, stream); }
+
+    }; // class KDTree
+
+    /** kd-tree dynamic index
+     *
+     * Contains the k-d trees and other information for indexing a set of points
+     * for nearest-neighbor matching.
+     *
+     * The class "DatasetAdaptor" must provide the following interface (can be
+     * non-virtual, inlined methods):
+     *
+     *  \code
+     *   // Must return the number of data poins
+     *   size_t kdtree_get_point_count() const { ... }
+     *
+     *   // Must return the dim'th component of the idx'th point in the class:
+     *   T kdtree_get_pt(const size_t idx, const size_t dim) const { ... }
+     *
+     *   // Optional bounding-box computation: return false to default to a standard
+     * bbox computation loop.
+     *   //   Return true if the BBOX was already computed by the class and returned
+     * in "bb" so it can be avoided to redo it again.
+     *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3
+     * for point clouds) template <class BBOX> bool kdtree_get_bbox(BBOX &bb) const
+     *   {
+     *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
+     *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
+     *      ...
+     *      return true;
+     *   }
+     *
+     *  \endcode
+     *
+     * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+     * \tparam Distance The distance metric to use: nanoflann::metric_L1,
+     * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+     * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+     * \tparam IndexType Type of the arguments with which the data can be
+     * accessed (e.g. float, double, int64_t, T*)
+     */
+    template <typename Distance, class DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+    class KDTreeSingleIndexDynamicAdaptor_
+        : public KDTreeBaseClass<KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM, IndexType>, Distance,
+                                 DatasetAdaptor, DIM, IndexType>
     {
-        if (row_major)
-            return m_data_matrix.get().coeff(idx, IndexType(dim));
-        else
-            return m_data_matrix.get().coeff(IndexType(dim), idx);
-    }
+    public:
+        /**
+         * The dataset used by this index
+         */
+        const DatasetAdaptor& dataset_; //!< The source of our data
 
-    // Optional bounding-box computation: return false to default to a standard
-    // bbox computation loop.
-    //   Return true if the BBOX was already computed by the class and returned
-    //   in "bb" so it can be avoided to redo it again. Look at bb.size() to
-    //   find out the expected dimensionality (e.g. 2 or 3 for point clouds)
-    template <class BBOX>
-    bool kdtree_get_bbox(BBOX& /*bb*/) const
+        KDTreeSingleIndexAdaptorParams index_params_;
+
+        std::vector<int>& treeIndex_;
+
+        Distance distance_;
+
+        using Base = typename nanoflann::KDTreeBaseClass<
+            nanoflann::KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM, IndexType>, Distance,
+            DatasetAdaptor, DIM, IndexType>;
+
+        using ElementType  = typename Base::ElementType;
+        using DistanceType = typename Base::DistanceType;
+
+        using Offset    = typename Base::Offset;
+        using Size      = typename Base::Size;
+        using Dimension = typename Base::Dimension;
+
+        using Node    = typename Base::Node;
+        using NodePtr = Node*;
+
+        using Interval = typename Base::Interval;
+        /** Define "BoundingBox" as a fixed-size or variable-size container
+         * depending on "DIM" */
+        using BoundingBox = typename Base::BoundingBox;
+
+        /** Define "distance_vector_t" as a fixed-size or variable-size container
+         * depending on "DIM" */
+        using distance_vector_t = typename Base::distance_vector_t;
+
+        /**
+         * KDTree constructor
+         *
+         * Refer to docs in README.md or online in
+         * https://github.com/jlblancoc/nanoflann
+         *
+         * The KD-Tree point dimension (the length of each point in the datase, e.g.
+         * 3 for 3D points) is determined by means of:
+         *  - The \a DIM template parameter if >0 (highest priority)
+         *  - Otherwise, the \a dimensionality parameter of this constructor.
+         *
+         * \param inputData Dataset with the input features. Its lifetime must be
+         *  equal or longer than that of the instance of this class.
+         * \param params Basically, the maximum leaf node size
+         */
+        KDTreeSingleIndexDynamicAdaptor_(
+            const Dimension dimensionality, const DatasetAdaptor& inputData, std::vector<int>& treeIndex,
+            const KDTreeSingleIndexAdaptorParams& params = KDTreeSingleIndexAdaptorParams())
+            : dataset_(inputData), index_params_(params), treeIndex_(treeIndex), distance_(inputData)
+        {
+            Base::size_                = 0;
+            Base::size_at_index_build_ = 0;
+            for (auto& v : Base::root_bbox_)
+                v = {};
+            Base::dim_ = dimensionality;
+            if (DIM > 0)
+                Base::dim_ = DIM;
+            Base::leaf_max_size_ = params.leaf_max_size;
+            if (params.n_thread_build > 0)
+            {
+                Base::n_thread_build_ = params.n_thread_build;
+            }
+            else
+            {
+                Base::n_thread_build_ = std::max(std::thread::hardware_concurrency(), 1u);
+            }
+        }
+
+        /** Explicitly default the copy constructor */
+        KDTreeSingleIndexDynamicAdaptor_(const KDTreeSingleIndexDynamicAdaptor_& rhs) = default;
+
+        /** Assignment operator definiton */
+        KDTreeSingleIndexDynamicAdaptor_ operator=(const KDTreeSingleIndexDynamicAdaptor_& rhs)
+        {
+            KDTreeSingleIndexDynamicAdaptor_ tmp(rhs);
+            std::swap(Base::vAcc_, tmp.Base::vAcc_);
+            std::swap(Base::leaf_max_size_, tmp.Base::leaf_max_size_);
+            std::swap(index_params_, tmp.index_params_);
+            std::swap(treeIndex_, tmp.treeIndex_);
+            std::swap(Base::size_, tmp.Base::size_);
+            std::swap(Base::size_at_index_build_, tmp.Base::size_at_index_build_);
+            std::swap(Base::root_node_, tmp.Base::root_node_);
+            std::swap(Base::root_bbox_, tmp.Base::root_bbox_);
+            std::swap(Base::pool_, tmp.Base::pool_);
+            return *this;
+        }
+
+        /**
+         * Builds the index
+         */
+        void buildIndex()
+        {
+            Base::size_ = Base::vAcc_.size();
+            this->freeIndex(*this);
+            Base::size_at_index_build_ = Base::size_;
+            if (Base::size_ == 0)
+                return;
+            computeBoundingBox(Base::root_bbox_);
+            // construct the tree
+            if (Base::n_thread_build_ == 1)
+            {
+                Base::root_node_ = this->divideTree(*this, 0, Base::size_, Base::root_bbox_);
+            }
+            else
+            {
+                std::atomic<unsigned int> thread_count(0u);
+                std::mutex mutex;
+                Base::root_node_ =
+                    this->divideTreeConcurrent(*this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
+            }
+        }
+
+        /** \name Query methods
+         * \{ */
+
+        /**
+         * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
+         * inside the result object.
+         * This is the core search function, all others are wrappers around this
+         * one.
+         *
+         * \param result The result object in which the indices of the
+         *               nearest-neighbors are stored.
+         * \param vec    The vector of the query point for which to search the
+         *               nearest neighbors.
+         * \param searchParams Optional parameters for the search.
+         *
+         * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return True if the requested neighbors could be found.
+         *
+         * \sa knnSearch(), radiusSearch(), radiusSearchCustomCallback()
+         *
+         * \note If L2 norms are used, all returned distances are actually squared
+         *       distances.
+         */
+        template <typename RESULTSET>
+        bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParameters& searchParams = {}) const
+        {
+            assert(vec);
+            if (this->size(*this) == 0)
+                return false;
+            if (!Base::root_node_)
+                return false;
+            float epsError = 1 + searchParams.eps;
+
+            // fixed or variable-sized container (depending on DIM)
+            distance_vector_t dists;
+            // Fill it with zeros.
+            assign(dists, (DIM > 0 ? DIM : Base::dim_), static_cast<typename distance_vector_t::value_type>(0));
+            DistanceType dist = this->computeInitialDistances(*this, vec, dists);
+            searchLevel(result, vec, Base::root_node_, dist, dists, epsError);
+            return result.full();
+        }
+
+        /**
+         * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1].
+         * Their indices are stored inside the result object. \sa radiusSearch,
+         * findNeighbors
+         * \return Number `N` of valid points in
+         * the result set.
+         *
+         * \note If L2 norms are used, all returned distances are actually squared
+         *       distances.
+         *
+         * \note Only the first `N` entries in `out_indices` and `out_distances`
+         *       will be valid. Return may be less than `num_closest` only if the
+         *       number of elements in the tree is less than `num_closest`.
+         */
+        Size knnSearch(const ElementType* query_point, const Size num_closest, IndexType* out_indices,
+                       DistanceType* out_distances) const
+        {
+            nanoflann::KNNResultSet<DistanceType, IndexType> resultSet(num_closest);
+            resultSet.init(out_indices, out_distances);
+            findNeighbors(resultSet, query_point);
+            return resultSet.size();
+        }
+
+        /**
+         * Find all the neighbors to \a query_point[0:dim-1] within a maximum
+         * radius. The output is given as a vector of pairs, of which the first
+         * element is a point index and the second the corresponding distance.
+         * Previous contents of \a IndicesDists are cleared.
+         *
+         * If searchParams.sorted==true, the output list is sorted by ascending
+         * distances.
+         *
+         * For a better performance, it is advisable to do a .reserve() on the
+         * vector if you have any wild guess about the number of expected matches.
+         *
+         *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
+         * \return The number of points within the given radius (i.e. indices.size()
+         * or dists.size() )
+         *
+         * \note If L2 norms are used, search radius and all returned distances
+         *       are actually squared distances.
+         */
+        Size radiusSearch(const ElementType* query_point, const DistanceType& radius,
+                          std::vector<ResultItem<IndexType, DistanceType>>& IndicesDists,
+                          const SearchParameters& searchParams = {}) const
+        {
+            RadiusResultSet<DistanceType, IndexType> resultSet(radius, IndicesDists);
+            const size_t nFound = radiusSearchCustomCallback(query_point, resultSet, searchParams);
+            if (searchParams.sorted)
+                std::sort(IndicesDists.begin(), IndicesDists.end(), IndexDist_Sorter());
+            return nFound;
+        }
+
+        /**
+         * Just like radiusSearch() but with a custom callback class for each point
+         * found in the radius of the query. See the source of RadiusResultSet<> as
+         * a start point for your own classes. \sa radiusSearch
+         */
+        template <class SEARCH_CALLBACK>
+        Size radiusSearchCustomCallback(const ElementType* query_point, SEARCH_CALLBACK& resultSet,
+                                        const SearchParameters& searchParams = {}) const
+        {
+            findNeighbors(resultSet, query_point, searchParams);
+            return resultSet.size();
+        }
+
+        /** \} */
+
+    public:
+        void computeBoundingBox(BoundingBox& bbox)
+        {
+            const auto dims = (DIM > 0 ? DIM : Base::dim_);
+            resize(bbox, dims);
+
+            if (dataset_.kdtree_get_bbox(bbox))
+            {
+                // Done! It was implemented in derived class
+            }
+            else
+            {
+                const Size N = Base::size_;
+                if (!N)
+                    throw std::runtime_error("[nanoflann] computeBoundingBox() called but "
+                                             "no data points found.");
+                for (Dimension i = 0; i < dims; ++i)
+                {
+                    bbox[i].low = bbox[i].high = this->dataset_get(*this, Base::vAcc_[0], i);
+                }
+                for (Offset k = 1; k < N; ++k)
+                {
+                    for (Dimension i = 0; i < dims; ++i)
+                    {
+                        const auto val = this->dataset_get(*this, Base::vAcc_[k], i);
+                        if (val < bbox[i].low)
+                            bbox[i].low = val;
+                        if (val > bbox[i].high)
+                            bbox[i].high = val;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Performs an exact search in the tree starting from a node.
+         * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         */
+        template <class RESULTSET>
+        void searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType mindist,
+                         distance_vector_t& dists, const float epsError) const
+        {
+            /* If this is a leaf node, then do check and return. */
+            if ((node->child1 == nullptr) && (node->child2 == nullptr))
+            {
+                DistanceType worst_dist = result_set.worstDist();
+                for (Offset i = node->node_type.lr.left; i < node->node_type.lr.right; ++i)
+                {
+                    const IndexType index = Base::vAcc_[i]; // reorder... : i;
+                    if (treeIndex_[index] == -1)
+                        continue;
+                    DistanceType dist = distance_.evalMetric(vec, index, (DIM > 0 ? DIM : Base::dim_));
+                    if (dist < worst_dist)
+                    {
+                        if (!result_set.addPoint(static_cast<typename RESULTSET::DistanceType>(dist),
+                                                 static_cast<typename RESULTSET::IndexType>(Base::vAcc_[i])))
+                        {
+                            // the resultset doesn't want to receive any more
+                            // points, we're done searching!
+                            return; // false;
+                        }
+                    }
+                }
+                return;
+            }
+
+            /* Which child branch should be taken first? */
+            Dimension idx      = node->node_type.sub.divfeat;
+            ElementType val    = vec[idx];
+            DistanceType diff1 = val - node->node_type.sub.divlow;
+            DistanceType diff2 = val - node->node_type.sub.divhigh;
+
+            NodePtr bestChild;
+            NodePtr otherChild;
+            DistanceType cut_dist;
+            if ((diff1 + diff2) < 0)
+            {
+                bestChild  = node->child1;
+                otherChild = node->child2;
+                cut_dist   = distance_.accum_dist(val, node->node_type.sub.divhigh, idx);
+            }
+            else
+            {
+                bestChild  = node->child2;
+                otherChild = node->child1;
+                cut_dist   = distance_.accum_dist(val, node->node_type.sub.divlow, idx);
+            }
+
+            /* Call recursively to search next level down. */
+            searchLevel(result_set, vec, bestChild, mindist, dists, epsError);
+
+            DistanceType dst = dists[idx];
+            mindist          = mindist + cut_dist - dst;
+            dists[idx]       = cut_dist;
+            if (mindist * epsError <= result_set.worstDist())
+            {
+                searchLevel(result_set, vec, otherChild, mindist, dists, epsError);
+            }
+            dists[idx] = dst;
+        }
+
+    public:
+        /**  Stores the index in a binary file.
+         *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
+         * when loading the index object it must be constructed associated to the
+         * same source of data points used while building it. See the example:
+         * examples/saveload_example.cpp \sa loadIndex  */
+        void saveIndex(std::ostream& stream) { saveIndex(*this, stream); }
+
+        /**  Loads a previous index from a binary file.
+         *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
+         * the index object must be constructed associated to the same source of
+         * data points used while building the index. See the example:
+         * examples/saveload_example.cpp \sa loadIndex  */
+        void loadIndex(std::istream& stream) { loadIndex(*this, stream); }
+    };
+
+    /** kd-tree dynaimic index
+     *
+     * class to create multiple static index and merge their results to behave as
+     * single dynamic index as proposed in Logarithmic Approach.
+     *
+     *  Example of usage:
+     *  examples/dynamic_pointcloud_example.cpp
+     *
+     * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+     * \tparam Distance The distance metric to use: nanoflann::metric_L1,
+     * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc. \tparam DIM
+     * Dimensionality of data points (e.g. 3 for 3D points) \tparam IndexType
+     * Will be typically size_t or int
+     */
+    template <typename Distance, class DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+    class KDTreeSingleIndexDynamicAdaptor
     {
-        return false;
-    }
+    public:
+        using ElementType  = typename Distance::ElementType;
+        using DistanceType = typename Distance::DistanceType;
 
+        using Offset    = typename KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM>::Offset;
+        using Size      = typename KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM>::Size;
+        using Dimension = typename KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM>::Dimension;
+
+    protected:
+        Size leaf_max_size_;
+        Size treeCount_;
+        Size pointCount_;
+
+        /**
+         * The dataset used by this index
+         */
+        const DatasetAdaptor& dataset_; //!< The source of our data
+
+        /** treeIndex[idx] is the index of tree in which point at idx is stored.
+         * treeIndex[idx]=-1 means that point has been removed. */
+        std::vector<int> treeIndex_;
+        std::unordered_set<int> removedPoints_;
+
+        KDTreeSingleIndexAdaptorParams index_params_;
+
+        Dimension dim_; //!< Dimensionality of each data point
+
+        using index_container_t = KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM, IndexType>;
+        std::vector<index_container_t> index_;
+
+    public:
+        /** Get a const ref to the internal list of indices; the number of indices
+         * is adapted dynamically as the dataset grows in size. */
+        const std::vector<index_container_t>& getAllIndices() const { return index_; }
+
+    private:
+        /** finds position of least significant unset bit */
+        int First0Bit(IndexType num)
+        {
+            int pos = 0;
+            while (num & 1)
+            {
+                num = num >> 1;
+                pos++;
+            }
+            return pos;
+        }
+
+        /** Creates multiple empty trees to handle dynamic support */
+        void init()
+        {
+            using my_kd_tree_t = KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM, IndexType>;
+            std::vector<my_kd_tree_t> index(treeCount_,
+                                            my_kd_tree_t(dim_ /*dim*/, dataset_, treeIndex_, index_params_));
+            index_ = index;
+        }
+
+    public:
+        Distance distance_;
+
+        /**
+         * KDTree constructor
+         *
+         * Refer to docs in README.md or online in
+         * https://github.com/jlblancoc/nanoflann
+         *
+         * The KD-Tree point dimension (the length of each point in the datase, e.g.
+         * 3 for 3D points) is determined by means of:
+         *  - The \a DIM template parameter if >0 (highest priority)
+         *  - Otherwise, the \a dimensionality parameter of this constructor.
+         *
+         * \param inputData Dataset with the input features. Its lifetime must be
+         *  equal or longer than that of the instance of this class.
+         * \param params Basically, the maximum leaf node size
+         */
+        explicit KDTreeSingleIndexDynamicAdaptor(
+            const int dimensionality, const DatasetAdaptor& inputData,
+            const KDTreeSingleIndexAdaptorParams& params = KDTreeSingleIndexAdaptorParams(),
+            const size_t maximumPointCount               = 1000000000U)
+            : dataset_(inputData), index_params_(params), distance_(inputData)
+        {
+            treeCount_  = static_cast<size_t>(std::log2(maximumPointCount)) + 1;
+            pointCount_ = 0U;
+            dim_        = dimensionality;
+            treeIndex_.clear();
+            if (DIM > 0)
+                dim_ = DIM;
+            leaf_max_size_ = params.leaf_max_size;
+            init();
+            const size_t num_initial_points = dataset_.kdtree_get_point_count();
+            if (num_initial_points > 0)
+            {
+                addPoints(0, num_initial_points - 1);
+            }
+        }
+
+        /** Deleted copy constructor*/
+        explicit KDTreeSingleIndexDynamicAdaptor(
+            const KDTreeSingleIndexDynamicAdaptor<Distance, DatasetAdaptor, DIM, IndexType>&) = delete;
+
+        /** Add points to the set, Inserts all points from [start, end] */
+        void addPoints(IndexType start, IndexType end)
+        {
+            const Size count = end - start + 1;
+            int maxIndex     = 0;
+            treeIndex_.resize(treeIndex_.size() + count);
+            for (IndexType idx = start; idx <= end; idx++)
+            {
+                const int pos           = First0Bit(pointCount_);
+                maxIndex                = std::max(pos, maxIndex);
+                treeIndex_[pointCount_] = pos;
+
+                const auto it = removedPoints_.find(idx);
+                if (it != removedPoints_.end())
+                {
+                    removedPoints_.erase(it);
+                    treeIndex_[idx] = pos;
+                }
+
+                for (int i = 0; i < pos; i++)
+                {
+                    for (int j = 0; j < static_cast<int>(index_[i].vAcc_.size()); j++)
+                    {
+                        index_[pos].vAcc_.push_back(index_[i].vAcc_[j]);
+                        if (treeIndex_[index_[i].vAcc_[j]] != -1)
+                            treeIndex_[index_[i].vAcc_[j]] = pos;
+                    }
+                    index_[i].vAcc_.clear();
+                }
+                index_[pos].vAcc_.push_back(idx);
+                pointCount_++;
+            }
+
+            for (int i = 0; i <= maxIndex; ++i)
+            {
+                index_[i].freeIndex(index_[i]);
+                if (!index_[i].vAcc_.empty())
+                    index_[i].buildIndex();
+            }
+        }
+
+        /** Remove a point from the set (Lazy Deletion) */
+        void removePoint(size_t idx)
+        {
+            if (idx >= pointCount_)
+                return;
+            removedPoints_.insert(idx);
+            treeIndex_[idx] = -1;
+        }
+
+        /**
+         * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
+         * inside the result object.
+         *
+         * Params:
+         *     result = the result object in which the indices of the
+         * nearest-neighbors are stored vec = the vector for which to search the
+         * nearest neighbors
+         *
+         * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return  True if the requested neighbors could be found.
+         * \sa knnSearch, radiusSearch
+         *
+         * \note If L2 norms are used, all returned distances are actually squared
+         *       distances.
+         */
+        template <typename RESULTSET>
+        bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParameters& searchParams = {}) const
+        {
+            for (size_t i = 0; i < treeCount_; i++)
+            {
+                index_[i].findNeighbors(result, &vec[0], searchParams);
+            }
+            return result.full();
+        }
+    };
+
+    /** An L2-metric KD-tree adaptor for working with data directly stored in an
+     * Eigen Matrix, without duplicating the data storage. You can select whether a
+     * row or column in the matrix represents a point in the state space.
+     *
+     * Example of usage:
+     * \code
+     * Eigen::Matrix<num_t,Eigen::Dynamic,Eigen::Dynamic>  mat;
+     *
+     * // Fill out "mat"...
+     * using my_kd_tree_t = nanoflann::KDTreeEigenMatrixAdaptor<
+     *   Eigen::Matrix<num_t,Dynamic,Dynamic>>;
+     *
+     * const int max_leaf = 10;
+     * my_kd_tree_t mat_index(mat, max_leaf);
+     * mat_index.index->...
+     * \endcode
+     *
+     *  \tparam DIM If set to >0, it specifies a compile-time fixed dimensionality
+     * for the points in the data set, allowing more compiler optimizations.
+     * \tparam Distance The distance metric to use: nanoflann::metric_L1,
+     * nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+     * \tparam row_major If set to true the rows of the matrix are used as the
+     *         points, if set to false  the columns of the matrix are used as the
+     *         points.
+     */
+    template <class MatrixType, int32_t DIM = -1, class Distance = nanoflann::metric_L2, bool row_major = true>
+    struct KDTreeEigenMatrixAdaptor
+    {
+        using self_t    = KDTreeEigenMatrixAdaptor<MatrixType, DIM, Distance, row_major>;
+        using num_t     = typename MatrixType::Scalar;
+        using IndexType = typename MatrixType::Index;
+        using metric_t  = typename Distance::template traits<num_t, self_t, IndexType>::distance_t;
+
+        using index_t = KDTreeSingleIndexAdaptor<
+            metric_t, self_t, row_major ? MatrixType::ColsAtCompileTime : MatrixType::RowsAtCompileTime, IndexType>;
+
+        index_t* index_; //! The kd-tree index for the user to call its methods as
+                         //! usual with any other FLANN index.
+
+        using Offset    = typename index_t::Offset;
+        using Size      = typename index_t::Size;
+        using Dimension = typename index_t::Dimension;
+
+        /// Constructor: takes a const ref to the matrix object with the data points
+        explicit KDTreeEigenMatrixAdaptor(const Dimension dimensionality,
+                                          const std::reference_wrapper<const MatrixType>& mat,
+                                          const int leaf_max_size = 10)
+            : m_data_matrix(mat)
+        {
+            const auto dims = row_major ? mat.get().cols() : mat.get().rows();
+            if (static_cast<Dimension>(dims) != dimensionality)
+                throw std::runtime_error("Error: 'dimensionality' must match column count in data "
+                                         "matrix");
+            if (DIM > 0 && static_cast<int32_t>(dims) != DIM)
+                throw std::runtime_error("Data set dimensionality does not match the 'DIM' template "
+                                         "argument");
+            index_ = new index_t(dims, *this /* adaptor */, nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size));
+        }
+
+    public:
+        /** Deleted copy constructor */
+        KDTreeEigenMatrixAdaptor(const self_t&) = delete;
+
+        ~KDTreeEigenMatrixAdaptor() { delete index_; }
+
+        const std::reference_wrapper<const MatrixType> m_data_matrix;
+
+        /** Query for the \a num_closest closest points to a given point (entered as
+         * query_point[0:dim-1]). Note that this is a short-cut method for
+         * index->findNeighbors(). The user can also call index->... methods as
+         * desired.
+         *
+         * \note If L2 norms are used, all returned distances are actually squared
+         *       distances.
+         */
+        void query(const num_t* query_point, const Size num_closest, IndexType* out_indices, num_t* out_distances) const
+        {
+            nanoflann::KNNResultSet<num_t, IndexType> resultSet(num_closest);
+            resultSet.init(out_indices, out_distances);
+            index_->findNeighbors(resultSet, query_point);
+        }
+
+        /** \name Interface expected by KDTreeSingleIndexAdaptor
+         * \{ */
+
+        const self_t& derived() const { return *this; }
+        self_t& derived() { return *this; }
+
+        // Must return the number of data points
+        Size kdtree_get_point_count() const
+        {
+            if (row_major)
+                return m_data_matrix.get().rows();
+            else
+                return m_data_matrix.get().cols();
+        }
+
+        // Returns the dim'th component of the idx'th point in the class:
+        num_t kdtree_get_pt(const IndexType idx, size_t dim) const
+        {
+            if (row_major)
+                return m_data_matrix.get().coeff(idx, IndexType(dim));
+            else
+                return m_data_matrix.get().coeff(IndexType(dim), idx);
+        }
+
+        // Optional bounding-box computation: return false to default to a standard
+        // bbox computation loop.
+        //   Return true if the BBOX was already computed by the class and returned
+        //   in "bb" so it can be avoided to redo it again. Look at bb.size() to
+        //   find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+        template <class BBOX>
+        bool kdtree_get_bbox(BBOX& /*bb*/) const
+        {
+            return false;
+        }
+
+        /** \} */
+
+    }; // end of KDTreeEigenMatrixAdaptor
     /** \} */
 
-};  // end of KDTreeEigenMatrixAdaptor
-/** \} */
-
-/** \} */  // end of grouping
-}  // namespace nanoflann
+    /** \} */ // end of grouping
+} // namespace nanoflann

--- a/examples/cpp/nanoflann/nanoflann.hpp
+++ b/examples/cpp/nanoflann/nanoflann.hpp
@@ -79,7 +79,7 @@
 namespace nanoflann
 {
 /** @addtogroup nanoflann_grp nanoflann C++ library for KD-trees
- *  @{ */
+ *  \{ */
 
 /** the PI constant (required to avoid MSVC missing symbols) */
 template <typename T>
@@ -157,7 +157,7 @@ inline typename std::enable_if<!has_assign<Container>::value, void>::type
 }
 
 /** @addtogroup result_sets_grp Result set classes
- *  @{ */
+ *  \{ */
 template <
     typename _DistanceType, typename _IndexType = size_t,
     typename _CountType = size_t>
@@ -195,7 +195,7 @@ class KNNResultSet
 
     /**
      * Called during search to add an element matching the criteria.
-     * @return true if the search should be continued, false if the results are
+     * \return true if the search should be continued, false if the results are
      * sufficient
      */
     bool addPoint(DistanceType dist, IndexType index)
@@ -301,7 +301,7 @@ class RadiusResultSet
 
     /**
      * Called during search to add an element matching the criteria.
-     * @return true if the search should be continued, false if the results are
+     * \return true if the search should be continued, false if the results are
      * sufficient
      */
     bool addPoint(DistanceType dist, IndexType index)
@@ -328,10 +328,10 @@ class RadiusResultSet
     }
 };
 
-/** @} */
+/** \} */
 
 /** @addtogroup loadsave_grp Load/save auxiliary functions
- * @{ */
+ * \{ */
 template <typename T>
 void save_value(std::ostream& stream, const T& value)
 {
@@ -360,10 +360,10 @@ void load_value(std::istream& stream, std::vector<T>& value)
     value.resize(size);
     stream.read(reinterpret_cast<char*>(value.data()), sizeof(T) * size);
 }
-/** @} */
+/** \} */
 
 /** @addtogroup metric_grp Metric (distance) classes
- * @{ */
+ * \{ */
 
 struct Metric
 {
@@ -671,10 +671,10 @@ struct metric_SO3 : public Metric
     };
 };
 
-/** @} */
+/** \} */
 
 /** @addtogroup param_grp Parameter structs
- * @{ */
+ * \{ */
 
 enum class KDTreeSingleIndexAdaptorFlags
 {
@@ -721,10 +721,10 @@ struct SearchParameters
     bool  sorted;  //!< only for radius search, require neighbours sorted by
                   //!< distance (default: true)
 };
-/** @} */
+/** \} */
 
 /** @addtogroup memalloc_grp Memory allocation
- * @{ */
+ * \{ */
 
 /**
  * Pooled storage allocator
@@ -861,10 +861,10 @@ class PooledAllocator
         return mem;
     }
 };
-/** @} */
+/** \} */
 
 /** @addtogroup nanoflann_metaprog_grp Auxiliary metaprogramming stuff
- * @{ */
+ * \{ */
 
 /** Used to declare fixed-size arrays when DIM>0, dynamically-allocated vectors
  * when DIM=-1. Fixed size version for a generic DIM:
@@ -881,7 +881,7 @@ struct array_or_vector<-1, T>
     using type = std::vector<T>;
 };
 
-/** @} */
+/** \} */
 
 /** kd-tree base-class
  *
@@ -1031,8 +1031,8 @@ class KDTreeBaseClass
      * Create a tree node that subdivides the list of vecs from vind[first]
      * to vind[last].  The routine is called recursively on each sublist.
      *
-     * @param left index of the first vector
-     * @param right index of the last vector
+     * \param left index of the first vector
+     * \param right index of the last vector
      */
     NodePtr divideTree(
         Derived& obj, const Offset left, const Offset right, BoundingBox& bbox)
@@ -1098,10 +1098,10 @@ class KDTreeBaseClass
      * vind[last] concurrently.  The routine is called recursively on each
      * sublist.
      *
-     * @param left index of the first vector
-     * @param right index of the last vector
-     * @param thread_count count of std::async threads
-     * @param mutex mutex for mempool allocation
+     * \param left index of the first vector
+     * \param right index of the last vector
+     * \param thread_count count of std::async threads
+     * \param mutex mutex for mempool allocation
      */
     NodePtr divideTreeConcurrent(
         Derived& obj, const Offset left, const Offset right, BoundingBox& bbox,
@@ -1382,7 +1382,7 @@ class KDTreeBaseClass
 };
 
 /** @addtogroup kdtrees_grp KD-tree classes and adaptors
- * @{ */
+ * \{ */
 
 /** kd-tree static index
  *
@@ -1479,9 +1479,9 @@ class KDTreeSingleIndexAdaptor
      *  - The \a DIM template parameter if >0 (highest priority)
      *  - Otherwise, the \a dimensionality parameter of this constructor.
      *
-     * @param inputData Dataset with the input features. Its lifetime must be
+     * \param inputData Dataset with the input features. Its lifetime must be
      *  equal or longer than that of the instance of this class.
-     * @param params Basically, the maximum leaf node size
+     * \param params Basically, the maximum leaf node size
      *
      * Note that there is a variable number of optional additional parameters
      * which will be forwarded to the metric class constructor. Refer to example
@@ -1564,7 +1564,7 @@ class KDTreeSingleIndexAdaptor
     }
 
     /** \name Query methods
-     * @{ */
+     * \{ */
 
     /**
      * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
@@ -1678,7 +1678,7 @@ class KDTreeSingleIndexAdaptor
         return resultSet.size();
     }
 
-    /** @} */
+    /** \} */
 
    public:
     /** Make sure the auxiliary list \a vind has the same size than the current
@@ -1923,9 +1923,9 @@ class KDTreeSingleIndexDynamicAdaptor_
      *  - The \a DIM template parameter if >0 (highest priority)
      *  - Otherwise, the \a dimensionality parameter of this constructor.
      *
-     * @param inputData Dataset with the input features. Its lifetime must be
+     * \param inputData Dataset with the input features. Its lifetime must be
      *  equal or longer than that of the instance of this class.
-     * @param params Basically, the maximum leaf node size
+     * \param params Basically, the maximum leaf node size
      */
     KDTreeSingleIndexDynamicAdaptor_(
         const Dimension dimensionality, const DatasetAdaptor& inputData,
@@ -2001,7 +2001,7 @@ class KDTreeSingleIndexDynamicAdaptor_
     }
 
     /** \name Query methods
-     * @{ */
+     * \{ */
 
     /**
      * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored
@@ -2116,7 +2116,7 @@ class KDTreeSingleIndexDynamicAdaptor_
         return resultSet.size();
     }
 
-    /** @} */
+    /** \} */
 
    public:
     void computeBoundingBox(BoundingBox& bbox)
@@ -2343,9 +2343,9 @@ class KDTreeSingleIndexDynamicAdaptor
      *  - The \a DIM template parameter if >0 (highest priority)
      *  - Otherwise, the \a dimensionality parameter of this constructor.
      *
-     * @param inputData Dataset with the input features. Its lifetime must be
+     * \param inputData Dataset with the input features. Its lifetime must be
      *  equal or longer than that of the instance of this class.
-     * @param params Basically, the maximum leaf node size
+     * \param params Basically, the maximum leaf node size
      */
     explicit KDTreeSingleIndexDynamicAdaptor(
         const int dimensionality, const DatasetAdaptor& inputData,
@@ -2542,8 +2542,8 @@ struct KDTreeEigenMatrixAdaptor
         index_->findNeighbors(resultSet, query_point);
     }
 
-    /** @name Interface expected by KDTreeSingleIndexAdaptor
-     * @{ */
+    /** \name Interface expected by KDTreeSingleIndexAdaptor
+     * \{ */
 
     const self_t& derived() const { return *this; }
     self_t&       derived() { return *this; }
@@ -2577,10 +2577,10 @@ struct KDTreeEigenMatrixAdaptor
         return false;
     }
 
-    /** @} */
+    /** \} */
 
 };  // end of KDTreeEigenMatrixAdaptor
-/** @} */
+/** \} */
 
-/** @} */  // end of grouping
+/** \} */  // end of grouping
 }  // namespace nanoflann

--- a/examples/cpp/nanoflann/ponca_nanoflann.cpp
+++ b/examples/cpp/nanoflann/ponca_nanoflann.cpp
@@ -17,27 +17,28 @@
 #include <Ponca/Fitting>
 #include <Ponca/SpatialPartitioning>
 
-
 using namespace Ponca;
-
 
 // This class defines the input data format
 class MyPoint
 {
 public:
-    enum {Dim = 3};
+    enum
+    {
+        Dim = 3
+    };
     typedef double Scalar;
-    typedef Eigen::Matrix<Scalar, Dim, 1>   VectorType;
+    typedef Eigen::Matrix<Scalar, Dim, 1> VectorType;
     typedef Eigen::Matrix<Scalar, Dim, Dim> MatrixType;
 
-    PONCA_MULTIARCH inline MyPoint(const VectorType& _pos    = VectorType::Zero()) : m_pos(_pos) {}
-    PONCA_MULTIARCH inline const VectorType& pos()    const { return m_pos; }
-    PONCA_MULTIARCH inline VectorType& pos()    { return m_pos; }
+    PONCA_MULTIARCH inline MyPoint(const VectorType& _pos = VectorType::Zero()) : m_pos(_pos) {}
+    PONCA_MULTIARCH inline const VectorType& pos() const { return m_pos; }
+    PONCA_MULTIARCH inline VectorType& pos() { return m_pos; }
 
     // Generate points on a sphere of radius 1
     static inline MyPoint Random()
     {
-        return { VectorType::Random().normalized() * Eigen::internal::random<Scalar>(0.9,1.1) };
+        return {VectorType::Random().normalized() * Eigen::internal::random<Scalar>(0.9, 1.1)};
     }
 
 private:
@@ -48,15 +49,14 @@ typedef MyPoint::Scalar Scalar;
 typedef MyPoint::VectorType VectorType;
 
 //! [Define Fit Type]
-using NeighborFilter =  DistWeightFunc<MyPoint,Ponca::SmoothWeightKernel<Scalar> > ;
-using FitType    = Basket<MyPoint,NeighborFilter, Ponca::DryFit>; // build a fitting object that does nothing
+using NeighborFilter = DistWeightFunc<MyPoint, Ponca::SmoothWeightKernel<Scalar>>;
+using FitType        = Basket<MyPoint, NeighborFilter, Ponca::DryFit>; // build a fitting object that does nothing
 //! [Define Fit Type]
-
 
 ///// Nanoflann stuff
 struct NFPointCloud
 {
-    using coord_t = typename MyPoint::Scalar;  //!< The type of each coordinate
+    using coord_t = typename MyPoint::Scalar; //!< The type of each coordinate
 
     const std::vector<MyPoint>& pts;
 
@@ -90,71 +90,74 @@ struct NFPointCloud
         return false;
     }
 };
-using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<
-        nanoflann::L2_Simple_Adaptor< Scalar, NFPointCloud>, NFPointCloud, 3>;
+using my_kd_tree_t =
+    nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<Scalar, NFPointCloud>, NFPointCloud, 3>;
 ///// Enf of nanoflann stuff
 
 int test_raw(FitType& f, const std::vector<MyPoint>& _vecs)
 {
-    if(! (f.compute( _vecs ) == STABLE) )
+    if (!(f.compute(_vecs) == STABLE))
         std::cerr << "[raw] Something weird happened" << std::endl;
     return f.getNumNeighbors();
 }
 
-int test_ponca_kdtree(FitType& f, const std::vector<MyPoint>& _vecs, VectorType _p, const KdTree<MyPoint>& tree, Scalar tmax){
-    if(! (
+int test_ponca_kdtree(FitType& f, const std::vector<MyPoint>& _vecs, VectorType _p, const KdTree<MyPoint>& tree,
+                      Scalar tmax)
+{
+    if (!(
             //! [Use Ponca KdTree]
-f.computeWithIds( tree.rangeNeighbors(_p, tmax), _vecs )
+            f.computeWithIds(tree.rangeNeighbors(_p, tmax), _vecs)
             //! [Use Ponca KdTree]
-            == STABLE) )
+            == STABLE))
         std::cerr << "[ponca_kdtree] Something weird happened" << std::endl;
     return f.getNumNeighbors();
 }
 
-int test_nanflann_kdtree(FitType& f, const std::vector<MyPoint>& _vecs, VectorType _p, const my_kd_tree_t& tree, Scalar tmax)
+int test_nanflann_kdtree(FitType& f, const std::vector<MyPoint>& _vecs, VectorType _p, const my_kd_tree_t& tree,
+                         Scalar tmax)
 {
     // radius search:
-    const Scalar                                       squaredRadius = 1;
+    const Scalar squaredRadius = 1;
     std::vector<nanoflann::ResultItem<size_t, Scalar>> indices_dists;
-    nanoflann::RadiusResultSet<Scalar, size_t>         resultSet(
-            tmax*tmax, indices_dists);
+    nanoflann::RadiusResultSet<Scalar, size_t> resultSet(tmax * tmax, indices_dists);
 
     tree.findNeighbors(resultSet, _p.data());
 
     //! [Use NanoFlann KdTree]
-f.init();
-// Compute
-auto res = Ponca::UNDEFINED;
-do {
-    f.startNewPass();
-    for (const auto& r : resultSet.m_indices_dists){
-        f.addNeighbor(_vecs[r.first]);
-    }
-    res = f.finalize();
-} while ( res == NEED_OTHER_PASS );
+    f.init();
+    // Compute
+    auto res = Ponca::UNDEFINED;
+    do
+    {
+        f.startNewPass();
+        for (const auto& r : resultSet.m_indices_dists)
+        {
+            f.addNeighbor(_vecs[r.first]);
+        }
+        res = f.finalize();
+    } while (res == NEED_OTHER_PASS);
     //! [Use NanoFlann KdTree]
 
-    if(res != STABLE)
+    if (res != STABLE)
         std::cerr << "[nanoflann_kdtree] Something weird happened" << std::endl;
     return f.getNumNeighbors();
 }
-
 
 int main()
 {
     using Scalar = typename MyPoint::Scalar;
     // init random point cloud
     int n = 100000;
-    std::vector<MyPoint> vecs (n);
-    std::generate(vecs.begin(), vecs.end(), []() {return MyPoint::Random(); });
+    std::vector<MyPoint> vecs(n);
+    std::generate(vecs.begin(), vecs.end(), []() { return MyPoint::Random(); });
 
     //! [Create Ponca KdTree]
-KdTreeDense<MyPoint> ponca_tree(vecs);
+    KdTreeDense<MyPoint> ponca_tree(vecs);
     //! [Create Ponca KdTree]
 
     //! [Create NanoFlann KdTree]
-NFPointCloud nfcloud(vecs);
-my_kd_tree_t mat_index(3, nfcloud);
+    NFPointCloud nfcloud(vecs);
+    my_kd_tree_t mat_index(3, nfcloud);
     //! [Create NanoFlann KdTree]
 
     Scalar tmax = 0.2;
@@ -162,43 +165,43 @@ my_kd_tree_t mat_index(3, nfcloud);
     FitType fit;
 
     int nbrun = 1000;
-    std::vector<typename MyPoint::VectorType> queries (nbrun);
-    std::generate(queries.begin(), queries.end(), []() {return MyPoint::Random().pos(); });
+    std::vector<typename MyPoint::VectorType> queries(nbrun);
+    std::generate(queries.begin(), queries.end(), []() { return MyPoint::Random().pos(); });
 
-    int neiRaw {0}, neiPonca {0}, neiFlann {0};
+    int neiRaw{0}, neiPonca{0}, neiFlann{0};
     auto start = std::chrono::system_clock::now();
-    for(int i = 0; i != nbrun; ++i)
+    for (int i = 0; i != nbrun; ++i)
     {
         fit.setNeighborFilter({queries[i], tmax});
         neiRaw += test_raw(fit, vecs);
     }
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> rawDiff = (end-start);
+    auto end                              = std::chrono::system_clock::now();
+    std::chrono::duration<double> rawDiff = (end - start);
 
     start = std::chrono::system_clock::now();
-    for(int i = 0; i != nbrun; ++i)
+    for (int i = 0; i != nbrun; ++i)
     {
         fit.setNeighborFilter({queries[i], tmax});
         neiPonca += test_ponca_kdtree(fit, vecs, queries[i], ponca_tree, tmax);
     }
-    end = std::chrono::system_clock::now();
-    std::chrono::duration<double> poncaDiff = (end-start);
+    end                                     = std::chrono::system_clock::now();
+    std::chrono::duration<double> poncaDiff = (end - start);
 
     start = std::chrono::system_clock::now();
-    for(int i = 0; i != nbrun; ++i)
+    for (int i = 0; i != nbrun; ++i)
     {
         fit.setNeighborFilter({queries[i], tmax});
         neiFlann += test_nanflann_kdtree(fit, vecs, queries[i], mat_index, tmax);
     }
-    end = std::chrono::system_clock::now();
-    std::chrono::duration<double> nanoflannDiff = (end-start);
+    end                                         = std::chrono::system_clock::now();
+    std::chrono::duration<double> nanoflannDiff = (end - start);
 
     std::cout << "Timings: " << "\n"
-              << "Raw :       " <<  rawDiff.count() << "\n"
-              << "Ponca :     " <<  poncaDiff.count() << "\n"
-              << "Nanoflann : " <<  nanoflannDiff.count() << "\n";
+              << "Raw :       " << rawDiff.count() << "\n"
+              << "Ponca :     " << poncaDiff.count() << "\n"
+              << "Nanoflann : " << nanoflannDiff.count() << "\n";
     std::cout << "Number of neighbors: " << "\n"
-              << "Raw :       " <<  neiRaw << "\n"
-              << "Ponca :     " <<  neiPonca << "\n"
-              << "Nanoflann : " <<  neiFlann << "\n";
+              << "Raw :       " << neiRaw << "\n"
+              << "Ponca :     " << neiPonca << "\n"
+              << "Nanoflann : " << neiFlann << "\n";
 }

--- a/examples/cpp/pcl/main.cpp
+++ b/examples/cpp/pcl/main.cpp
@@ -10,16 +10,15 @@
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/features/principal_curvatures.h>
 #include <pcl/features/normal_3d.h>
-#include<pcl/visualization/pcl_plotter.h>
+#include <pcl/visualization/pcl_plotter.h>
 #include <pcl/common/time.h>
 
 #include "pcl_wrapper.h"
 
-
 typedef struct
 {
-    double r,g,b;
-}Color;
+    double r, g, b;
+} Color;
 
 // Colormap function
 Color getColor(float value, float min_value, float max_value)
@@ -27,7 +26,7 @@ Color getColor(float value, float min_value, float max_value)
     Color c = {1.0, 1.0, 1.0};
     double dv;
     // Unknown values in our kernel
-    if(value == 0.)
+    if (value == 0.)
     {
         return c;
     }
@@ -43,7 +42,7 @@ Color getColor(float value, float min_value, float max_value)
     // Interval
     dv = max_value - min_value;
     // Seismic color map like
-    if(value < (min_value + 0.5 * dv))
+    if (value < (min_value + 0.5 * dv))
     {
         c.r = 2 * (value - min_value) / dv;
         c.g = 2 * (value - min_value) / dv;
@@ -64,9 +63,9 @@ int main()
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_without_normals(new pcl::PointCloud<pcl::PointXYZ>);
 
     // load an object into a point cloud
-    if (pcl::io::loadPLYFile<pcl::PointXYZ> ("bun_zipper.ply", *cloud_without_normals) == -1)
+    if (pcl::io::loadPLYFile<pcl::PointXYZ>("bun_zipper.ply", *cloud_without_normals) == -1)
     {
-        PCL_ERROR ("bun_zipper.ply \n");
+        PCL_ERROR("bun_zipper.ply \n");
         return (-1);
     }
 
@@ -75,9 +74,9 @@ int main()
     // calculate surface normals with a search radius of 0.01
     pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
     ne.setInputCloud(cloud_without_normals);
-    pcl::search::KdTree<pcl::PointXYZ>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZ> ());
+    pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>());
     ne.setSearchMethod(tree);
-    pcl::PointCloud<pcl::Normal>::Ptr normals (new pcl::PointCloud<pcl::Normal>);
+    pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
     ne.setRadiusSearch(radius);
     ne.compute(*normals);
 
@@ -87,13 +86,13 @@ int main()
     // compute the gls curvature feature
     pcl::GlsCurvature<pcl::PointNormal, pcl::PointNormal> ne2;
     ne2.setInputCloud(cloud);
-    pcl::search::KdTree<pcl::PointNormal>::Ptr tree2 (new pcl::search::KdTree<pcl::PointNormal> ());
+    pcl::search::KdTree<pcl::PointNormal>::Ptr tree2(new pcl::search::KdTree<pcl::PointNormal>());
     ne2.setSearchMethod(tree2);
-    pcl::PointCloud<pcl::PointNormal>::Ptr output_cloud (new pcl::PointCloud<pcl::PointNormal>);
-    ne2.setRadiusSearch( radius );
+    pcl::PointCloud<pcl::PointNormal>::Ptr output_cloud(new pcl::PointCloud<pcl::PointNormal>);
+    ne2.setRadiusSearch(radius);
     {
-      pcl::ScopeTime t1 ("Curvature computation using Ponca");
-      ne2.compute(*output_cloud);
+        pcl::ScopeTime t1("Curvature computation using Ponca");
+        ne2.compute(*output_cloud);
     }
 
     // compare timings with PCL curvature estimation
@@ -102,25 +101,24 @@ int main()
     pce.setInputNormals(normals);
     pce.setSearchMethod(tree);
     pce.setRadiusSearch(radius);
-    pcl::PointCloud<pcl::PrincipalCurvatures>::Ptr principalCurvatures (new pcl::PointCloud<pcl::PrincipalCurvatures> ());
+    pcl::PointCloud<pcl::PrincipalCurvatures>::Ptr principalCurvatures(new pcl::PointCloud<pcl::PrincipalCurvatures>());
     {
-      pcl::ScopeTime t1 ("Curvature computation using PCL");
-      pce.compute(*principalCurvatures);
+        pcl::ScopeTime t1("Curvature computation using PCL");
+        pce.compute(*principalCurvatures);
     }
 
     // Use another point cloud for the visualizer (use a colormap to represent the curvature)
-    pcl::PointCloud<pcl::PointXYZRGB>::Ptr
-        cloud_rgb1 (new pcl::PointCloud<pcl::PointXYZRGB>), //ponca version
-        cloud_rgb2 (new pcl::PointCloud<pcl::PointXYZRGB>); //pcl version
-    std::vector<double> curvBuffer1 (cloud->size()),  // ponca version
-                        curvBuffer2 (cloud->size());  // pcl version
-    for(size_t i = 0; i < cloud->size(); ++i)
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_rgb1(new pcl::PointCloud<pcl::PointXYZRGB>), // ponca version
+        cloud_rgb2(new pcl::PointCloud<pcl::PointXYZRGB>);                                    // pcl version
+    std::vector<double> curvBuffer1(cloud->size()),                                           // ponca version
+        curvBuffer2(cloud->size());                                                           // pcl version
+    for (size_t i = 0; i < cloud->size(); ++i)
     {
         // \FIXME There is problem with the magnitude of the derivative computed with Ponca.
         float curvature1 = 1.f / 6000.f * output_cloud->points[i].curvature;
-        curvBuffer1[i] = curvature1;
-        float curvature2 = 1.f / 0.5f * (principalCurvatures->points[i].pc1 + principalCurvatures->points[i].pc2)/2.f;
-        curvBuffer2[i] = curvature2;
+        curvBuffer1[i]   = curvature1;
+        float curvature2 = 1.f / 0.5f * (principalCurvatures->points[i].pc1 + principalCurvatures->points[i].pc2) / 2.f;
+        curvBuffer2[i]   = curvature2;
 
         Color c1 = getColor(curvature1, -0.5f, 0.5f);
         Color c2 = getColor(-curvature2, -0.5f, 0.5f);
@@ -131,49 +129,49 @@ int main()
         point.y = cloud->points[i].y;
         point.z = cloud->points[i].z;
 
-        //convert into int
+        // convert into int
         point.r = c1.r * 255;
         point.g = c1.g * 255;
         point.b = c1.b * 255;
-        cloud_rgb1->points.push_back (point);
-
+        cloud_rgb1->points.push_back(point);
 
         point.r = c2.r * 255;
         point.g = c2.g * 255;
         point.b = c2.b * 255;
-        cloud_rgb2->points.push_back (point);
+        cloud_rgb2->points.push_back(point);
     }
-//    // visualize curvature plots
-//    pcl::visualization::PCLPlotter * plotter = new pcl::visualization::PCLPlotter ();
-//    plotter->addHistogramData (curvBuffer2, 100, "PCL");
-//    plotter->addHistogramData (curvBuffer1, 100, "Ponca");
-//    plotter->setShowLegend (true); //show legends
+    //    // visualize curvature plots
+    //    pcl::visualization::PCLPlotter * plotter = new pcl::visualization::PCLPlotter ();
+    //    plotter->addHistogramData (curvBuffer2, 100, "PCL");
+    //    plotter->addHistogramData (curvBuffer1, 100, "Ponca");
+    //    plotter->setShowLegend (true); //show legends
 
     // visualize curvatures
-    boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer (new pcl::visualization::PCLVisualizer ("Ponca - PCL Demo"));
-    viewer->setBackgroundColor (0.5, 0.5, 0.5);
+    boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer(
+        new pcl::visualization::PCLVisualizer("Ponca - PCL Demo"));
+    viewer->setBackgroundColor(0.5, 0.5, 0.5);
     pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb1(cloud_rgb1);
-    viewer->addPointCloud<pcl::PointXYZRGB> (cloud_rgb1, rgb1, "Ponca estimation");
+    viewer->addPointCloud<pcl::PointXYZRGB>(cloud_rgb1, rgb1, "Ponca estimation");
     pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb2(cloud_rgb2);
-    viewer->addPointCloud<pcl::PointXYZRGB> (cloud_rgb2, rgb2, "PCL estimation");
+    viewer->addPointCloud<pcl::PointXYZRGB>(cloud_rgb2, rgb2, "PCL estimation");
 
     // make cloud visible directly
-    Eigen::Affine3f tr {Eigen::Affine3f::Identity()};
+    Eigen::Affine3f tr{Eigen::Affine3f::Identity()};
 
-    tr.translate( Eigen::Vector3f{ 0.1, -0.1, 0.4 } );
-    viewer->updatePointCloudPose( "Ponca estimation", tr);
+    tr.translate(Eigen::Vector3f{0.1, -0.1, 0.4});
+    viewer->updatePointCloudPose("Ponca estimation", tr);
 
-    tr.translate( Eigen::Vector3f{ -0.2, 0.0, 0.0 } );
-    viewer->updatePointCloudPose( "PCL estimation", tr);
+    tr.translate(Eigen::Vector3f{-0.2, 0.0, 0.0});
+    viewer->updatePointCloudPose("PCL estimation", tr);
 
-    viewer->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 5, "Ponca estimation");
-    viewer->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 5, "PCL estimation");
-    viewer->initCameraParameters ();
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 5, "Ponca estimation");
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 5, "PCL estimation");
+    viewer->initCameraParameters();
 
-    while (!viewer->wasStopped ())
+    while (!viewer->wasStopped())
     {
-        viewer->spinOnce (100);
-//        plotter->spinOnce (100);
-        boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+        viewer->spinOnce(100);
+        //        plotter->spinOnce (100);
+        boost::this_thread::sleep(boost::posix_time::microseconds(100000));
     }
 }

--- a/examples/cpp/pcl/pcl_wrapper.cpp
+++ b/examples/cpp/pcl/pcl_wrapper.cpp
@@ -11,4 +11,5 @@
 #include "pcl_wrapper.hpp"
 
 // Instantiations of specific point types
-PCL_INSTANTIATE_PRODUCT(GlsCurvature, ((pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal))((pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal)));
+PCL_INSTANTIATE_PRODUCT(GlsCurvature, ((pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal))(
+                                          (pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal)));

--- a/examples/cpp/pcl/pcl_wrapper.h
+++ b/examples/cpp/pcl/pcl_wrapper.h
@@ -21,32 +21,35 @@
 class GlsPoint
 {
 public:
-    enum {Dim = 3};
+    enum
+    {
+        Dim = 3
+    };
     typedef float Scalar;
     typedef Eigen::Matrix<Scalar, 3, 1> VectorType;
     typedef Eigen::Matrix<Scalar, 3, 3> MatrixType;
 
-    PONCA_MULTIARCH inline GlsPoint(Eigen::Map< const VectorType > pos, Eigen::Map< const VectorType > normal)
-        : pos_   (pos),
-          normal_(normal)
-    {}
+    PONCA_MULTIARCH inline GlsPoint(Eigen::Map<const VectorType> pos, Eigen::Map<const VectorType> normal)
+        : pos_(pos), normal_(normal)
+    {
+    }
 
-    PONCA_MULTIARCH inline const Eigen::Map< const VectorType >& pos()    const { return pos_; }
-    PONCA_MULTIARCH inline const Eigen::Map< const VectorType >& normal() const { return normal_; }
+    PONCA_MULTIARCH inline const Eigen::Map<const VectorType>& pos() const { return pos_; }
+    PONCA_MULTIARCH inline const Eigen::Map<const VectorType>& normal() const { return normal_; }
 
 private:
-    Eigen::Map< const VectorType > pos_, normal_;
+    Eigen::Map<const VectorType> pos_, normal_;
 };
 
 namespace pcl
 {
-    /** \brief GlsCurvature estimates local surface curvatures at each 3D point with oriented normal using the Ponca library
-    * method.
-    *
-    *
-    * \author Gautier Ciaudo
-    */
-    template<typename PointInT, typename PointOutT>
+    /** \brief GlsCurvature estimates local surface curvatures at each 3D point with oriented normal using the Ponca
+     * library method.
+     *
+     *
+     * \author Gautier Ciaudo
+     */
+    template <typename PointInT, typename PointOutT>
     class GlsCurvature : public Feature<PointInT, PointOutT>
     {
         using Feature<PointInT, PointOutT>::feature_name_;
@@ -63,33 +66,29 @@ namespace pcl
 
     public:
         /** \brief Empty constructor. */
-        GlsCurvature()
-        {
-            feature_name_ = "GlsCurvature";
-        }
+        GlsCurvature() { feature_name_ = "GlsCurvature"; }
 
         /** \brief Compute the Growing Least-Squares sphere fit for a given set of points, using their indices,
-        * and return the estimated surface curvature.
-        * \param cloud the input point cloud
-        * \param indices the point cloud indices that need to be used
-        * \param curvature the estimated surface curvature
-        */
-        void computeCurvature(const pcl::PointCloud<PointInT> &cloud, int p_idx, const std::vector<int> &indices, float &curvature);
+         * and return the estimated surface curvature.
+         * \param cloud the input point cloud
+         * \param indices the point cloud indices that need to be used
+         * \param curvature the estimated surface curvature
+         */
+        void computeCurvature(const pcl::PointCloud<PointInT>& cloud, int p_idx, const std::vector<int>& indices,
+                              float& curvature);
 
     protected:
         /** \brief Estimate curvatures for all points given in <setInputCloud (), setIndices ()> using the surface in
-        * setSearchSurface () and the spatial locator in setSearchMethod ()
-        * \note In situations where not enough neighbors are found, curvature values are set to qNan.
-        * \param output the resultant point cloud model dataset that contains surface curvatures
-        */
-        void
-        computeFeature (PointCloudOut &output);
+         * setSearchSurface () and the spatial locator in setSearchMethod ()
+         * \note In situations where not enough neighbors are found, curvature values are set to qNan.
+         * \param output the resultant point cloud model dataset that contains surface curvatures
+         */
+        void computeFeature(PointCloudOut& output);
 
     private:
         /** \brief Make the computeFeature (&Eigen::MatrixXf); inaccessible from outside the class
-          * \param[out] output the output point cloud
-          */
-        void
-        computeFeatureEigen (pcl::PointCloud<Eigen::MatrixXf> &) {}
+         * \param[out] output the output point cloud
+         */
+        void computeFeatureEigen(pcl::PointCloud<Eigen::MatrixXf>&) {}
     };
-}
+} // namespace pcl

--- a/examples/cpp/pcl/pcl_wrapper.hpp
+++ b/examples/cpp/pcl/pcl_wrapper.hpp
@@ -10,60 +10,61 @@
 #include <pcl/common/point_tests.h> // isFinite
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::GlsCurvature<PointInT, PointOutT>::computeFeature(PointCloudOut &output)
+template <typename PointInT, typename PointOutT>
+void pcl::GlsCurvature<PointInT, PointOutT>::computeFeature(PointCloudOut& output)
 {
     // Allocate enough space to hold the results
     // \note This resize is irrelevant for a radiusSearch ().
-    std::vector<int> nn_indices (k_);
-    std::vector<float> nn_dists (k_);
+    std::vector<int> nn_indices(k_);
+    std::vector<float> nn_dists(k_);
 
     output.is_dense = true;
     // Save a few cycles by not checking every point for NaN/Inf values if the cloud is set to dense
     if (input_->is_dense)
     {
         // Iterating over the entire index vector
-        for (size_t idx = 0; idx < indices_->size (); ++idx)
+        for (size_t idx = 0; idx < indices_->size(); ++idx)
         {
-            if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
+            if (this->searchForNeighbors((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
             {
-                output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN ();
-                output.is_dense = false;
+                output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN();
+                output.is_dense              = false;
                 continue;
             }
 
-            computeCurvature (*surface_, (*indices_)[idx], nn_indices, output.points[idx].curvature);
+            computeCurvature(*surface_, (*indices_)[idx], nn_indices, output.points[idx].curvature);
         }
     }
     else
     {
         // Iterating over the entire index vector
-        for (size_t idx = 0; idx < indices_->size (); ++idx)
+        for (size_t idx = 0; idx < indices_->size(); ++idx)
         {
-            if (!pcl::isFinite ((*input_)[(*indices_)[idx]]) ||
-                this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
+            if (!pcl::isFinite((*input_)[(*indices_)[idx]]) ||
+                this->searchForNeighbors((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
             {
-                output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN ();
-                output.is_dense = false;
+                output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN();
+                output.is_dense              = false;
                 continue;
             }
 
-            computeCurvature (*surface_, (*indices_)[idx], nn_indices, output.points[idx].curvature);
+            computeCurvature(*surface_, (*indices_)[idx], nn_indices, output.points[idx].curvature);
         }
     }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::GlsCurvature<PointInT, PointOutT>::computeCurvature(const pcl::PointCloud<PointInT> &cloud,
-                                                         int p_idx, const std::vector<int> &indices,
-                                                         float &curvature)
+template <typename PointInT, typename PointOutT>
+void pcl::GlsCurvature<PointInT, PointOutT>::computeCurvature(const pcl::PointCloud<PointInT>& cloud, int p_idx,
+                                                              const std::vector<int>& indices, float& curvature)
 {
     typedef GlsPoint::Scalar Scalar;
-    typedef Ponca::DistWeightFunc<GlsPoint, Ponca::SmoothWeightKernel<Scalar> > WeightFunc;
+    typedef Ponca::DistWeightFunc<GlsPoint, Ponca::SmoothWeightKernel<Scalar>> WeightFunc;
     typedef Ponca::Basket<GlsPoint, WeightFunc, Ponca::CovariancePlaneFit> FitBasket;
-    typedef Ponca::BasketDiff<FitBasket, Ponca::FitScaleSpaceDer, Ponca::CovariancePlaneDer, Ponca::CurvatureEstimatorDer,
-                              Ponca::NormalDerivativeWeingartenEstimator, Ponca::WeingartenCurvatureEstimatorDer> Fit;
+    typedef Ponca::BasketDiff<FitBasket, Ponca::FitScaleSpaceDer, Ponca::CovariancePlaneDer,
+                              Ponca::CurvatureEstimatorDer, Ponca::NormalDerivativeWeingartenEstimator,
+                              Ponca::WeingartenCurvatureEstimatorDer>
+        Fit;
 
     Fit fit;
     // Set a weighting function instance using the search radius of the tree as scale
@@ -74,7 +75,7 @@ pcl::GlsCurvature<PointInT, PointOutT>::computeCurvature(const pcl::PointCloud<P
     // Iterate over indices and fit the primitive
     // A GlsPoint instance is generated on the fly to bind the positions to the
     // library representation. No copy is done at this step.
-    for(size_t idx = 0; idx < indices.size (); ++idx)
+    for (size_t idx = 0; idx < indices.size(); ++idx)
     {
         int id = indices[idx];
 
@@ -85,13 +86,13 @@ pcl::GlsCurvature<PointInT, PointOutT>::computeCurvature(const pcl::PointCloud<P
     fit.finalize();
 
     // Test if the fitting ended without errors. Set curvature to qNan otherwise.
-    if(fit.isStable())
+    if (fit.isStable())
     {
         curvature = fit.kMean();
     }
     else
     {
-        curvature = std::numeric_limits<float>::quiet_NaN ();
+        curvature = std::numeric_limits<float>::quiet_NaN();
     }
 }
 

--- a/examples/cpp/ponca_basic_cpu.cpp
+++ b/examples/cpp/ponca_basic_cpu.cpp
@@ -4,7 +4,6 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
 \file examples/Grenaille/basic_cpu.h
 \brief Basic use of Grenaille
@@ -39,99 +38,95 @@ typedef MyPoint::Scalar Scalar;
 typedef MyPoint::VectorType VectorType;
 
 // Define related structure
-typedef DistWeightFunc<MyPoint,SmoothWeightKernel<Scalar> > WeightFunc;
-using Fit1 = Basket<MyPoint,WeightFunc,OrientedSphereFit,   GLSParam>;
-using Fit2 = Basket<MyPoint,WeightFunc,UnorientedSphereFit, GLSParam>;
-using Fit3 = BasketDiff< Fit1, FitSpaceDer, OrientedSphereDer, GLSDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
-using Fit4 = Basket<MyPoint,WeightFunc,SphereFit, GLSParam>;
+typedef DistWeightFunc<MyPoint, SmoothWeightKernel<Scalar>> WeightFunc;
+using Fit1 = Basket<MyPoint, WeightFunc, OrientedSphereFit, GLSParam>;
+using Fit2 = Basket<MyPoint, WeightFunc, UnorientedSphereFit, GLSParam>;
+using Fit3 = BasketDiff<Fit1, FitSpaceDer, OrientedSphereDer, GLSDer, CurvatureEstimatorDer,
+                        NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+using Fit4 = Basket<MyPoint, WeightFunc, SphereFit, GLSParam>;
 
-template<typename Fit>
+template <typename Fit>
 void test_fit(Fit& _fit, const KdTree<MyPoint>& tree, const VectorType& _p)
 {
-  Scalar tmax = 100.0;
+    Scalar tmax = 100.0;
 
-  // Set a weighting function instance
-  _fit.setNeighborFilter({_p, tmax});
+    // Set a weighting function instance
+    _fit.setNeighborFilter({_p, tmax});
 
-  _fit.init();
+    _fit.init();
 
-  // Iterate over samples and _fit the primitive
-  for(int i : tree.rangeNeighbors(_p, tmax) )
-  {
-      _fit.addNeighbor( tree.points()[i] );
-  }
+    // Iterate over samples and _fit the primitive
+    for (int i : tree.rangeNeighbors(_p, tmax))
+    {
+        _fit.addNeighbor(tree.points()[i]);
+    }
 
-  //finalize fitting
-  _fit.finalize();
+    // finalize fitting
+    _fit.finalize();
 
-  //Test if the fitting ended without errors
-  if(_fit.isStable())
-  {
-    cout << "Center: [" << _fit.center().transpose() << "] ;  radius: " << _fit.radius() << endl;
+    // Test if the fitting ended without errors
+    if (_fit.isStable())
+    {
+        cout << "Center: [" << _fit.center().transpose() << "] ;  radius: " << _fit.radius() << endl;
 
-    cout << "Pratt normalization"
-      << (_fit.applyPrattNorm() ? " is now done." : " has already been applied.") << endl;
+        cout << "Pratt normalization" << (_fit.applyPrattNorm() ? " is now done." : " has already been applied.")
+             << endl;
 
-    // Play with fitting output
-    cout << "Value of the scalar field at the initial point: "
-      << _p.transpose()
-      << " is equal to " << _fit.potential(_p)
-      << endl;
+        // Play with fitting output
+        cout << "Value of the scalar field at the initial point: " << _p.transpose() << " is equal to "
+             << _fit.potential(_p) << endl;
 
-    cout << "It's gradient at this place is equal to: "
-      << _fit.primitiveGradient(_p).transpose()
-      << endl;
+        cout << "It's gradient at this place is equal to: " << _fit.primitiveGradient(_p).transpose() << endl;
 
-    cout << "Fitted Sphere: " << endl
-      << "\t Tau  : "      << _fit.tau()             << endl
-      << "\t Eta  : "      << _fit.eta().transpose() << endl
-      << "\t Kappa: "      << _fit.kappa()           << endl;
+        cout << "Fitted Sphere: " << endl
+             << "\t Tau  : " << _fit.tau() << endl
+             << "\t Eta  : " << _fit.eta().transpose() << endl
+             << "\t Kappa: " << _fit.kappa() << endl;
 
-    cout << "The initial point " << _p.transpose()              << endl
-      << "Is projected at   " << _fit.project(_p).transpose() << endl;
-  }
-
+        cout << "The initial point " << _p.transpose() << endl
+             << "Is projected at   " << _fit.project(_p).transpose() << endl;
+    }
 }
 
 int main()
 {
-  // set evaluation point and scale
-  VectorType p = VectorType::Random();
+    // set evaluation point and scale
+    VectorType p = VectorType::Random();
 
-  // init input data
-  int n = 10000;
-  vector<MyPoint> vecs (n);
-  std::generate(vecs.begin(), vecs.end(), getRandomPoint<MyPoint>);
+    // init input data
+    int n = 10000;
+    vector<MyPoint> vecs(n);
+    std::generate(vecs.begin(), vecs.end(), getRandomPoint<MyPoint>);
 
-  p = vecs.at(0).pos();
+    p = vecs.at(0).pos();
 
-  KdTreeDense<MyPoint> tree {vecs};
+    KdTreeDense<MyPoint> tree{vecs};
 
-  std::cout << "====================\nOrientedSphereFit:\n";
-  Fit1 fit1;
-  test_fit(fit1, tree, p);
+    std::cout << "====================\nOrientedSphereFit:\n";
+    Fit1 fit1;
+    test_fit(fit1, tree, p);
 
-  std::cout << "\n\n====================\nUnorientedSphereFit:\n";
-  Fit2 fit2;
-  test_fit(fit2, tree, p);
+    std::cout << "\n\n====================\nUnorientedSphereFit:\n";
+    Fit2 fit2;
+    test_fit(fit2, tree, p);
 
-  std::cout << "\n\n====================\nUnorientedSphereFit:\n";
-  Fit3 fit3;
-  test_fit(fit3, tree, p);
+    std::cout << "\n\n====================\nUnorientedSphereFit:\n";
+    Fit3 fit3;
+    test_fit(fit3, tree, p);
 
-  if(fit3.isStable())
-  {
-    cout << "eigen values: "<< endl;
-    cout << fit3.kmin() << endl;
-    cout << fit3.kmax() << endl;
-    cout << "eigen vectors: "<< endl;
-    cout << fit3.kminDirection() << endl << endl;
-    cout << fit3.kmaxDirection() << endl;
-  }
+    if (fit3.isStable())
+    {
+        cout << "eigen values: " << endl;
+        cout << fit3.kmin() << endl;
+        cout << fit3.kmax() << endl;
+        cout << "eigen vectors: " << endl;
+        cout << fit3.kminDirection() << endl << endl;
+        cout << fit3.kmaxDirection() << endl;
+    }
 
-  std::cout << "\n\n====================\nSphereFit:\n";
-  Fit4 fit4;
-  test_fit(fit4, tree, p);
+    std::cout << "\n\n====================\nSphereFit:\n";
+    Fit4 fit4;
+    test_fit(fit4, tree, p);
 
-  return 0;
+    return 0;
 }

--- a/examples/cpp/ponca_binding.cpp
+++ b/examples/cpp/ponca_binding.cpp
@@ -4,7 +4,6 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
 \file examples/cpp/ponca_binding.cpp
 \brief Basic use example of the Ponca point binding type
@@ -33,14 +32,10 @@ typedef MyPoint::VectorType VectorType;
 
 // Define related structure
 typedef DistWeightFunc<MyPoint, SmoothWeightKernel<Scalar>> WeightFunc;
-typedef Basket<MyPoint, WeightFunc,OrientedSphereFit, GLSParam> Fit;
+typedef Basket<MyPoint, WeightFunc, OrientedSphereFit, GLSParam> Fit;
 
-
-template<typename Fit>
-void test_fit(Fit& _fit,
-              Scalar* const _interlacedArray,
-              const int _n,
-              const VectorType& _p)
+template <typename Fit>
+void test_fit(Fit& _fit, Scalar* const _interlacedArray, const int _n, const VectorType& _p)
 {
     Scalar tmax = 100.0;
 
@@ -51,7 +46,7 @@ void test_fit(Fit& _fit,
     // Iterate over samples and _fit the primitive
     // A MyPoint instance is generated on the fly to bind the raw arrays to the
     // library representation. No copy is done at this step.
-    for(int i = 0; i!= _n; i++)
+    for (int i = 0; i != _n; i++)
     {
         _fit.addNeighbor(MyPoint(_interlacedArray, i));
     }
@@ -60,49 +55,45 @@ void test_fit(Fit& _fit,
     _fit.finalize();
 
     // Test if the fitting ended without errors
-    if(_fit.isStable())
+    if (_fit.isStable())
     {
         cout << "Center: [" << _fit.center().transpose() << "] ;  radius: " << _fit.radius() << endl;
 
-        cout << "Pratt normalization"
-            << (_fit.applyPrattNorm() ? " is now done." : " has already been applied.") << endl;
+        cout << "Pratt normalization" << (_fit.applyPrattNorm() ? " is now done." : " has already been applied.")
+             << endl;
 
         // Play with fitting output
-        cout << "Value of the scalar field at the initial point: "
-            << _p.transpose()
-            << " is equal to " << _fit.potential(_p)
-            << endl;
+        cout << "Value of the scalar field at the initial point: " << _p.transpose() << " is equal to "
+             << _fit.potential(_p) << endl;
 
-        cout << "It's gradient at this place is equal to: "
-            << _fit.primitiveGradient(_p).transpose()
-            << endl;
+        cout << "It's gradient at this place is equal to: " << _fit.primitiveGradient(_p).transpose() << endl;
 
         cout << "Fitted Sphere: " << endl
-            << "\t Tau  : "      << _fit.tau()             << endl
-            << "\t Eta  : "      << _fit.eta().transpose() << endl
-            << "\t Kappa: "      << _fit.kappa()           << endl;
+             << "\t Tau  : " << _fit.tau() << endl
+             << "\t Eta  : " << _fit.eta().transpose() << endl
+             << "\t Kappa: " << _fit.kappa() << endl;
 
-        cout << "The initial point " << _p.transpose()              << endl
-            << "Is projected at   " << _fit.project(_p).transpose() << endl;
+        cout << "The initial point " << _p.transpose() << endl
+             << "Is projected at   " << _fit.project(_p).transpose() << endl;
     }
 }
 
 // Build an interlaced array containing _n position and normal vectors
 Scalar* buildInterlacedArray(const int _n)
 {
-    auto* const interlacedArray = new Scalar[2*DIMENSION*_n];
+    auto* const interlacedArray = new Scalar[2 * DIMENSION * _n];
 
-    for(int k=0; k<_n; ++k)
+    for (int k = 0; k < _n; ++k)
     {
         // For the simplicity of this example, we use Eigen Vectors to compute
         // both coordinates and normals, and then copy the raw values to an
         // interlaced array, discarding the Eigen representation.
         const Eigen::Matrix<Scalar, DIMENSION, 1> nvec = Eigen::Matrix<Scalar, DIMENSION, 1>::Random().normalized();
-        const Eigen::Matrix<Scalar, DIMENSION, 1> pvec = nvec * Eigen::internal::random<Scalar>(0.9,1.1);
+        const Eigen::Matrix<Scalar, DIMENSION, 1> pvec = nvec * Eigen::internal::random<Scalar>(0.9, 1.1);
 
         // Grab coordinates and store them as raw buffer
-        memcpy(interlacedArray+2*DIMENSION*k,           pvec.data(), DIMENSION*sizeof(Scalar));
-        memcpy(interlacedArray+2*DIMENSION*k+DIMENSION, nvec.data(), DIMENSION*sizeof(Scalar));
+        memcpy(interlacedArray + 2 * DIMENSION * k, pvec.data(), DIMENSION * sizeof(Scalar));
+        memcpy(interlacedArray + 2 * DIMENSION * k + DIMENSION, nvec.data(), DIMENSION * sizeof(Scalar));
     }
 
     return interlacedArray;
@@ -112,11 +103,11 @@ int main()
 {
     // Build arrays containing normals and positions,
     // simulating data coming from outside the library.
-    constexpr int n = 1000;
+    constexpr int n               = 1000;
     Scalar* const interlacedArray = buildInterlacedArray(n);
 
     // Set evaluation point and scale at the first coordinate
-    const VectorType p (interlacedArray);
+    const VectorType p(interlacedArray);
 
     // Here we now perform the fit, starting from a raw interlaced buffer,
     // without any data duplication

--- a/examples/cpp/ponca_customize_kdtree.cpp
+++ b/examples/cpp/ponca_customize_kdtree.cpp
@@ -15,7 +15,8 @@ using DataPoint = Ponca::PointPosition<float, 3>;
 
 //! [CustomInnerNodeDefinition]
 template <typename NodeIndex, typename Scalar, int DIM, typename _AabbType = Eigen::AlignedBox<Scalar, DIM>>
-struct MyKdTreeInnerNode : public Ponca::KdTreeDefaultInnerNode<NodeIndex, Scalar, DIM> {
+struct MyKdTreeInnerNode : public Ponca::KdTreeDefaultInnerNode<NodeIndex, Scalar, DIM>
+{
     using AabbType = _AabbType;
     AabbType m_aabb{};
 };
@@ -23,23 +24,27 @@ struct MyKdTreeInnerNode : public Ponca::KdTreeDefaultInnerNode<NodeIndex, Scala
 
 //! [CustomNodeDefinition]
 template <typename Index, typename NodeIndex, typename DataPoint, typename LeafSize = Index>
-struct MyKdTreeNode : Ponca::KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
-        MyKdTreeInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>> {
+struct MyKdTreeNode
+    : Ponca::KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
+                                    MyKdTreeInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>>
+{
 
-    using Base = Ponca::KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
-            MyKdTreeInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>>;
-    using AabbType  = typename Base::AabbType;
+    using Base =
+        Ponca::KdTreeCustomizableNode<Index, NodeIndex, DataPoint, LeafSize,
+                                      MyKdTreeInnerNode<NodeIndex, typename DataPoint::Scalar, DataPoint::Dim>>;
+    using AabbType = typename Base::AabbType;
 
-    void configure_range(Index start, Index size, const AabbType &aabb)
+    void configure_range(Index start, Index size, const AabbType& aabb)
     {
         Base::configure_range(start, size, aabb);
-        if (! Base::is_leaf() )
+        if (!Base::is_leaf())
         {
             Base::getAsInner().m_aabb = aabb;
         }
     }
-    [[nodiscard]] inline std::optional<AabbType> getAabb() const {
-        if (! Base::is_leaf())
+    [[nodiscard]] inline std::optional<AabbType> getAabb() const
+    {
+        if (!Base::is_leaf())
             return Base::getAsInner().m_aabb;
         else
             return std::optional<AabbType>();
@@ -50,14 +55,13 @@ struct MyKdTreeNode : Ponca::KdTreeCustomizableNode<Index, NodeIndex, DataPoint,
 int main()
 {
     // generate N random points
-    constexpr int N {100000};
+    constexpr int N{100000};
     std::vector<DataPoint> points(N);
-    std::generate(points.begin(), points.end(), [](){
-        return DataPoint{100 * DataPoint::VectorType::Random()};});
+    std::generate(points.begin(), points.end(), []() { return DataPoint{100 * DataPoint::VectorType::Random()}; });
 
-//! [KdTreeTypeWithCustomNode]
-    using CustomKdTree = Ponca::KdTreeDenseBase<Ponca::KdTreeDefaultTraits<DataPoint,MyKdTreeNode>>;
-//! [KdTreeTypeWithCustomNode]
+    //! [KdTreeTypeWithCustomNode]
+    using CustomKdTree = Ponca::KdTreeDenseBase<Ponca::KdTreeDefaultTraits<DataPoint, MyKdTreeNode>>;
+    //! [KdTreeTypeWithCustomNode]
 
     // build the k-d tree
     const CustomKdTree kdtree(points);
@@ -76,11 +80,10 @@ int main()
 
     //! [ReadCustomProperties]
     auto bbox = kdtree.nodes()[0].getAabb();
-    if (bbox) {
+    if (bbox)
+    {
         std::cout << "Root bounding box is as follows: \n"
-                  << "  Center:   " << bbox->center()
-                  << "  Diagonal: " << bbox->diagonal()
-                  << std::endl;
+                  << "  Center:   " << bbox->center() << "  Diagonal: " << bbox->diagonal() << std::endl;
     }
     //! [ReadCustomProperties]
 

--- a/examples/cpp/ponca_fit_line.cpp
+++ b/examples/cpp/ponca_fit_line.cpp
@@ -22,20 +22,19 @@ using MyPoint = PointPosition<double, 3>;
 typedef MyPoint::Scalar Scalar;
 typedef MyPoint::VectorType VectorType;
 
-typedef DistWeightFunc<MyPoint,ConstantWeightKernel<Scalar> > WeightFunc;
-typedef Basket<MyPoint,WeightFunc, CovarianceLineFit> Fit;
+typedef DistWeightFunc<MyPoint, ConstantWeightKernel<Scalar>> WeightFunc;
+typedef Basket<MyPoint, WeightFunc, CovarianceLineFit> Fit;
 
-
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
 
     int n = 10000;
 
     // Generate a random set of n points along a line
     vector<MyPoint> points(n);
     VectorType dir = VectorType::Random().normalized();
-    std::generate(points.begin(), points.end(), [&dir]() {
-        return (dir * Eigen::internal::random<Scalar>(0.1,2)).eval();
-    });
+    std::generate(points.begin(), points.end(),
+                  [&dir]() { return (dir * Eigen::internal::random<Scalar>(0.1, 2)).eval(); });
     const VectorType& p = points.at(0).pos();
 
     std::cout << "====================\nLeastSquareLineFit:\n";
@@ -47,18 +46,16 @@ int main(int argc, char **argv) {
     _fit.compute(points.cbegin(), points.cend());
 
     // Check Fit output
-    if( _fit.isStable() ) {
+    if (_fit.isStable())
+    {
         cout << "Direction of the fitted 3D line: " << _fit.direction().transpose() << endl;
         cout << "Origin of the fitted line: " << _fit.origin().transpose() << endl;
         cout << "Projection of the basis center on the fitted line: " << _fit.project(p).transpose() << endl;
 
         /// Compute sum of the distances between samples and line: should be 0
-        Scalar dist = std::transform_reduce(points.cbegin(), points.cend(),
-                                                   Scalar(0),
-                                                   std::plus<>(),
-                                                   [&_fit](const MyPoint &q) {
-                                                       return (q.pos() - _fit.project(q.pos())).norm();
-                                                   });
+        Scalar dist =
+            std::transform_reduce(points.cbegin(), points.cend(), Scalar(0), std::plus<>(),
+                                  [&_fit](const MyPoint& q) { return (q.pos() - _fit.project(q.pos())).norm(); });
         cout << "Mean error between samples and fitted line: " << dist / Scalar(n) << endl;
         return EXIT_SUCCESS;
     }

--- a/examples/cpp/ponca_fit_plane.cpp
+++ b/examples/cpp/ponca_fit_plane.cpp
@@ -4,7 +4,6 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
 \file examples/Grenaille/basic_cpu.h
 \brief Basic use of Grenaille with plane fit
@@ -31,48 +30,42 @@ typedef MyPoint::Scalar Scalar;
 typedef MyPoint::VectorType VectorType;
 
 // Define related structure
-typedef DistWeightFunc<MyPoint,SmoothWeightKernel<Scalar> > WeightFunc;
+typedef DistWeightFunc<MyPoint, SmoothWeightKernel<Scalar>> WeightFunc;
 typedef Basket<MyPoint, WeightFunc, CovariancePlaneFit> CovPlaneFit;
 
-template<typename Fit>
+template <typename Fit>
 void test_fit(Fit& _fit, vector<MyPoint>& _vecs, const VectorType& _p)
 {
-  Scalar tmax = 100.0;
+    Scalar tmax = 100.0;
 
-  // Set a weighting function instance
-  _fit.setNeighborFilter({_p, tmax});
+    // Set a weighting function instance
+    _fit.setNeighborFilter({_p, tmax});
 
-  // Fit plane (method compute handles multipass fitting
-  _fit.compute( _vecs.begin(), _vecs.end() );
+    // Fit plane (method compute handles multipass fitting
+    _fit.compute(_vecs.begin(), _vecs.end());
 
-  if(_fit.isStable())
-  {
-        cout << "Value of the scalar field at the initial point: "
-            << _p.transpose()
-            << " is equal to " << _fit.potential(_p)
-            << endl;
+    if (_fit.isStable())
+    {
+        cout << "Value of the scalar field at the initial point: " << _p.transpose() << " is equal to "
+             << _fit.potential(_p) << endl;
 
-        cout << "It's gradient at this place is equal to: "
-            << _fit.primitiveGradient(_p).transpose()
-            << endl;
+        cout << "It's gradient at this place is equal to: " << _fit.primitiveGradient(_p).transpose() << endl;
 
-        cout << "The initial point " << _p.transpose()              << endl
-            << "Is projected at   " << _fit.project(_p).transpose() << endl;
+        cout << "The initial point " << _p.transpose() << endl
+             << "Is projected at   " << _fit.project(_p).transpose() << endl;
 
-        cout << "Value of the surface variation: "
-            << _fit.surfaceVariation()
-            << endl;
-  }
+        cout << "Value of the surface variation: " << _fit.surfaceVariation() << endl;
+    }
 }
 
 int main()
 {
-  // init random point cloud
-  int n = 10000;
-  vector<MyPoint> vecs (n);
-  std::generate(vecs.begin(), vecs.end(), getRandomPoint<MyPoint>);
+    // init random point cloud
+    int n = 10000;
+    vector<MyPoint> vecs(n);
+    std::generate(vecs.begin(), vecs.end(), getRandomPoint<MyPoint>);
 
-  std::cout << "====================\nCovariancePlaneFit:\n";
-  CovPlaneFit fit;
-  test_fit(fit, vecs, vecs.at(0).pos());
+    std::cout << "====================\nCovariancePlaneFit:\n";
+    CovPlaneFit fit;
+    test_fit(fit, vecs, vecs.at(0).pos());
 }

--- a/examples/cpp/ponca_neighbor_search.cpp
+++ b/examples/cpp/ponca_neighbor_search.cpp
@@ -16,17 +16,14 @@ using DataPoint = Ponca::PointPosition<float, 3>;
 int main()
 {
     // generate N random points
-    constexpr int N {100000};
-
+    constexpr int N{100000};
 
     //////////////////////////////////////////////////////////////
     ////////////////////// Tree construction /////////////////////
     //////////////////////////////////////////////////////////////
     /// [Kdtree Dense construction]
     std::vector<DataPoint> points(N);
-    std::generate(points.begin(), points.end(), [](){
-        return DataPoint{100 * DataPoint::VectorType::Random()};
-    });
+    std::generate(points.begin(), points.end(), []() { return DataPoint{100 * DataPoint::VectorType::Random()}; });
     // build the k-d tree
     Ponca::KdTreeDense<DataPoint> kdtreeDense(points);
     /// [Kdtree Dense construction]
@@ -42,7 +39,7 @@ int main()
 
     /// [KdTree pointer usage]
     // Abstract pointer type that can receive KdTreeSparse or KdTreeDense objects
-    Ponca::KdTree<DataPoint> *kdtree {nullptr};
+    Ponca::KdTree<DataPoint>* kdtree{nullptr};
     /// [KdTree pointer usage]
 
     /// [KdTree assign sparse]
@@ -74,7 +71,8 @@ int main()
 
     /// [Kdtree k-nearest neighbors index search]
     std::cout << "The " << k << "-nearest neighbors of the point at index " << query_idx << " are at indices: ";
-    for(int neighbor_idx : kdtreeDense.kNearestNeighbors(query_idx, k)) { // Iterates over the neighbors of query_idx
+    for (int neighbor_idx : kdtreeDense.kNearestNeighbors(query_idx, k))
+    { // Iterates over the neighbors of query_idx
         std::cout << neighbor_idx << ", ";
     }
     /// [Kdtree k-nearest neighbors index search]
@@ -82,7 +80,8 @@ int main()
 
     /// [Kdtree k-nearest neighbors position search]
     std::cout << "The " << k << "-nearest neighbors of the point (" << query_pt.transpose() << ") are at indices: ";
-    for(auto neighbor_idx : kdtreeDense.kNearestNeighbors(query_pt, k)) {
+    for (auto neighbor_idx : kdtreeDense.kNearestNeighbors(query_pt, k))
+    {
         std::cout << neighbor_idx << ", ";
     }
     /// [Kdtree k-nearest neighbors position search]
@@ -90,7 +89,8 @@ int main()
 
     /// [KnnGraph k-nearest neighbors index search]
     std::cout << "The nearest neighbors of the point at index " << query_idx << " are at indices: ";
-    for(int neighbor_idx : knnGraph.kNearestNeighbors(query_idx)) {
+    for (int neighbor_idx : knnGraph.kNearestNeighbors(query_idx))
+    {
         std::cout << neighbor_idx << ", ";
     }
     /// [KnnGraph k-nearest neighbors index search]
@@ -102,10 +102,12 @@ int main()
     const int second_query_idx = 5;
     /// [Kdtree range neighbors index mutable search]
     constexpr DataPoint::Scalar radius = 5.25;
-    auto rangeNeighbors = kdtreeDense.rangeNeighbors(query_idx, radius); // First query
+    auto rangeNeighbors                = kdtreeDense.rangeNeighbors(query_idx, radius); // First query
 
-    std::cout << "The neighbors of the point at index " << second_query_idx << " at a distance " << radius << " are at indices: ";
-    for(int neighbor_idx : rangeNeighbors(second_query_idx, radius)) { // Iterate over a new rangeNeighbors query
+    std::cout << "The neighbors of the point at index " << second_query_idx << " at a distance " << radius
+              << " are at indices: ";
+    for (int neighbor_idx : rangeNeighbors(second_query_idx, radius))
+    { // Iterate over a new rangeNeighbors query
         std::cout << neighbor_idx << ", ";
     }
     /// [Kdtree range neighbors index mutable search]
@@ -113,8 +115,10 @@ int main()
     /// [Kdtree range neighbors position mutable search]
     auto posRangeNeighbors = kdtreeDense.rangeNeighborsQuery(); // Empty query
 
-    std::cout << "The neighbors of the point (" << query_pt.transpose() << ") at a distance " << radius << " are at indices: ";
-    for(auto neighbor_idx : posRangeNeighbors(query_pt, radius)) {
+    std::cout << "The neighbors of the point (" << query_pt.transpose() << ") at a distance " << radius
+              << " are at indices: ";
+    for (auto neighbor_idx : posRangeNeighbors(query_pt, radius))
+    {
         std::cout << neighbor_idx << ", ";
     }
     /// [Kdtree range neighbors position mutable search]
@@ -123,8 +127,10 @@ int main()
     /// [KnnGraph range neighbors index mutable search]
     auto knnRangeNeighbors = knnGraph.rangeNeighborsIndexQuery(); // Empty query
 
-    std::cout << "The neighbors of the point (" << query_pt.transpose() << ") at a distance " << radius << " are at indices: ";
-    for(auto neighbor_idx : knnRangeNeighbors(query_idx, radius)) { // Iterates over the neighbors of query_idx
+    std::cout << "The neighbors of the point (" << query_pt.transpose() << ") at a distance " << radius
+              << " are at indices: ";
+    for (auto neighbor_idx : knnRangeNeighbors(query_idx, radius))
+    { // Iterates over the neighbors of query_idx
         std::cout << neighbor_idx << ", ";
     }
     /// [KnnGraph range neighbors index mutable search]

--- a/tests/common/has_duplicate.h
+++ b/tests/common/has_duplicate.h
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 
-
 /*!
  * \copybrief hasDuplicate(Iter first, Iter last)
  *
@@ -14,16 +13,13 @@
  * \param last The end iterator (obtained using `std::end(container)` on an STL-like container).
  * \return True if the container has a duplicate element inside it.
  */
-template<class RandomIt>
+template <class RandomIt>
 bool randomAccessIteratorHasDuplicate(RandomIt first, RandomIt last)
 {
-    static_assert(std::is_base_of_v<
-        std::random_access_iterator_tag,
-        typename std::iterator_traits<RandomIt>::iterator_category
-    >);
+    static_assert(
+        std::is_base_of_v<std::random_access_iterator_tag, typename std::iterator_traits<RandomIt>::iterator_category>);
 
-    return std::any_of(first, last, [&](const auto& cur)->bool
-    {
+    return std::any_of(first, last, [&](const auto& cur) -> bool {
         // next is the iterator pointing after the current value cur
         RandomIt next = first + (&cur - &(*first)) + 1;
         return std::find(next, last, cur) != last;
@@ -41,13 +37,11 @@ bool randomAccessIteratorHasDuplicate(RandomIt first, RandomIt last)
  * \param last The end iterator (obtained using `std::end(container)` on an STL-like container).
  * \return True if the container has a duplicate element inside it.
  */
-template<class ForwardIt>
+template <class ForwardIt>
 bool forwardIteratorHasDuplicate(ForwardIt first, ForwardIt last)
 {
-    static_assert(std::is_base_of_v<
-        std::forward_iterator_tag,
-        typename std::iterator_traits<ForwardIt>::iterator_category
-    >);
+    static_assert(
+        std::is_base_of_v<std::forward_iterator_tag, typename std::iterator_traits<ForwardIt>::iterator_category>);
 
     for (ForwardIt it = first; it != last; ++it)
     {
@@ -68,13 +62,12 @@ bool forwardIteratorHasDuplicate(ForwardIt first, ForwardIt last)
  * \param last The end iterator (obtained using `std::end(container)` on an STL-like container).
  * \return True if the container has a duplicate element inside it.
  */
-template<typename IteratorT>
+template <typename IteratorT>
 bool hasDuplicate(IteratorT first, IteratorT last)
 {
-    if constexpr (std::is_base_of_v<
-        std::random_access_iterator_tag,
-        typename std::iterator_traits<IteratorT>::iterator_category()
-    >) return randomAccessIteratorHasDuplicate(first, last);
+    if constexpr (std::is_base_of_v<std::random_access_iterator_tag,
+                                    typename std::iterator_traits<IteratorT>::iterator_category()>)
+        return randomAccessIteratorHasDuplicate(first, last);
 
     return forwardIteratorHasDuplicate(first, last);
 }
@@ -88,7 +81,7 @@ bool hasDuplicate(IteratorT first, IteratorT last)
  * \param container The container to check.
  * \return True if the container has a duplicate element inside it.
  */
-template<class ContainerT>
+template <class ContainerT>
 bool hasDuplicate(ContainerT container)
 {
     return hasDuplicate(std::begin(container), std::end(container));

--- a/tests/common/kdtree_utils.h
+++ b/tests/common/kdtree_utils.h
@@ -11,183 +11,210 @@
 
 #include "../common/has_duplicate.h"
 
-#define EXPECT_EQ(a,b) assert(a==b)
-#define EXPECT_TRUE(a) assert(a==true)
-
+#define EXPECT_EQ(a, b) assert(a == b)
+#define EXPECT_TRUE(a) assert(a == true)
 
 using namespace Eigen;
 using namespace std;
 
 using uint = unsigned int;
 
-template<typename DataPoint, typename VectorContainer, typename QueryInput, typename NeighborsIndexRange>
-bool checkRangeNeighbors(const VectorContainer& points, const std::vector<int>& sampling, QueryInput& queryInput, typename DataPoint::Scalar r, NeighborsIndexRange& neighbors) {
-	using Scalar     = typename DataPoint::Scalar;
-	using VectorType = typename DataPoint::VectorType;
-
-	if (hasDuplicate(neighbors))
-		return false;
-
-	VectorType point;
-	constexpr bool isIndexQuery {std::is_same_v<QueryInput, int>}; // Determines if the query input is the eval point or it's index
-	if constexpr (isIndexQuery) { // queryInput == index of the eval point
-		auto it = std::find(neighbors.begin(), neighbors.end(), queryInput);
-		if (it != neighbors.end()) return false;
-
-		point = points[queryInput].pos();
-	} else { // queryInput == eval point
-		point = queryInput;
-	}
-
-	for (int idx : neighbors) {
-		if (std::find(sampling.begin(), sampling.end(), idx) == sampling.end())
-		{
-			std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
-			return false;
-		}
-		Scalar dist = (points[idx].pos() - point).norm();
-		if (r < dist)
-		{
-            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
-			return false;
-		}
-	}
-
-	for (int idx : sampling) {
-		if constexpr (isIndexQuery)
-			if (idx == queryInput) continue;
-
-		Scalar dist = (points[idx].pos() - point).norm();
-		auto it = std::find(neighbors.begin(), neighbors.end(), idx);
-		bool is_neighbor = it != neighbors.end();
-
-		if (is_neighbor && r < dist)
-		{
-            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
-			return false;
-		}
-		if (!is_neighbor && dist < r)
-		{
-            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
-			return false;
-		}
-	}
-	return true;
-}
-
-template<typename DataPoint, typename VectorContainer, typename QueryInput>
-bool checkKNearestNeighbors(const VectorContainer& points, QueryInput& queryInput, const int k, const std::vector<int>& neighbors)
+template <typename DataPoint, typename VectorContainer, typename QueryInput, typename NeighborsIndexRange>
+bool checkRangeNeighbors(const VectorContainer& points, const std::vector<int>& sampling, QueryInput& queryInput,
+                         typename DataPoint::Scalar r, NeighborsIndexRange& neighbors)
 {
-	using Scalar     = typename DataPoint::Scalar;
-	using VectorType = typename DataPoint::VectorType;
+    using Scalar     = typename DataPoint::Scalar;
+    using VectorType = typename DataPoint::VectorType;
 
-	VectorType point;
-	constexpr bool isIndexQuery {std::is_same_v<QueryInput, int>}; // Determines if the query input is the eval point or it's index
-	if constexpr (isIndexQuery) { // queryInput == index of the eval point
-		auto it = std::find(neighbors.begin(), neighbors.end(), queryInput);
-		if (it != neighbors.end()) return false;
+    if (hasDuplicate(neighbors))
+        return false;
 
-		point = points[queryInput].pos();
-	} else { // queryInput == eval point
-		point = queryInput;
-	}
+    VectorType point;
+    constexpr bool isIndexQuery{
+        std::is_same_v<QueryInput, int>}; // Determines if the query input is the eval point or it's index
+    if constexpr (isIndexQuery)
+    { // queryInput == index of the eval point
+        auto it = std::find(neighbors.begin(), neighbors.end(), queryInput);
+        if (it != neighbors.end())
+            return false;
 
-	if (int(points.size()) > k && int(neighbors.size()) != k)
-		return false;
+        point = points[queryInput].pos();
+    }
+    else
+    { // queryInput == eval point
+        point = queryInput;
+    }
 
-	if (hasDuplicate(neighbors))
-		return false;
-
-	Scalar max_dist = 0;
-	for (int idx : neighbors)
-		max_dist = std::max(max_dist, (points[idx].pos() - point).norm());
-
-	for (int idx = 0; idx<int(points.size()); ++idx)
-	{
-		if constexpr (isIndexQuery)
-			if (idx == queryInput) continue;
-
-		Scalar dist = (points[idx].pos() - point).norm();
-		auto it = std::find(neighbors.begin(), neighbors.end(), idx);
-		bool is_neighbor = it != neighbors.end();
-
-		if (is_neighbor && max_dist < dist)
-			return false;
-		if (!is_neighbor && dist < max_dist)
-			return false;
-	}
-	return true;
-}
-
-template<typename DataPoint, typename VectorContainer, typename QueryInput>
-bool checkKNearestNeighbors(const VectorContainer& points, const std::vector<int>& sampling, QueryInput& queryInput, const int k, const std::vector<int>& neighbors)
-{
-	using Scalar     = typename DataPoint::Scalar;
-	using VectorType = typename DataPoint::VectorType;
-
-	if (int(points.size()) > k && int(neighbors.size()) != k)
-		return false;
-
-	VectorType point;
-	constexpr bool isIndexQuery {std::is_same_v<QueryInput, int>}; // Determines if the query input is the eval point or it's index
-	if constexpr (isIndexQuery) { // queryInput == index of the eval point
-		auto it = std::find(neighbors.begin(), neighbors.end(), queryInput);
-		if (it != neighbors.end()) return false;
-
-		point = points[queryInput].pos();
-	} else { // queryInput == eval point
-		point = queryInput;
-	}
-
-	if (hasDuplicate(neighbors))
-		return false;
-
-	for (int idx : neighbors) {
-		if (std::find(sampling.begin(), sampling.end(), idx) == sampling.end())
-			return false;
-	}
-
-	Scalar max_dist = 0;
-	for (int idx : neighbors)
-		max_dist = std::max(max_dist, (points[idx].pos() - point).norm());
-
-	for (int idx : sampling) {
-		if constexpr (isIndexQuery)
-			if (idx == queryInput) continue;
-
-		Scalar dist = (points[idx].pos() - point).norm();
-		auto it = std::find(neighbors.begin(), neighbors.end(), idx);
-		bool is_neighbor = it != neighbors.end();
-
-		if (is_neighbor && max_dist < dist)
-		{
-			return false;
-		}
-		if (!is_neighbor && dist < max_dist)
-		{
+    for (int idx : neighbors)
+    {
+        if (std::find(sampling.begin(), sampling.end(), idx) == sampling.end())
+        {
             std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
-			return false;
-		}
-	}
-	return true;
+            return false;
+        }
+        Scalar dist = (points[idx].pos() - point).norm();
+        if (r < dist)
+        {
+            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
+            return false;
+        }
+    }
+
+    for (int idx : sampling)
+    {
+        if constexpr (isIndexQuery)
+            if (idx == queryInput)
+                continue;
+
+        Scalar dist      = (points[idx].pos() - point).norm();
+        auto it          = std::find(neighbors.begin(), neighbors.end(), idx);
+        bool is_neighbor = it != neighbors.end();
+
+        if (is_neighbor && r < dist)
+        {
+            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
+            return false;
+        }
+        if (!is_neighbor && dist < r)
+        {
+            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
+            return false;
+        }
+    }
+    return true;
 }
 
-template<typename DataPoint, typename VectorContainer, typename QueryInput>
+template <typename DataPoint, typename VectorContainer, typename QueryInput>
+bool checkKNearestNeighbors(const VectorContainer& points, QueryInput& queryInput, const int k,
+                            const std::vector<int>& neighbors)
+{
+    using Scalar     = typename DataPoint::Scalar;
+    using VectorType = typename DataPoint::VectorType;
+
+    VectorType point;
+    constexpr bool isIndexQuery{
+        std::is_same_v<QueryInput, int>}; // Determines if the query input is the eval point or it's index
+    if constexpr (isIndexQuery)
+    { // queryInput == index of the eval point
+        auto it = std::find(neighbors.begin(), neighbors.end(), queryInput);
+        if (it != neighbors.end())
+            return false;
+
+        point = points[queryInput].pos();
+    }
+    else
+    { // queryInput == eval point
+        point = queryInput;
+    }
+
+    if (int(points.size()) > k && int(neighbors.size()) != k)
+        return false;
+
+    if (hasDuplicate(neighbors))
+        return false;
+
+    Scalar max_dist = 0;
+    for (int idx : neighbors)
+        max_dist = std::max(max_dist, (points[idx].pos() - point).norm());
+
+    for (int idx = 0; idx < int(points.size()); ++idx)
+    {
+        if constexpr (isIndexQuery)
+            if (idx == queryInput)
+                continue;
+
+        Scalar dist      = (points[idx].pos() - point).norm();
+        auto it          = std::find(neighbors.begin(), neighbors.end(), idx);
+        bool is_neighbor = it != neighbors.end();
+
+        if (is_neighbor && max_dist < dist)
+            return false;
+        if (!is_neighbor && dist < max_dist)
+            return false;
+    }
+    return true;
+}
+
+template <typename DataPoint, typename VectorContainer, typename QueryInput>
+bool checkKNearestNeighbors(const VectorContainer& points, const std::vector<int>& sampling, QueryInput& queryInput,
+                            const int k, const std::vector<int>& neighbors)
+{
+    using Scalar     = typename DataPoint::Scalar;
+    using VectorType = typename DataPoint::VectorType;
+
+    if (int(points.size()) > k && int(neighbors.size()) != k)
+        return false;
+
+    VectorType point;
+    constexpr bool isIndexQuery{
+        std::is_same_v<QueryInput, int>}; // Determines if the query input is the eval point or it's index
+    if constexpr (isIndexQuery)
+    { // queryInput == index of the eval point
+        auto it = std::find(neighbors.begin(), neighbors.end(), queryInput);
+        if (it != neighbors.end())
+            return false;
+
+        point = points[queryInput].pos();
+    }
+    else
+    { // queryInput == eval point
+        point = queryInput;
+    }
+
+    if (hasDuplicate(neighbors))
+        return false;
+
+    for (int idx : neighbors)
+    {
+        if (std::find(sampling.begin(), sampling.end(), idx) == sampling.end())
+            return false;
+    }
+
+    Scalar max_dist = 0;
+    for (int idx : neighbors)
+        max_dist = std::max(max_dist, (points[idx].pos() - point).norm());
+
+    for (int idx : sampling)
+    {
+        if constexpr (isIndexQuery)
+            if (idx == queryInput)
+                continue;
+
+        Scalar dist      = (points[idx].pos() - point).norm();
+        auto it          = std::find(neighbors.begin(), neighbors.end(), idx);
+        bool is_neighbor = it != neighbors.end();
+
+        if (is_neighbor && max_dist < dist)
+        {
+            return false;
+        }
+        if (!is_neighbor && dist < max_dist)
+        {
+            std::cerr << "Test failed in : checkRangeNeighbors " << __FILE__ << " (" << __LINE__ << ")" << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename DataPoint, typename VectorContainer, typename QueryInput>
 bool checkNearestNeighbor(const VectorContainer& points, QueryInput& queryInput, int nearest)
 {
-    return checkKNearestNeighbors<DataPoint>(points, queryInput, 1, { nearest });
+    return checkKNearestNeighbors<DataPoint>(points, queryInput, 1, {nearest});
 }
 
-template<typename DataPoint, typename VectorContainer, typename QueryInput>
-bool checkNearestNeighbor(const VectorContainer& points, const std::vector<int>& sampling, QueryInput& queryInput, int nearest)
+template <typename DataPoint, typename VectorContainer, typename QueryInput>
+bool checkNearestNeighbor(const VectorContainer& points, const std::vector<int>& sampling, QueryInput& queryInput,
+                          int nearest)
 {
-    return checkKNearestNeighbors<DataPoint, VectorContainer>(points, sampling, queryInput, 1, { nearest });
+    return checkKNearestNeighbors<DataPoint, VectorContainer>(points, sampling, queryInput, 1, {nearest});
 }
 
-template<typename DataPoint>
-void generateData(std::vector<DataPoint>& points) {
-	using VectorType      = typename DataPoint::VectorType;
-	std::generate(points.begin(), points.end(), []() { return DataPoint(VectorType::Random()); });
+template <typename DataPoint>
+void generateData(std::vector<DataPoint>& points)
+{
+    using VectorType = typename DataPoint::VectorType;
+    std::generate(points.begin(), points.end(), []() { return DataPoint(VectorType::Random()); });
 }
 
 /*! \brief Builds the KdTree with the points values for testing
@@ -201,113 +228,104 @@ void generateData(std::vector<DataPoint>& points) {
  * \param sampling An empty integer vector, to output the sampled points
  * \return A unique pointer to the KdTree instance
  */
-template<typename DataPoint, template <typename> class KdTree = Ponca::KdTreeDense>
-std::unique_ptr<KdTree<DataPoint>> testBuildKdTree(std::vector<DataPoint>& points, std::vector<int>& sampling) {
-	if constexpr (KdTree<DataPoint>::SUPPORTS_SUBSAMPLING)
-	{
-		// Build to test subsampling
-		std::vector<int> indices(points.size());
-		std::iota(indices.begin(), indices.end(), 0);
-		sampling.resize(points.size() / 2);
+template <typename DataPoint, template <typename> class KdTree = Ponca::KdTreeDense>
+std::unique_ptr<KdTree<DataPoint>> testBuildKdTree(std::vector<DataPoint>& points, std::vector<int>& sampling)
+{
+    if constexpr (KdTree<DataPoint>::SUPPORTS_SUBSAMPLING)
+    {
+        // Build to test subsampling
+        std::vector<int> indices(points.size());
+        std::iota(indices.begin(), indices.end(), 0);
+        sampling.resize(points.size() / 2);
 
-		int seed = 0;
-		std::sample(indices.begin(), indices.end(), sampling.begin(), points.size() / 2, std::mt19937(seed));
+        int seed = 0;
+        std::sample(indices.begin(), indices.end(), sampling.begin(), points.size() / 2, std::mt19937(seed));
 
-		return std::make_unique<KdTree<DataPoint>>(points, sampling);
-	}
-	else
-	{
-		// Build to test without subsampling
-		sampling.resize(points.size());
-		std::iota(sampling.begin(), sampling.end(), 0);
+        return std::make_unique<KdTree<DataPoint>>(points, sampling);
+    }
+    else
+    {
+        // Build to test without subsampling
+        sampling.resize(points.size());
+        std::iota(sampling.begin(), sampling.end(), 0);
 
-		return std::make_unique<KdTree<DataPoint>>(points);
-	}
+        return std::make_unique<KdTree<DataPoint>>(points);
+    }
 }
 
-template< bool doIndexQuery,
-	typename DataPoint, typename PointContainer,
-	typename QueryFunctor, typename CheckQueryFunctor,
-	typename... QueryInputTypes>
-std::chrono::milliseconds
-testQuery(
-	PointContainer &points,
-	QueryFunctor callQuery,
-	CheckQueryFunctor checkQuery,
-	const int retry_number = 1,
-	QueryInputTypes &&... outs
-) {
-	using VectorType = typename DataPoint::VectorType;
-	const auto time = std::chrono::system_clock::now();
+template <bool doIndexQuery, typename DataPoint, typename PointContainer, typename QueryFunctor,
+          typename CheckQueryFunctor, typename... QueryInputTypes>
+std::chrono::milliseconds testQuery(PointContainer& points, QueryFunctor callQuery, CheckQueryFunctor checkQuery,
+                                    const int retry_number = 1, QueryInputTypes&&... outs)
+{
+    using VectorType = typename DataPoint::VectorType;
+    const auto time  = std::chrono::system_clock::now();
 
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-	for (int i = 0; i < points.size(); ++i) {
-		auto queryInput = [i]{
-			// Call query with index input
-			if constexpr (doIndexQuery)
-				return i;
-			// Call query with position input
-			else
-				return VectorType(VectorType::Random()); // values between [-1:1]
-		}(); // Either an index or a position
+    for (int i = 0; i < points.size(); ++i)
+    {
+        auto queryInput = [i] {
+            // Call query with index input
+            if constexpr (doIndexQuery)
+                return i;
+            // Call query with position input
+            else
+                return VectorType(VectorType::Random()); // values between [-1:1]
+        }(); // Either an index or a position
 
-		for (int j = 0; j < retry_number; ++j) {
-			std::vector<int> resQuery;
+        for (int j = 0; j < retry_number; ++j)
+        {
+            std::vector<int> resQuery;
 
-			for (int point_idx : callQuery(queryInput, std::forward<QueryInputTypes>(outs)...))
-				resQuery.push_back(point_idx);
+            for (int point_idx : callQuery(queryInput, std::forward<QueryInputTypes>(outs)...))
+                resQuery.push_back(point_idx);
 
-			VERIFY((checkQuery(queryInput, resQuery)));
-		}
-	}
-	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - time);
+            VERIFY((checkQuery(queryInput, resQuery)));
+        }
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - time);
 }
 
-template<bool doIndexQuery,
-	typename DataPoint, typename PointContainer,
-	typename MutableQueryFunctor, typename RegularQueryFunctor, typename CheckQueryFunctor,
-	typename... QueryInputTypes>
-std::chrono::milliseconds
-testQuery(
-	PointContainer& points,
-	MutableQueryFunctor callMutableQuery,
-	RegularQueryFunctor callRegularQuery,
-	CheckQueryFunctor checkQuery,
-	const int retry_number = 1,
-	QueryInputTypes&&... outs
-) {
-	using VectorType = typename DataPoint::VectorType;
-	const auto time = std::chrono::system_clock::now();
+template <bool doIndexQuery, typename DataPoint, typename PointContainer, typename MutableQueryFunctor,
+          typename RegularQueryFunctor, typename CheckQueryFunctor, typename... QueryInputTypes>
+std::chrono::milliseconds testQuery(PointContainer& points, MutableQueryFunctor callMutableQuery,
+                                    RegularQueryFunctor callRegularQuery, CheckQueryFunctor checkQuery,
+                                    const int retry_number = 1, QueryInputTypes&&... outs)
+{
+    using VectorType = typename DataPoint::VectorType;
+    const auto time  = std::chrono::system_clock::now();
 
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-	for (int i = 0; i < points.size(); ++i) {
+    for (int i = 0; i < points.size(); ++i)
+    {
 
-		auto queryInput = [i]{
-			// Do index query input
-			if constexpr (doIndexQuery)
-				return i;
-			// Do position query input
-			else
-				return VectorType(VectorType::Random()); // values between [-1:1]
-		}();
-		auto mutableQuery = callMutableQuery();
+        auto queryInput = [i] {
+            // Do index query input
+            if constexpr (doIndexQuery)
+                return i;
+            // Do position query input
+            else
+                return VectorType(VectorType::Random()); // values between [-1:1]
+        }();
+        auto mutableQuery = callMutableQuery();
 
-		for (int j = 0; j < retry_number; ++j) {
-			std::vector<int> resRegularQuery, resMutableQuery;
+        for (int j = 0; j < retry_number; ++j)
+        {
+            std::vector<int> resRegularQuery, resMutableQuery;
 
-			for (int point_idx : callRegularQuery(queryInput, std::forward<QueryInputTypes>(outs)...))
-				resRegularQuery.push_back(point_idx);
-			for (int point_idx : mutableQuery(queryInput, std::forward<QueryInputTypes>(outs)...))
-				resMutableQuery.push_back(point_idx);
+            for (int point_idx : callRegularQuery(queryInput, std::forward<QueryInputTypes>(outs)...))
+                resRegularQuery.push_back(point_idx);
+            for (int point_idx : mutableQuery(queryInput, std::forward<QueryInputTypes>(outs)...))
+                resMutableQuery.push_back(point_idx);
 
-			VERIFY((checkQuery(queryInput, resRegularQuery)));
-			VERIFY((checkQuery(queryInput, resMutableQuery)));
-		}
-	}
-	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - time);
+            VERIFY((checkQuery(queryInput, resRegularQuery)));
+            VERIFY((checkQuery(queryInput, resMutableQuery)));
+        }
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - time);
 }
 

--- a/tests/common/scalar_precision_check.h
+++ b/tests/common/scalar_precision_check.h
@@ -7,7 +7,6 @@
  \author Gael Guennebaud gael.guennebaud@inria.com
 */
 
-
 #pragma once
 
 #include <limits>
@@ -15,7 +14,7 @@
 #include <cmath>
 #include <algorithm>
 
-template <typename _lowPrecisionScalarT,typename _highPrecisionScalarT>
+template <typename _lowPrecisionScalarT, typename _highPrecisionScalarT>
 class ScalarPrecisionCheck;
 
 /*!
@@ -40,11 +39,11 @@ class ScalarPrecisionCheck;
     std::cout << c.lp() << " " << c.hp() << std::endl;
     \endcode
  */
-template <typename _lowPrecisionScalarT  = float,
-          typename _highPrecisionScalarT = double>
-class ScalarPrecisionCheck {
+template <typename _lowPrecisionScalarT = float, typename _highPrecisionScalarT = double>
+class ScalarPrecisionCheck
+{
 public:
-    typedef _lowPrecisionScalarT  LPScalar;
+    typedef _lowPrecisionScalarT LPScalar;
     typedef _highPrecisionScalarT HPScalar;
 
     inline ScalarPrecisionCheck() {}
@@ -52,40 +51,37 @@ public:
     /*!
      */
     template <typename RealScalar>
-    inline ScalarPrecisionCheck(RealScalar v)
-        : _lp(v), _hp(v) {
+    inline ScalarPrecisionCheck(RealScalar v) : _lp(v), _hp(v)
+    {
         precision_assert(*this);
     }
 
-    inline ScalarPrecisionCheck(const ScalarPrecisionCheck& __rhs)
-        : _lp(__rhs._lp), _hp(__rhs._hp) {
+    inline ScalarPrecisionCheck(const ScalarPrecisionCheck& __rhs) : _lp(__rhs._lp), _hp(__rhs._hp)
+    {
         precision_assert(*this);
-
     }
 
-    inline ScalarPrecisionCheck(LPScalar lp,
-                                HPScalar hp)
-        : _lp(lp), _hp(hp) {
-        //if(CheckEnabled && relativePrecisionDelta()>0)
-        //  std::cerr << "    " << _lp << " " << _hp << " -> " << relativePrecisionDelta() << "\n";
+    inline ScalarPrecisionCheck(LPScalar lp, HPScalar hp) : _lp(lp), _hp(hp)
+    {
+        // if(CheckEnabled && relativePrecisionDelta()>0)
+        //   std::cerr << "    " << _lp << " " << _hp << " -> " << relativePrecisionDelta() << "\n";
         precision_assert(*this);
     }
 
     inline HPScalar precisionDelta() const { return std::abs(HPScalar(_lp) - _hp); }
-    inline HPScalar relativePrecisionDelta() const {
-      using std::abs;
-      using std::max;
-      using std::min;
-      HPScalar diff = abs(HPScalar(_lp) - _hp);
-      if(min(abs(HPScalar(_lp)),abs(_hp))<7e-5)
-        return 0;
-      return diff<std::numeric_limits<LPScalar>::min() ? 0 : diff/abs(HPScalar(_hp));
+    inline HPScalar relativePrecisionDelta() const
+    {
+        using std::abs;
+        using std::max;
+        using std::min;
+        HPScalar diff = abs(HPScalar(_lp) - _hp);
+        if (min(abs(HPScalar(_lp)), abs(_hp)) < 7e-5)
+            return 0;
+        return diff < std::numeric_limits<LPScalar>::min() ? 0 : diff / abs(HPScalar(_hp));
     }
-    inline bool checkPrecision() const {
-      return ( relativePrecisionDelta() < epsilon);
-    }
+    inline bool checkPrecision() const { return (relativePrecisionDelta() < epsilon); }
 
-    operator const LPScalar () const { return _lp; }
+    operator const LPScalar() const { return _lp; }
     inline LPScalar lp() const { return _lp; }
     inline HPScalar hp() const { return _hp; }
 
@@ -93,42 +89,52 @@ public:
     /// Pairwise operators between ScalarPrecisionChecks
     ///
     inline ScalarPrecisionCheck operator*(const ScalarPrecisionCheck& __rhs) const
-    { return ScalarPrecisionCheck ( _lp * __rhs._lp, _hp * __rhs._hp ); }
+    {
+        return ScalarPrecisionCheck(_lp * __rhs._lp, _hp * __rhs._hp);
+    }
 
     inline ScalarPrecisionCheck operator/(const ScalarPrecisionCheck& __rhs) const
-    { return ScalarPrecisionCheck ( _lp / __rhs._lp, _hp / __rhs._hp ); }
+    {
+        return ScalarPrecisionCheck(_lp / __rhs._lp, _hp / __rhs._hp);
+    }
 
     inline ScalarPrecisionCheck operator+(const ScalarPrecisionCheck& __rhs) const
-    { return ScalarPrecisionCheck ( _lp + __rhs._lp, _hp + __rhs._hp ); }
+    {
+        return ScalarPrecisionCheck(_lp + __rhs._lp, _hp + __rhs._hp);
+    }
 
     inline ScalarPrecisionCheck operator-(const ScalarPrecisionCheck& __rhs) const
-    { return ScalarPrecisionCheck ( _lp - __rhs._lp, _hp - __rhs._hp ); }
+    {
+        return ScalarPrecisionCheck(_lp - __rhs._lp, _hp - __rhs._hp);
+    }
 
-    inline ScalarPrecisionCheck& operator*=(const ScalarPrecisionCheck& __rhs)
-    { return *this = __rhs * (*this); }
+    inline ScalarPrecisionCheck& operator*=(const ScalarPrecisionCheck& __rhs) { return *this = __rhs * (*this); }
 
-    inline ScalarPrecisionCheck& operator/=(const ScalarPrecisionCheck& __rhs)
-    { return *this = __rhs / (*this); }
+    inline ScalarPrecisionCheck& operator/=(const ScalarPrecisionCheck& __rhs) { return *this = __rhs / (*this); }
 
-     inline ScalarPrecisionCheck& operator+=(const ScalarPrecisionCheck& __rhs)
-    { return *this = __rhs + (*this); }
+    inline ScalarPrecisionCheck& operator+=(const ScalarPrecisionCheck& __rhs) { return *this = __rhs + (*this); }
 
-     inline ScalarPrecisionCheck& operator-=(const ScalarPrecisionCheck& __rhs)
-    { return *this = __rhs - (*this); }
+    inline ScalarPrecisionCheck& operator-=(const ScalarPrecisionCheck& __rhs) { return *this = __rhs - (*this); }
 
     inline bool operator<(const ScalarPrecisionCheck& __rhs) const
-    { return AND_assert( _lp < __rhs._lp, _hp < __rhs._hp ); }
-
+    {
+        return AND_assert(_lp < __rhs._lp, _hp < __rhs._hp);
+    }
 
     inline bool operator>(const ScalarPrecisionCheck& __rhs) const
-    { return AND_assert( _lp > __rhs._lp, _hp > __rhs._hp ); }
+    {
+        return AND_assert(_lp > __rhs._lp, _hp > __rhs._hp);
+    }
 
     inline bool operator==(const ScalarPrecisionCheck& __rhs) const
-    { return AND_assert( _lp == __rhs._lp, _hp == __rhs._hp ); }
-
+    {
+        return AND_assert(_lp == __rhs._lp, _hp == __rhs._hp);
+    }
 
     inline bool operator!=(const ScalarPrecisionCheck& __rhs) const
-    { return AND_assert( _lp != __rhs._lp, _hp != __rhs._hp ); }
+    {
+        return AND_assert(_lp != __rhs._lp, _hp != __rhs._hp);
+    }
 
 public:
     static HPScalar epsilon;
@@ -139,61 +145,69 @@ private:
     HPScalar _hp;
     static inline const ScalarPrecisionCheck& precision_assert(const ScalarPrecisionCheck& s)
     {
-      if(check_enabled) assert(s.checkPrecision());
-      return s;
+        if (check_enabled)
+            assert(s.checkPrecision());
+        return s;
     }
 
     static inline bool AND_assert(bool lp, bool hp)
     {
-      if(check_enabled) assert (lp==hp);
-      return lp && hp;
+        if (check_enabled)
+            assert(lp == hp);
+        return lp && hp;
     }
 
 }; // class ScalarPrecisionCheck
 
 template <typename lps, typename hps>
-hps ScalarPrecisionCheck<lps,hps>::epsilon = 2*std::numeric_limits<lps>::epsilon();
+hps ScalarPrecisionCheck<lps, hps>::epsilon = 2 * std::numeric_limits<lps>::epsilon();
 
 template <typename lps, typename hps>
-bool ScalarPrecisionCheck<lps,hps>::check_enabled = true;
+bool ScalarPrecisionCheck<lps, hps>::check_enabled = true;
 
 // create definitions for common std math functions
-namespace std{
-template <typename lps, typename hps>
-inline ScalarPrecisionCheck<lps,hps> abs(const ScalarPrecisionCheck<lps,hps>& spc){
-    return ScalarPrecisionCheck<lps,hps>(std::abs(spc.lp()), std::abs(spc.hp()));
-}
+namespace std
+{
+    template <typename lps, typename hps>
+    inline ScalarPrecisionCheck<lps, hps> abs(const ScalarPrecisionCheck<lps, hps>& spc)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::abs(spc.lp()), std::abs(spc.hp()));
+    }
 
-template <typename lps, typename hps, typename PowScalar>
-inline ScalarPrecisionCheck<lps,hps> pow(const ScalarPrecisionCheck<lps,hps>& spc, PowScalar p){
-    return ScalarPrecisionCheck<lps,hps>(std::pow(spc.lp(), p), std::pow(spc.hp(), p));
-}
+    template <typename lps, typename hps, typename PowScalar>
+    inline ScalarPrecisionCheck<lps, hps> pow(const ScalarPrecisionCheck<lps, hps>& spc, PowScalar p)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::pow(spc.lp(), p), std::pow(spc.hp(), p));
+    }
 
-template <typename lps, typename hps>
-inline ScalarPrecisionCheck<lps,hps> sqrt(const ScalarPrecisionCheck<lps,hps>& spc){
-    return ScalarPrecisionCheck<lps,hps>(std::sqrt(spc.lp()), std::sqrt(spc.hp()));
-}
+    template <typename lps, typename hps>
+    inline ScalarPrecisionCheck<lps, hps> sqrt(const ScalarPrecisionCheck<lps, hps>& spc)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::sqrt(spc.lp()), std::sqrt(spc.hp()));
+    }
 
-template <typename lps, typename hps>
-inline ScalarPrecisionCheck<lps,hps> cos(const ScalarPrecisionCheck<lps,hps>& spc){
-    return ScalarPrecisionCheck<lps,hps>(std::cos(spc.lp()), std::cos(spc.hp()));
-}
+    template <typename lps, typename hps>
+    inline ScalarPrecisionCheck<lps, hps> cos(const ScalarPrecisionCheck<lps, hps>& spc)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::cos(spc.lp()), std::cos(spc.hp()));
+    }
 
-template <typename lps, typename hps>
-inline ScalarPrecisionCheck<lps,hps> sin(
-        const ScalarPrecisionCheck<lps,hps>& spc){
-    return ScalarPrecisionCheck<lps,hps>(std::sin(spc.lp()),
-                                                std::sin(spc.hp()));
-}
+    template <typename lps, typename hps>
+    inline ScalarPrecisionCheck<lps, hps> sin(const ScalarPrecisionCheck<lps, hps>& spc)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::sin(spc.lp()), std::sin(spc.hp()));
+    }
 
-template <typename lps, typename hps>
-inline ScalarPrecisionCheck<lps,hps> tan(const ScalarPrecisionCheck<lps,hps>& spc){
-    return ScalarPrecisionCheck<lps,hps>(std::tan(spc.lp()), std::tan(spc.hp()));
-}
+    template <typename lps, typename hps>
+    inline ScalarPrecisionCheck<lps, hps> tan(const ScalarPrecisionCheck<lps, hps>& spc)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::tan(spc.lp()), std::tan(spc.hp()));
+    }
 
-template <typename lps, typename hps>
-inline ScalarPrecisionCheck<lps,hps> atan(const ScalarPrecisionCheck<lps,hps>& spc){
-    return ScalarPrecisionCheck<lps,hps>(std::atan(spc.lp()), std::atan(spc.hp()));
-}
+    template <typename lps, typename hps>
+    inline ScalarPrecisionCheck<lps, hps> atan(const ScalarPrecisionCheck<lps, hps>& spc)
+    {
+        return ScalarPrecisionCheck<lps, hps>(std::atan(spc.lp()), std::atan(spc.hp()));
+    }
 
 } // namespace std

--- a/tests/common/testUtils.h
+++ b/tests/common/testUtils.h
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
   \file test/common/testUtils.h
   \brief Useful functions for tests
@@ -21,41 +20,45 @@
 #include <vector>
 
 // Epsilon precision
-template<typename T> inline T testEpsilon()
+template <typename T>
+inline T testEpsilon()
 {
     return Eigen::NumTraits<T>::dummy_precision();
 }
 
-template<> inline float testEpsilon<float>()
+template <>
+inline float testEpsilon<float>()
 {
     return 1e-2f;
 }
 
-template<> inline double testEpsilon<double>()
+template <>
+inline double testEpsilon<double>()
 {
     return 1e-5;
 }
 
-template<> inline long double testEpsilon<long double>()
+template <>
+inline long double testEpsilon<long double>()
 {
     return 1e-5;
 }
 
-template<typename DataPoint>
+template <typename DataPoint>
 void reverseNormals(std::vector<DataPoint>& _dest, const std::vector<DataPoint>& _src, bool _bRandom = true)
 {
     typedef typename DataPoint::VectorType VectorType;
 
     VectorType vNormal;
 
-    for(unsigned int i = 0; i < _src.size(); ++i)
+    for (unsigned int i = 0; i < _src.size(); ++i)
     {
         vNormal = _src[i].normal();
 
-        if(_bRandom)
+        if (_bRandom)
         {
             float reverse = Eigen::internal::random<float>(0.f, 1.f);
-            if(reverse > 0.5f)
+            if (reverse > 0.5f)
             {
                 vNormal = -vNormal;
             }
@@ -69,8 +72,9 @@ void reverseNormals(std::vector<DataPoint>& _dest, const std::vector<DataPoint>&
     }
 }
 
-template<typename DataPoint>
-typename DataPoint::Scalar getPointKappaMean(typename DataPoint::VectorType _vPoint, typename DataPoint::Scalar _a, typename DataPoint::Scalar _b)
+template <typename DataPoint>
+typename DataPoint::Scalar getPointKappaMean(typename DataPoint::VectorType _vPoint, typename DataPoint::Scalar _a,
+                                             typename DataPoint::Scalar _b)
 {
     typedef typename DataPoint::Scalar Scalar;
 
@@ -82,29 +86,30 @@ typename DataPoint::Scalar getPointKappaMean(typename DataPoint::VectorType _vPo
 
     Scalar num = (1 + ax2) * _b + (1 + by2) * _a;
     Scalar den = (1 + ax2 + by2);
-    den = std::pow(den, Scalar(3./2.));
+    den        = std::pow(den, Scalar(3. / 2.));
 
     Scalar kappa = num / den * Scalar(0.5);
 
     return kappa;
 }
 
-template<typename DataPoint>
-typename DataPoint::Scalar getKappaMean(const std::vector<DataPoint>& _vectorPoints, typename DataPoint::VectorType _vCenter,
-                                        typename DataPoint::Scalar _a, typename DataPoint::Scalar _b, typename DataPoint::Scalar _analysisScale)
+template <typename DataPoint>
+typename DataPoint::Scalar getKappaMean(const std::vector<DataPoint>& _vectorPoints,
+                                        typename DataPoint::VectorType _vCenter, typename DataPoint::Scalar _a,
+                                        typename DataPoint::Scalar _b, typename DataPoint::Scalar _analysisScale)
 {
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    int size = static_cast<int>(_vectorPoints.size());
+    int size         = static_cast<int>(_vectorPoints.size());
     Scalar kappaMean = 0.;
-    int nbNei = 0;
+    int nbNei        = 0;
 
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         VectorType q = _vectorPoints[i].pos() - _vCenter;
 
-        if(q.norm() <= _analysisScale)
+        if (q.norm() <= _analysisScale)
         {
             kappaMean += getPointKappaMean<DataPoint>(_vectorPoints[i].pos(), _a, _b);
             ++nbNei;
@@ -114,26 +119,29 @@ typename DataPoint::Scalar getKappaMean(const std::vector<DataPoint>& _vectorPoi
     return kappaMean / nbNei;
 }
 
-template<typename Fit1, typename Fit2>
-void isSamePlane(const Fit1& fit1, const Fit2& fit2) {
-    const auto &plane1 = fit1.compactPlane();
-    const auto &plane2 = fit2.compactPlane();
+template <typename Fit1, typename Fit2>
+void isSamePlane(const Fit1& fit1, const Fit2& fit2)
+{
+    const auto& plane1 = fit1.compactPlane();
+    const auto& plane2 = fit2.compactPlane();
 
     // Test we fit the same plane
     VERIFY(plane1.isApprox(plane2));
 }
 
-template<typename Fit1, typename Fit2>
-void isSameSphere(const Fit1& fit1, const Fit2& fit2) {
-    const auto &sphere1 = fit1.algebraicSphere();
-    const auto &sphere2 = fit2.algebraicSphere();
+template <typename Fit1, typename Fit2>
+void isSameSphere(const Fit1& fit1, const Fit2& fit2)
+{
+    const auto& sphere1 = fit1.algebraicSphere();
+    const auto& sphere2 = fit2.algebraicSphere();
 
     // Test we fit the same plane
     VERIFY(sphere1 == sphere2);
 }
 
-template<typename Fit1, typename Fit2>
-void hasSamePlaneDerivatives(const Fit1& fit1, const Fit2& fit2) {
+template <typename Fit1, typename Fit2>
+void hasSamePlaneDerivatives(const Fit1& fit1, const Fit2& fit2)
+{
     // Get covariance
     const auto& dpot1 = fit1.covariancePlaneDer().dPotential();
     const auto& dpot2 = fit2.covariancePlaneDer().dPotential();
@@ -141,6 +149,6 @@ void hasSamePlaneDerivatives(const Fit1& fit1, const Fit2& fit2) {
     const auto& dnor2 = fit2.covariancePlaneDer().dNormal();
 
     // Test we compute the same derivatives
-    VERIFY(dpot1.isApprox( dpot2 ));
-    VERIFY(dnor1.isApprox( dnor2 ));
+    VERIFY(dpot1.isApprox(dpot2));
+    VERIFY(dnor1.isApprox(dnor2));
 }

--- a/tests/common/testing.h
+++ b/tests/common/testing.h
@@ -6,7 +6,6 @@
 
 // Part of this file has been adapted from the Eigen library.
 
-
 #pragma once
 
 #include <iostream>
@@ -16,28 +15,28 @@
 #include <sstream>
 #include <ctime>
 
-#if defined (_MSC_VER)
-#	define _USE_MATH_DEFINES
-#	include <cmath>
+#if defined(_MSC_VER)
+#    define _USE_MATH_DEFINES
+#    include <cmath>
 #endif
 
 #ifdef PONCA_COVERAGE_ENABLED
-#define DEFAULT_REPEAT 1
+#    define DEFAULT_REPEAT 1
 #else
-#define DEFAULT_REPEAT 10
+#    define DEFAULT_REPEAT 10
 #endif
 
 static bool QUICK_TESTS =
 #ifdef PONCA_COVERAGE_ENABLED
-        true;
+    true;
 #else
-false;
+    false;
 #endif
 
 #ifdef PONCA_COVERAGE_ENABLED
-#include "Ponca/Common"
-#include "Ponca/Fitting"
-#include "Ponca/SpatialPartitioning"
+#    include "Ponca/Common"
+#    include "Ponca/Fitting"
+#    include "Ponca/SpatialPartitioning"
 #endif
 
 #define PONCA_PP_MAKE_STRING2(S) #S
@@ -48,100 +47,104 @@ static int g_repeat;
 static unsigned int g_seed;
 static bool g_has_set_repeat, g_has_set_seed;
 
-void verify_impl(bool condition, const char *testname, const char *file, int line, const char *condition_as_string)
+void verify_impl(bool condition, const char* testname, const char* file, int line, const char* condition_as_string)
 {
-  if (!condition)
-  {
-    std::cerr << "Test " << testname << " failed in " << file << " (" << line << ")"
-      << std::endl << "    " << condition_as_string << std::endl;
-    abort();
-  }
+    if (!condition)
+    {
+        std::cerr << "Test " << testname << " failed in " << file << " (" << line << ")" << std::endl
+                  << "    " << condition_as_string << std::endl;
+        abort();
+    }
 }
 
 #define VERIFY(a) ::verify_impl(a, g_test_stack.back().c_str(), __FILE__, __LINE__, PONCA_PP_MAKE_STRING(a))
 
-#define CALL_SUBTEST(FUNC) do { \
-    g_test_stack.emplace_back(PONCA_PP_MAKE_STRING(FUNC)); \
-    FUNC; \
-    g_test_stack.pop_back(); \
-  } while (0)
+#define CALL_SUBTEST(FUNC)                                     \
+    do                                                         \
+    {                                                          \
+        g_test_stack.emplace_back(PONCA_PP_MAKE_STRING(FUNC)); \
+        FUNC;                                                  \
+        g_test_stack.pop_back();                               \
+    } while (0)
 
-inline void set_repeat_from_string(const char *str)
+inline void set_repeat_from_string(const char* str)
 {
-  errno = 0;
-  g_repeat = int(strtoul(str, 0, 10));
-  if(errno || g_repeat <= 0)
-  {
-    std::cout << "Invalid repeat value " << str << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  g_has_set_repeat = true;
-}
-
-inline void set_seed_from_string(const char *str)
-{
-  errno = 0;
-  g_seed = int(strtoul(str, 0, 10));
-  if(errno || g_seed == 0)
-  {
-    std::cout << "Invalid seed value " << str << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  g_has_set_seed = true;
-}
-
-static bool init_testing(int argc, char *argv[])
-{
-  g_has_set_repeat = false;
-  g_has_set_seed   = false;
-  bool need_help   = false;
-
-  for(int i = 1; i < argc; i++)
-  {
-    if(argv[i][0] == 'r')
+    errno    = 0;
+    g_repeat = int(strtoul(str, 0, 10));
+    if (errno || g_repeat <= 0)
     {
-      if(g_has_set_repeat)
-      {
-        std::cout << "Argument " << argv[i] << " conflicting with a former argument" << std::endl;
-        return 1;
-      }
-      set_repeat_from_string(argv[i]+1);
+        std::cout << "Invalid repeat value " << str << std::endl;
+        exit(EXIT_FAILURE);
     }
-    else if(argv[i][0] == 's')
+    g_has_set_repeat = true;
+}
+
+inline void set_seed_from_string(const char* str)
+{
+    errno  = 0;
+    g_seed = int(strtoul(str, 0, 10));
+    if (errno || g_seed == 0)
     {
-      if(g_has_set_seed)
-      {
-        std::cout << "Argument " << argv[i] << " conflicting with a former argument" << std::endl;
+        std::cout << "Invalid seed value " << str << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    g_has_set_seed = true;
+}
+
+static bool init_testing(int argc, char* argv[])
+{
+    g_has_set_repeat = false;
+    g_has_set_seed   = false;
+    bool need_help   = false;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (argv[i][0] == 'r')
+        {
+            if (g_has_set_repeat)
+            {
+                std::cout << "Argument " << argv[i] << " conflicting with a former argument" << std::endl;
+                return 1;
+            }
+            set_repeat_from_string(argv[i] + 1);
+        }
+        else if (argv[i][0] == 's')
+        {
+            if (g_has_set_seed)
+            {
+                std::cout << "Argument " << argv[i] << " conflicting with a former argument" << std::endl;
+                return false;
+            }
+            set_seed_from_string(argv[i] + 1);
+        }
+        else
+        {
+            need_help = true;
+        }
+    }
+
+    if (need_help)
+    {
+        std::cout << "This test application takes the following optional arguments:" << std::endl;
+        std::cout << "  rN     Repeat each test N times (default: " << DEFAULT_REPEAT << ")" << std::endl;
+        std::cout << "  sN     Use N as seed for random numbers (default: based on current time)" << std::endl;
+        std::cout << std::endl;
+        std::cout << "If defined, the environment variables EIGEN_REPEAT and EIGEN_SEED" << std::endl;
+        std::cout << "will be used as default values for these parameters." << std::endl;
         return false;
-      }
-        set_seed_from_string(argv[i]+1);
     }
-    else
-    {
-      need_help = true;
-    }
-  }
 
-  if(need_help)
-  {
-    std::cout << "This test application takes the following optional arguments:" << std::endl;
-    std::cout << "  rN     Repeat each test N times (default: " << DEFAULT_REPEAT << ")" << std::endl;
-    std::cout << "  sN     Use N as seed for random numbers (default: based on current time)" << std::endl;
-    std::cout << std::endl;
-    std::cout << "If defined, the environment variables EIGEN_REPEAT and EIGEN_SEED" << std::endl;
-    std::cout << "will be used as default values for these parameters." << std::endl;
-    return false;
-  }
+    if (!g_has_set_seed)
+        g_seed = (unsigned int)time(NULL);
+    if (!g_has_set_repeat)
+        g_repeat = DEFAULT_REPEAT;
 
-  if(!g_has_set_seed) g_seed = (unsigned int) time(NULL);
-  if(!g_has_set_repeat) g_repeat = DEFAULT_REPEAT;
+    std::cout << "Initializing random number generator with seed " << g_seed << std::endl;
+    std::stringstream ss;
+    ss << "Seed: " << g_seed;
+    g_test_stack.push_back(ss.str());
+    srand(g_seed);
+    std::cout << "Repeating each test " << g_repeat << " times" << std::endl;
 
-  std::cout << "Initializing random number generator with seed " << g_seed << std::endl;
-  std::stringstream ss;
-  ss << "Seed: " << g_seed;
-  g_test_stack.push_back(ss.str());
-  srand(g_seed);
-  std::cout << "Repeating each test " << g_repeat << " times" << std::endl;
-
-  return true;
+    return true;
 }

--- a/tests/src/barycenter.cpp
+++ b/tests/src/barycenter.cpp
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-template<typename DataPoint, typename FitA, typename FitB>
+template <typename DataPoint, typename FitA, typename FitB>
 void compareFit(const bool _bAddPositionNoise = false, const bool _bAddNormalNoise = false)
 {
     // Define related structure
@@ -33,12 +33,14 @@ void compareFit(const bool _bAddPositionNoise = false, const bool _bAddNormalNoi
     const VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 5);
 
     std::vector<DataPoint> vectorPoints(nbPoints);
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
-        vectorPoints[i] = Ponca::getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise, false);
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
+        vectorPoints[i] =
+            Ponca::getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise, false);
 
     // the fittingScale must be large enough so that all the points included, otherwise it is not possible to compare
     // local and global fits, as local fits will discard all points whose distance is larger than radius.
-    const Scalar fittingScale = center.norm() + Scalar(1.1)*radius; //radius is slightly increased to avoid approx errors
+    const Scalar fittingScale =
+        center.norm() + Scalar(1.1) * radius; // radius is slightly increased to avoid approx errors
 
     FitA fitA;
     FitB fitB;
@@ -50,33 +52,38 @@ void compareFit(const bool _bAddPositionNoise = false, const bool _bAddNormalNoi
     // Barycenter should also be somewhat close to the center
     auto epsilon = Scalar(0.01); // Greater tolerance
 
-    try {
+    try
+    {
         VERIFY(((fitA.barycenter() - fitB.barycenter()).norm() < epsilon));
         // here we have imprecision as the sphere is poorly sampled, so the barycenter can be quite far from sphere
         // center. To be conservative, we consider that it cannot be outside a sphere of radius 10% smaller than the
         // theoretical one, but colocated.
-        VERIFY(((center - fitA.barycenter()).norm() < radius*Scalar(0.1)));
-    } catch (const std::exception& /*e*/) {
+        VERIFY(((center - fitA.barycenter()).norm() < radius * Scalar(0.1)));
+    }
+    catch (const std::exception& /*e*/)
+    {
         std::cout << "Sphere radius : " << radius << std::endl;
         std::cout << "Fit scale : " << fittingScale << std::endl;
         std::cout << "Nb points : " << nbPoints << std::endl;
         std::cout << "True center : { " << center.transpose() << " }" << std::endl;
         std::cout << "fitA.barycenter() : { " << fitA.barycenter().transpose() << " }" << std::endl;
         std::cout << "fitB.barycenter() : { " << fitB.barycenter().transpose() << " }" << std::endl;
-        std::cout << "(fitA-fitB).barycenter() : { " << (fitA.barycenter()-fitB.barycenter()).transpose() << " }" << std::endl;
-        std::cout << "(fitA-fitB).barycenter().norm() : { " << (fitA.barycenter()-fitB.barycenter()).norm() << " }" << std::endl;
+        std::cout << "(fitA-fitB).barycenter() : { " << (fitA.barycenter() - fitB.barycenter()).transpose() << " }"
+                  << std::endl;
+        std::cout << "(fitA-fitB).barycenter().norm() : { " << (fitA.barycenter() - fitB.barycenter()).norm() << " }"
+                  << std::endl;
         std::cout << "fitA.barycenter() distance from center : " << (center - fitA.barycenter()).norm() << std::endl;
         std::cout << "fitB.barycenter() distance from center : " << (center - fitB.barycenter()).norm() << std::endl;
         throw;
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef Ponca::PointPositionNormal<Scalar, Dim> Point;
 
-    typedef Ponca::DistWeightFunc<Point, Ponca::ConstantWeightKernel<Scalar> > WeightConstantFuncLocal;
+    typedef Ponca::DistWeightFunc<Point, Ponca::ConstantWeightKernel<Scalar>> WeightConstantFuncLocal;
     typedef Ponca::NoWeightFuncGlobal<Point> NoWeightFuncGlobal;
     typedef Ponca::NoWeightFunc<Point> NoWeightFunc;
 
@@ -84,17 +91,18 @@ void callSubTests()
     typedef Ponca::Basket<Point, NoWeightFunc, Ponca::MeanPosition> FitNoWeightLocal;
     typedef Ponca::Basket<Point, NoWeightFuncGlobal, Ponca::MeanPosition> FitNoWeightGlobal;
 
-    for(int i = 0; i < g_repeat; ++i) {
+    for (int i = 0; i < g_repeat; ++i)
+    {
         // check if, in local basis, no weight is equivalent to constant weight
-        CALL_SUBTEST(( compareFit<Point, FitConstantLocal, FitNoWeightLocal>( )));
+        CALL_SUBTEST((compareFit<Point, FitConstantLocal, FitNoWeightLocal>()));
         // check that no weight is stable in both local and global frames
-        CALL_SUBTEST(( compareFit<Point, FitNoWeightGlobal, FitNoWeightLocal>( )));
+        CALL_SUBTEST((compareFit<Point, FitNoWeightGlobal, FitNoWeightLocal>()));
     }
 }
 
 int main(const int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
         return EXIT_FAILURE;
 
     cout << "Test Global / Local Weight Func" << endl;

--- a/tests/src/basket.cpp
+++ b/tests/src/basket.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/basket.cpp
     \brief Test basket utility functions
@@ -27,13 +26,13 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint>
+template <typename DataPoint>
 typename DataPoint::Scalar generateData(KdTree<DataPoint>& tree)
 {
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
 #ifdef NDEBUG
     int nbPoints = Eigen::internal::random<int>(500, 1000);
 #else
@@ -42,16 +41,16 @@ typename DataPoint::Scalar generateData(KdTree<DataPoint>& tree)
 
     Scalar radius = Eigen::internal::random<Scalar>(1., 10.);
 
-    Scalar analysisScale = Scalar(10.) * std::sqrt( Scalar(4. * M_PI) * radius * radius / nbPoints);
-    Scalar centerScale = Eigen::internal::random<Scalar>(1,10000);
-    VectorType center = VectorType::Random() * centerScale;
+    Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
+    VectorType center    = VectorType::Random() * centerScale;
 
     vector<DataPoint> vectorPoints(nbPoints);
 
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < int(vectorPoints.size()); ++i)
+    for (int i = 0; i < int(vectorPoints.size()); ++i)
     {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, false, false, false);
     }
@@ -61,7 +60,7 @@ typename DataPoint::Scalar generateData(KdTree<DataPoint>& tree)
     return analysisScale;
 }
 
-template<typename Fit>
+template <typename Fit>
 void testBasicFunctionalities(const KdTree<typename Fit::DataPoint>& tree, typename Fit::Scalar analysisScale)
 {
     using DataPoint = typename Fit::DataPoint;
@@ -76,19 +75,19 @@ void testBasicFunctionalities(const KdTree<typename Fit::DataPoint>& tree, typen
 
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
-        const auto &fitInitPos = vectorPoints[i].pos();
+        const auto& fitInitPos = vectorPoints[i].pos();
 
         // use addNeighbor
         //! [Fit Manual Traversal]
         Fit fit;
         fit.setNeighborFilter({fitInitPos, analysisScale});
         fit.init();
-        for(auto it = vectorPoints.begin(); it != vectorPoints.end(); ++it)
-           fit.addNeighbor(*it);
+        for (auto it = vectorPoints.begin(); it != vectorPoints.end(); ++it)
+            fit.addNeighbor(*it);
         fit.finalize();
         //! [Fit Manual Traversal]
 
@@ -104,9 +103,9 @@ void testBasicFunctionalities(const KdTree<typename Fit::DataPoint>& tree, typen
         VERIFY(fit1 == fit1);
         VERIFY(fit == fit1);
         VERIFY(fit1 == fit);
-        VERIFY(! (fit != fit));
-        VERIFY(! (fit != fit1));
-        VERIFY(! (fit1 != fit1));
+        VERIFY(!(fit != fit));
+        VERIFY(!(fit != fit1));
+        VERIFY(!(fit1 != fit1));
 
         Fit fit2;
         fit2.setNeighborFilter({fitInitPos, analysisScale});
@@ -116,22 +115,22 @@ void testBasicFunctionalities(const KdTree<typename Fit::DataPoint>& tree, typen
             neighbors2.push_back(iNeighbor);
         neighbors2.sort();
         // Compute the neighbors
-        fit2.computeWithIds( neighbors2, vectorPoints );
+        fit2.computeWithIds(neighbors2, vectorPoints);
 
         VERIFY(fit2 == fit2);
         VERIFY(fit == fit2);
-        VERIFY(! (fit != fit2));
+        VERIFY(!(fit != fit2));
         VERIFY(fit2 == fit);
     }
 }
 
-template<typename Fit1, typename Fit2, typename Functor>
-void testIsSame(const KdTree<typename Fit1::DataPoint>& tree,
-                typename Fit1::Scalar analysisScale,
-                Functor f)
+template <typename Fit1, typename Fit2, typename Functor>
+void testIsSame(const KdTree<typename Fit1::DataPoint>& tree, typename Fit1::Scalar analysisScale, Functor f)
 {
-    static_assert(std::is_same<typename Fit1::DataPoint, typename Fit2::DataPoint>::value, "Both Fit should use the same point type");
-    static_assert(std::is_same<typename Fit1::NeighborFilter, typename Fit2::NeighborFilter>::value, "Both Fit should use the same NeighborFilter");
+    static_assert(std::is_same<typename Fit1::DataPoint, typename Fit2::DataPoint>::value,
+                  "Both Fit should use the same point type");
+    static_assert(std::is_same<typename Fit1::NeighborFilter, typename Fit2::NeighborFilter>::value,
+                  "Both Fit should use the same NeighborFilter");
 
     const auto& vectorPoints = tree.points();
 
@@ -140,27 +139,27 @@ void testIsSame(const KdTree<typename Fit1::DataPoint>& tree,
 
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         using Fit = Fit1; // create an alias to ease doc snippet generation
         //! [Fit computeWithIds]
         Fit fit3;
         fit3.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         auto neighborhoodRange = tree.rangeNeighbors(vectorPoints[i].pos(), analysisScale);
-        fit3.computeWithIds( neighborhoodRange, vectorPoints );
+        fit3.computeWithIds(neighborhoodRange, vectorPoints);
         //! [Fit computeWithIds]
 
         Fit2 fit2;
         fit2.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
-        fit2.computeWithIds( neighborhoodRange, vectorPoints );
+        fit2.computeWithIds(neighborhoodRange, vectorPoints);
 
         f(fit3, fit2);
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     //! [SpecializedPointType]
@@ -169,7 +168,7 @@ void callSubTests()
 
     // We test only primitive functions and not the fitting procedure
     //! [NeighborFilter]
-    using NeighborFilter = DistWeightFunc<Point, SmoothWeightKernel<Scalar> >;
+    using NeighborFilter = DistWeightFunc<Point, SmoothWeightKernel<Scalar>>;
     //! [NeighborFilter]
     //! [PlaneFitType]
     using TestPlane = Basket<Point, NeighborFilter, CovariancePlaneFit>;
@@ -179,37 +178,36 @@ void callSubTests()
     //! [FitType]
     //! [HybridType]
     // Create an hybrid structure fitting a plane and a sphere at the same time
-    using Hybrid = Basket<Point, NeighborFilter,
-                          AlgebraicSphere, Plane,                     // primitives
-                          MeanNormal, MeanPosition,                   // shared computation
-                          OrientedSphereFitImpl,                      // sphere fitting
-                          CovarianceFitBase, CovariancePlaneFitImpl>; // plane fitting
+    using Hybrid = Basket<Point, NeighborFilter, AlgebraicSphere, Plane, // primitives
+                          MeanNormal, MeanPosition,                      // shared computation
+                          OrientedSphereFitImpl,                         // sphere fitting
+                          CovarianceFitBase, CovariancePlaneFitImpl>;    // plane fitting
     //! [HybridType]
 
     //! [PlaneFitDerTypes]
-    using PlaneScaleDiff = BasketDiff<TestPlane, FitScaleDer, CovariancePlaneDer>;
-    using PlaneSpaceDiff = BasketDiff<TestPlane, FitSpaceDer, CovariancePlaneDer>;
+    using PlaneScaleDiff      = BasketDiff<TestPlane, FitScaleDer, CovariancePlaneDer>;
+    using PlaneSpaceDiff      = BasketDiff<TestPlane, FitSpaceDer, CovariancePlaneDer>;
     using PlaneScaleSpaceDiff = BasketDiff<TestPlane, FitScaleSpaceDer, CovariancePlaneDer>;
     //! [PlaneFitDerTypes]
 
-    using HybridScaleDiff = BasketDiff<Hybrid, FitScaleDer, CovariancePlaneDer>;
-    using HybridSpaceDiff = BasketDiff<Hybrid, FitSpaceDer, CovariancePlaneDer>;
+    using HybridScaleDiff      = BasketDiff<Hybrid, FitScaleDer, CovariancePlaneDer>;
+    using HybridSpaceDiff      = BasketDiff<Hybrid, FitSpaceDer, CovariancePlaneDer>;
     using HybridScaleSpaceDiff = BasketDiff<Hybrid, FitScaleSpaceDer, CovariancePlaneDer>;
 
     KdTreeDense<Point> tree;
     Scalar scale = generateData(tree);
 
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
         // Single Primitive
-        CALL_SUBTEST((testBasicFunctionalities<TestPlane>(tree, scale) ));
-        CALL_SUBTEST((testBasicFunctionalities<Sphere>(tree, scale) ));
+        CALL_SUBTEST((testBasicFunctionalities<TestPlane>(tree, scale)));
+        CALL_SUBTEST((testBasicFunctionalities<Sphere>(tree, scale)));
         // Hybrid
-        CALL_SUBTEST((testBasicFunctionalities<Hybrid>(tree, scale) ));
+        CALL_SUBTEST((testBasicFunctionalities<Hybrid>(tree, scale)));
         //  Plane diffs
-        CALL_SUBTEST((testBasicFunctionalities<PlaneScaleDiff>(tree, scale) ));
-        CALL_SUBTEST((testBasicFunctionalities<PlaneSpaceDiff>(tree, scale) ));
-        CALL_SUBTEST((testBasicFunctionalities<PlaneScaleSpaceDiff>(tree, scale) ));
+        CALL_SUBTEST((testBasicFunctionalities<PlaneScaleDiff>(tree, scale)));
+        CALL_SUBTEST((testBasicFunctionalities<PlaneSpaceDiff>(tree, scale)));
+        CALL_SUBTEST((testBasicFunctionalities<PlaneScaleSpaceDiff>(tree, scale)));
         // Hybrid diffs
         // TODO : Fix hybrid diffs (function calls are ambiguous on primitives)
         // CALL_SUBTEST((testBasicFunctionalities<HybridScaleDiff>(tree, scale) ));
@@ -217,41 +215,41 @@ void callSubTests()
         // CALL_SUBTEST((testBasicFunctionalities<HybridScaleSpaceDiff>(tree, scale) ));
 
         // Check that we get the same Sphere, whatever the extensions
-        auto checkIsSameSphere = [](const auto&f1, const auto&f2){isSameSphere(f1,f2);};
-        CALL_SUBTEST((testIsSame<Sphere, Hybrid>(tree, scale, checkIsSameSphere) ));
-        CALL_SUBTEST((testIsSame<Sphere, HybridScaleDiff>(tree, scale, checkIsSameSphere) ));
-        CALL_SUBTEST((testIsSame<Sphere, HybridSpaceDiff>(tree, scale, checkIsSameSphere) ));
-        CALL_SUBTEST((testIsSame<Sphere, HybridScaleSpaceDiff>(tree, scale, checkIsSameSphere) ));
+        auto checkIsSameSphere = [](const auto& f1, const auto& f2) { isSameSphere(f1, f2); };
+        CALL_SUBTEST((testIsSame<Sphere, Hybrid>(tree, scale, checkIsSameSphere)));
+        CALL_SUBTEST((testIsSame<Sphere, HybridScaleDiff>(tree, scale, checkIsSameSphere)));
+        CALL_SUBTEST((testIsSame<Sphere, HybridSpaceDiff>(tree, scale, checkIsSameSphere)));
+        CALL_SUBTEST((testIsSame<Sphere, HybridScaleSpaceDiff>(tree, scale, checkIsSameSphere)));
 
         // Check that we get the same Plane, whatever the extensions
-        auto checkIsSamePlane = [](const auto&f1, const auto&f2){isSamePlane(f1,f2);};
-        CALL_SUBTEST((testIsSame<TestPlane, Hybrid>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<TestPlane, HybridScaleDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<TestPlane, HybridSpaceDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<TestPlane, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneScaleDiff, HybridSpaceDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneScaleDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneSpaceDiff, HybridScaleDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneSpaceDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridScaleDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridSpaceDiff>(tree, scale, checkIsSamePlane) ));
-        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane) ));
+        auto checkIsSamePlane = [](const auto& f1, const auto& f2) { isSamePlane(f1, f2); };
+        CALL_SUBTEST((testIsSame<TestPlane, Hybrid>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<TestPlane, HybridScaleDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<TestPlane, HybridSpaceDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<TestPlane, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneScaleDiff, HybridSpaceDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneScaleDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneSpaceDiff, HybridScaleDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneSpaceDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridScaleDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridSpaceDiff>(tree, scale, checkIsSamePlane)));
+        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlane)));
 
-        auto checkIsSamePlaneDerivative = [](const auto&f1, const auto&f2){
-            isSamePlane(f1,f2);
+        auto checkIsSamePlaneDerivative = [](const auto& f1, const auto& f2) {
+            isSamePlane(f1, f2);
             hasSamePlaneDerivatives(f1, f2);
         };
         // Check that we get the same Plane derivative, whatever if we have one or more primitive fitted.
         int fff = 0;
-        CALL_SUBTEST((testIsSame<PlaneScaleDiff, HybridScaleDiff>(tree, scale, checkIsSamePlaneDerivative) ));
-        CALL_SUBTEST((testIsSame<PlaneSpaceDiff, HybridSpaceDiff>(tree, scale, checkIsSamePlaneDerivative) ));
-        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlaneDerivative) ));
+        CALL_SUBTEST((testIsSame<PlaneScaleDiff, HybridScaleDiff>(tree, scale, checkIsSamePlaneDerivative)));
+        CALL_SUBTEST((testIsSame<PlaneSpaceDiff, HybridSpaceDiff>(tree, scale, checkIsSamePlaneDerivative)));
+        CALL_SUBTEST((testIsSame<PlaneScaleSpaceDiff, HybridScaleSpaceDiff>(tree, scale, checkIsSamePlaneDerivative)));
     }
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/binding.cpp
+++ b/tests/src/binding.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/basket.cpp
     \brief Test basket utility functions
@@ -26,55 +25,59 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint>
+template <typename DataPoint>
 typename DataPoint::Scalar generateData(vector<DataPoint>& points)
 {
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
 #ifdef NDEBUG
     int nbPoints = Eigen::internal::random<int>(500, 1000);
 #else
     int nbPoints = Eigen::internal::random<int>(100, 200);
 #endif
 
-    Scalar radius = Eigen::internal::random<Scalar>(1., 10.);
-    Scalar analysisScale = Scalar(10.) * std::sqrt( Scalar(4. * M_PI) * radius * radius / nbPoints);
-    Scalar centerScale = Eigen::internal::random<Scalar>(1,10000);
-    VectorType center = VectorType::Random() * centerScale;
+    Scalar radius        = Eigen::internal::random<Scalar>(1., 10.);
+    Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
+    VectorType center    = VectorType::Random() * centerScale;
 
     points.reserve(nbPoints);
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < nbPoints; ++i) {
+    for (int i = 0; i < nbPoints; ++i)
+    {
         points.push_back(getPointOnSphere<DataPoint>(radius, center, false, false, false));
     }
 
     return analysisScale;
 }
 
-/*! \brief Variadic function to copy a vector of points to one or multiple vectors of points that are bound to a single interlaced array of positions and normals.
+/*! \brief Variadic function to copy a vector of points to one or multiple vectors of points that are bound to a single
+ * interlaced array of positions and normals.
  *
  * \tparam DataPoint Regular point data type (e.g. \ref PointPositionNormal)
- * \tparam DataPointRef Point data types referencing the interlaced array (e.g. \ref PointPositionNormalBinding, \ref PointPositionNormalLazyBinding)
+ * \tparam DataPointRef Point data types referencing the interlaced array (e.g. \ref PointPositionNormalBinding, \ref
+ * PointPositionNormalLazyBinding)
  * \param points As an input, a vector of DataPoint.
  * \param pointsBinding As an output, empty vectors of DataPointRef types.
- * \return An interlaced array containing the position and normal values. The `pointsBinding` vectors are linked to this array.
+ * \return An interlaced array containing the position and normal values. The `pointsBinding` vectors are linked to this
+ * array.
  */
-template<typename DataPoint, typename... DataPointRef>
-typename DataPoint::Scalar * copyDataRef(std::vector<DataPoint>& points, std::vector<DataPointRef>&... pointsBinding)
+template <typename DataPoint, typename... DataPointRef>
+typename DataPoint::Scalar* copyDataRef(std::vector<DataPoint>& points, std::vector<DataPointRef>&... pointsBinding)
 {
-    using VectorType            = typename DataPoint::VectorType;
-    using Scalar                = typename DataPoint::Scalar;
+    using VectorType = typename DataPoint::VectorType;
+    using Scalar     = typename DataPoint::Scalar;
 
-    constexpr int DIM           =  DataPoint::Dim;
+    constexpr int DIM           = DataPoint::Dim;
     const int nPoints           = int(points.size());
-    auto* const interlacedArray = new Scalar[2*DIM*nPoints];
+    auto* const interlacedArray = new Scalar[2 * DIM * nPoints];
     (pointsBinding.reserve(nPoints), ...);
 
-    for(int i=0; i<nPoints; ++i)
+    for (int i = 0; i < nPoints; ++i)
     {
         // We use Eigen Vectors to compute both coordinates and normals,
         // and then copy the raw values to an interlaced array.
@@ -82,8 +85,8 @@ typename DataPoint::Scalar * copyDataRef(std::vector<DataPoint>& points, std::ve
         VectorType p = points[i].pos();
 
         // Grab coordinates and store them as raw buffer
-        memcpy(interlacedArray+2*DIM*i    , p.data(), DIM*sizeof(Scalar));
-        memcpy(interlacedArray+2*DIM*i+DIM, n.data(), DIM*sizeof(Scalar));
+        memcpy(interlacedArray + 2 * DIM * i, p.data(), DIM * sizeof(Scalar));
+        memcpy(interlacedArray + 2 * DIM * i + DIM, n.data(), DIM * sizeof(Scalar));
 
         (pointsBinding.emplace_back(interlacedArray, i), ...);
     }
@@ -91,49 +94,55 @@ typename DataPoint::Scalar * copyDataRef(std::vector<DataPoint>& points, std::ve
     return interlacedArray;
 }
 
-/*! \brief Verify that the fit results between two point data types are the same. The points are passed through an spatial partitioning structure
+/*! \brief Verify that the fit results between two point data types are the same. The points are passed through an
+ * spatial partitioning structure
  *
  * The fit is computed for each point of the point cloud. The results are compared using the `fit.isApprox` method
  *
  * \tparam Fit A fit class that performs the fitting over the neighborhood
- * \tparam SpatialStruct1 The first Spatial partitioning structure containing a rangeNeighbors method (e.g. \ref KdTree or \ref KnnGraph)
- * \tparam SpatialStruct2 The second Spatial partitioning structure containing a rangeNeighbors method (e.g. \ref KdTree or \ref KnnGraph)
+ * \tparam SpatialStruct1 The first Spatial partitioning structure containing a rangeNeighbors method (e.g. \ref KdTree
+ * or \ref KnnGraph)
+ * \tparam SpatialStruct2 The second Spatial partitioning structure containing a rangeNeighbors method (e.g. \ref KdTree
+ * or \ref KnnGraph)
  * \param spatialStruct1 A spatial partitioning structure containing the first set of data point
  * \param spatialStruct2 A spatial partitioning structure the first set of data point that we are comparing to the first
  * \param analysisScale The radius of the neighborhood for the fitting process
  */
-template<template<typename> typename Fit, typename SpatialStruct1, typename SpatialStruct2>
-void compareFitOverPointTypes( SpatialStruct1& spatialStruct1, SpatialStruct2& spatialStruct2, typename SpatialStruct2::DataPoint::Scalar analysisScale)
+template <template <typename> typename Fit, typename SpatialStruct1, typename SpatialStruct2>
+void compareFitOverPointTypes(SpatialStruct1& spatialStruct1, SpatialStruct2& spatialStruct2,
+                              typename SpatialStruct2::DataPoint::Scalar analysisScale)
 {
-    using DataPoint1          = typename SpatialStruct1::DataPoint;
-    using DataPoint2          = typename SpatialStruct2::DataPoint;
-    constexpr int  DIMENSION  = DataPoint1::Dim;
-    static_assert( DIMENSION == DataPoint2::Dim, "Both dimension should be the same" );
-    static_assert( std::is_same_v<typename DataPoint1::Scalar, typename DataPoint2::Scalar>, "Both scalar type should be the same" );
+    using DataPoint1        = typename SpatialStruct1::DataPoint;
+    using DataPoint2        = typename SpatialStruct2::DataPoint;
+    constexpr int DIMENSION = DataPoint1::Dim;
+    static_assert(DIMENSION == DataPoint2::Dim, "Both dimension should be the same");
+    static_assert(std::is_same_v<typename DataPoint1::Scalar, typename DataPoint2::Scalar>,
+                  "Both scalar type should be the same");
     const std::vector<DataPoint1>& points1 = spatialStruct1.points();
     const std::vector<DataPoint2>& points2 = spatialStruct2.points();
-    VERIFY( points1.size() == points2.size() );
+    VERIFY(points1.size() == points2.size());
 
     // Quick testing is requested for coverage
     const int nPoint = QUICK_TESTS ? 1 : int(points1.size());
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < nPoint; ++i)
+    for (int i = 0; i < nPoint; ++i)
     {
         Fit<DataPoint1> f1;
         f1.setNeighborFilter({points1[i].pos(), analysisScale});
         const auto neighborhoodRange1 = spatialStruct1.rangeNeighbors(points1[i].pos(), analysisScale);
-        f1.computeWithIds( neighborhoodRange1, points1 );
+        f1.computeWithIds(neighborhoodRange1, points1);
 
         Fit<DataPoint2> f2;
         f2.setNeighborFilter({points2[i].pos(), analysisScale});
         const auto neighborhoodRange2 = spatialStruct2.rangeNeighbors(points2[i].pos(), analysisScale);
-        f2.computeWithIds( neighborhoodRange2, points2 );
+        f2.computeWithIds(neighborhoodRange2, points2);
 
         VERIFY((f1.isStable() == f2.isStable()));
-        if (f1.isStable() && f2.isStable()) {
+        if (f1.isStable() && f2.isStable())
+        {
             VERIFY(f1.isApprox(f2));
             VERIFY(f2.isApprox(f1));
         }
@@ -142,35 +151,35 @@ void compareFitOverPointTypes( SpatialStruct1& spatialStruct1, SpatialStruct2& s
 
 //! \brief Smooth weight neighbor filter class templated over the point data type.
 template <typename DataPoint>
-using NeighborFilter = DistWeightFunc<DataPoint, SmoothWeightKernel<typename DataPoint::Scalar> >;
+using NeighborFilter = DistWeightFunc<DataPoint, SmoothWeightKernel<typename DataPoint::Scalar>>;
 //! \brief Fitting templated over the point data type.
 template <typename DataPoint>
-using TestSphereFit  = Basket<DataPoint, NeighborFilter<DataPoint>, OrientedSphereFit>;
+using TestSphereFit = Basket<DataPoint, NeighborFilter<DataPoint>, OrientedSphereFit>;
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
     typedef PointPositionNormalBinding<Scalar, Dim> PointRef;
     typedef PointPositionNormalLazyBinding<Scalar, Dim> PointLateRef;
 
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
         // Points to compare
-        vector<Point>        points;
-        vector<PointRef>     pointsRef;
+        vector<Point> points;
+        vector<PointRef> pointsRef;
         vector<PointLateRef> pointsLateRef;
 
-        const Scalar  analysisScale   = generateData(points);
+        const Scalar analysisScale = generateData(points);
         // Copy the point data to an external buffer, and bind some point vectors to it.
         const Scalar* interlacedArray = copyDataRef(points, pointsRef, pointsLateRef);
 
-        KdTreeDense<Point>        kdtree(points);
-        KdTreeDense<PointRef>     kdtreeRef(pointsRef);
+        KdTreeDense<Point> kdtree(points);
+        KdTreeDense<PointRef> kdtreeRef(pointsRef);
         KdTreeDense<PointLateRef> kdtreeLateRef(pointsLateRef);
 
         // Compare fits made with the kdtree
-        CALL_SUBTEST((compareFitOverPointTypes<TestSphereFit>(kdtree, kdtreeRef    , analysisScale)));
+        CALL_SUBTEST((compareFitOverPointTypes<TestSphereFit>(kdtree, kdtreeRef, analysisScale)));
         CALL_SUBTEST((compareFitOverPointTypes<TestSphereFit>(kdtree, kdtreeLateRef, analysisScale)));
 
         // Delete buffer before the next pass
@@ -180,7 +189,7 @@ void callSubTests()
 
 int main(const int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/change_basis.cpp
+++ b/tests/src/change_basis.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/Grenaille/okabe_primitive.cpp
     \brief Test validity Algebraic Sphere Primitive
@@ -22,31 +21,30 @@
 
 #include <vector>
 
-
 using namespace std;
 using namespace Ponca;
 
-template<typename Point, typename Fit>
+template <typename Point, typename Fit>
 void testFunction()
 {
-        // Define related structure
+    // Define related structure
     typedef typename Point::Scalar Scalar;
     typedef typename Point::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar radius = Eigen::internal::random<Scalar>(1., 10.);
 
-    Scalar analysisScale = Scalar(10.) * std::sqrt( Scalar(4. * M_PI) * radius * radius / nbPoints);
-    Scalar centerScale = Eigen::internal::random<Scalar>(1,1000);
-    VectorType center = VectorType::Random() * centerScale;
+    Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 1000);
+    VectorType center    = VectorType::Random() * centerScale;
 
     Scalar epsilon = testEpsilon<Scalar>();
 
-    vector<Point> vecs ( nbPoints );
+    vector<Point> vecs(nbPoints);
 
-    for(unsigned int i = 0; i < vecs.size(); ++i)
+    for (unsigned int i = 0; i < vecs.size(); ++i)
     {
         vecs[i] = getPointOnSphere<Point>(radius, center, true, false, false);
     }
@@ -55,53 +53,54 @@ void testFunction()
     int size = QUICK_TESTS ? 1 : int(vecs.size());
 
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int k=0; k<size; ++k)
+    for (int k = 0; k < size; ++k)
     {
-        const auto &fitInitPos = vecs[k].pos();
+        const auto& fitInitPos = vecs[k].pos();
 
         Fit fit;
         fit.setNeighborFilter({fitInitPos, analysisScale});
         fit.compute(vecs);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
             Fit f2 = fit;
             // do two iterations to test successive calls
             VectorType candidate = VectorType::Random();
-            for (unsigned int j = 0; j != 2; ++j){
+            for (unsigned int j = 0; j != 2; ++j)
+            {
                 // move basis center to a portion of the radius of the sphere
-                f2.changeBasis(fitInitPos + Scalar(0.1)*radius*VectorType::Random());
+                f2.changeBasis(fitInitPos + Scalar(0.1) * radius * VectorType::Random());
 
-                VERIFY( (fit.project(candidate) - f2.project(candidate)).norm() - Scalar(1.) < epsilon );
+                VERIFY((fit.project(candidate) - f2.project(candidate)).norm() - Scalar(1.) < epsilon);
             }
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     using Point = PointPositionNormal<Scalar, Dim>;
 
     // We test only primitive functions and not the fitting procedure
-    using NeighborFilter = DistWeightFunc<Point, SmoothWeightKernel<Scalar> >;
+    using NeighborFilter = DistWeightFunc<Point, SmoothWeightKernel<Scalar>>;
     using Sphere         = Basket<Point, NeighborFilter, OrientedSphereFit>;
     using Plane          = Basket<Point, NeighborFilter, CovariancePlaneFit>;
     using Line           = Basket<Point, NeighborFilter, CovarianceLineFit>;
 
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, Sphere>() ));
-        CALL_SUBTEST(( testFunction<Point, Plane>() ));
-        CALL_SUBTEST(( testFunction<Point, Line>() ));
+        CALL_SUBTEST((testFunction<Point, Sphere>()));
+        CALL_SUBTEST((testFunction<Point, Plane>()));
+        CALL_SUBTEST((testFunction<Point, Line>()));
     }
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/cnc.cpp
+++ b/tests/src/cnc.cpp
@@ -4,7 +4,6 @@ This Source Code Form is subject to the terms of the Mozilla Public
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/src/cnc.cpp
  \brief Test validity of the CNC curvature estimator procedure
@@ -25,26 +24,25 @@ This Source Code Form is subject to the terms of the Mozilla Public
 #include "Ponca/src/Fitting/weightKernel.h"
 #include "Ponca/src/Fitting/weingarten.h"
 
-
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint, typename VectorType>
+template <typename DataPoint, typename VectorType>
 typename DataPoint::Scalar generateSpherePC(
-    KdTree<DataPoint>& tree,
-    const int nbPoints = Eigen::internal::random<int>(500, 1000),
-    const VectorType& center = VectorType::Random() * Eigen::internal::random<typename DataPoint::Scalar>(1,10000)
-) {
+    KdTree<DataPoint>& tree, const int nbPoints = Eigen::internal::random<int>(500, 1000),
+    const VectorType& center = VectorType::Random() * Eigen::internal::random<typename DataPoint::Scalar>(1, 10000))
+{
     typedef typename DataPoint::Scalar Scalar;
 
-    Scalar radius = Eigen::internal::random<Scalar>(1., 10.);
-    Scalar analysisScale = Scalar(10.) * std::sqrt( Scalar(4. * M_PI) * radius * radius / nbPoints);
+    Scalar radius        = Eigen::internal::random<Scalar>(1., 10.);
+    Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
     vector<DataPoint> vectorPoints(nbPoints);
 
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < int(vectorPoints.size()); ++i) {
+    for (int i = 0; i < int(vectorPoints.size()); ++i)
+    {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, false, false, false);
     }
 
@@ -65,39 +63,39 @@ typename DataPoint::Scalar generateSpherePC(
  * \param analysisScale The size of the neighborhood
  * \param epsilon The precision of the mutability check
  */
-template<typename Fit, typename Scalar>
-void testBasicFunctionalities(
-    const KdTree<typename Fit::DataPoint>& tree,
-    const Scalar analysisScale,
-    const Scalar epsilon = testEpsilon<Scalar>() *2
-) {
+template <typename Fit, typename Scalar>
+void testBasicFunctionalities(const KdTree<typename Fit::DataPoint>& tree, const Scalar analysisScale,
+                              const Scalar epsilon = testEpsilon<Scalar>() * 2)
+{
     using DataPoint = typename Fit::DataPoint;
 
     const auto& vectorPoints = tree.points();
-    auto rng = std::default_random_engine {};
+    auto rng                 = std::default_random_engine{};
 
     // Quick testing is requested for coverage
     const int size = QUICK_TESTS ? 1 : int(vectorPoints.size());
 
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for (int i = 0; i < size; ++i) {
+    for (int i = 0; i < size; ++i)
+    {
         const DataPoint& evalPoint = vectorPoints[i];
 
         //! [Fit compute]
         Fit fit1;
         fit1.setNeighborFilter({evalPoint, analysisScale});
-        fit1.compute( vectorPoints );
+        fit1.compute(vectorPoints);
         //! [Fit compute]
         VERIFY(fit1 == fit1);
-        VERIFY(! (fit1 != fit1));
+        VERIFY(!(fit1 != fit1));
 
         // Sample the neighbors
         std::vector<int> pointsIndex;
         pointsIndex.push_back(i);
-        for (int j : tree.rangeNeighbors(i, analysisScale)) {
+        for (int j : tree.rangeNeighbors(i, analysisScale))
+        {
             pointsIndex.push_back(j);
         }
 
@@ -107,7 +105,7 @@ void testBasicFunctionalities(
         //! [Fit computeWithIds]
         Fit fit2;
         fit2.setNeighborFilter({evalPoint, analysisScale});
-        fit2.computeWithIds( pointsIndex, vectorPoints );
+        fit2.computeWithIds(pointsIndex, vectorPoints);
         //! [Fit computeWithIds]
 
         VERIFY((fit1.isStable()));
@@ -115,14 +113,15 @@ void testBasicFunctionalities(
 
         // Equal to self test
         VERIFY((fit2 == fit2));
-        VERIFY(! (fit2 != fit2));
+        VERIFY(!(fit2 != fit2));
         VERIFY((fit1 == fit1));
-        VERIFY(! (fit1 != fit1));
+        VERIFY(!(fit1 != fit1));
 
-        if (std::abs(fit1.kMean()  - fit2.kMean()) > epsilon)
-            std::cout << "std::abs(kMean()  - other.kMean() :" << std::abs(fit1.kMean()  - fit2.kMean()) << std::endl;
+        if (std::abs(fit1.kMean() - fit2.kMean()) > epsilon)
+            std::cout << "std::abs(kMean()  - other.kMean() :" << std::abs(fit1.kMean() - fit2.kMean()) << std::endl;
         if (std::abs(fit1.GaussianCurvature() - fit2.GaussianCurvature()) > epsilon)
-            std::cout << "std::abs(GaussianCurvature() - other.GaussianCurvature() :" << std::abs(fit1.GaussianCurvature() - fit2.GaussianCurvature()) << std::endl;
+            std::cout << "std::abs(GaussianCurvature() - other.GaussianCurvature() :"
+                      << std::abs(fit1.GaussianCurvature() - fit2.GaussianCurvature()) << std::endl;
 
         // Compare computeWithIds with compute result
         VERIFY((std::abs(fit1.kMean() - fit2.kMean()) < epsilon));
@@ -131,35 +130,39 @@ void testBasicFunctionalities(
 }
 
 /// \breif Compare the GaussianCurvature and kMean between two fit
-template<typename Fit1, typename Fit2, bool orderedByDistance = false, typename Scalar>
-void testCompareFit(
-    const KdTree<typename Fit1::DataPoint>& tree,
-    const Scalar analysisScale,
-    const Scalar epsilon = testEpsilon<Scalar>() *2
-) {
+template <typename Fit1, typename Fit2, bool orderedByDistance = false, typename Scalar>
+void testCompareFit(const KdTree<typename Fit1::DataPoint>& tree, const Scalar analysisScale,
+                    const Scalar epsilon = testEpsilon<Scalar>() * 2)
+{
     const auto& vectorPoints = tree.points();
     // Quick testing is requested for coverage
     const int size = QUICK_TESTS ? 1 : int(vectorPoints.size());
 
     // Test for each point if the curvature results are equivalent
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < size; ++i) {
-        typename Fit1::NeighborFilter w {vectorPoints[i].pos(), analysisScale};
+    for (int i = 0; i < size; ++i)
+    {
+        typename Fit1::NeighborFilter w{vectorPoints[i].pos(), analysisScale};
         // compute the indices list
         std::vector<int> pointsIndex;
         pointsIndex.push_back(i);
 
-        if constexpr (orderedByDistance) {
-            for (int j : tree.kNearestNeighbors(i, int(vectorPoints.size()))) {
+        if constexpr (orderedByDistance)
+        {
+            for (int j : tree.kNearestNeighbors(i, int(vectorPoints.size())))
+            {
                 // Stops when we go past the analysis scale
-                if (w(vectorPoints[ j ]).first == Scalar(0.))
+                if (w(vectorPoints[j]).first == Scalar(0.))
                     break;
                 pointsIndex.push_back(j);
             }
-        } else {
-            for (const int j : tree.rangeNeighbors(i, analysisScale)) {
+        }
+        else
+        {
+            for (const int j : tree.rangeNeighbors(i, analysisScale))
+            {
                 pointsIndex.push_back(j);
             }
         }
@@ -181,19 +184,18 @@ void testCompareFit(
     }
 }
 
-template<typename Scalar, int Dim>
-void callSubTests() {
+template <typename Scalar, int Dim>
+void callSubTests()
+{
     //! [SpecializedPointType]
     typedef PointPositionNormal<Scalar, Dim> Point;
     typedef typename Point::VectorType VectorType;
     //! [SpecializedPointType]
 
-    using SmoothWeightFunc   = DistWeightFunc< Point, SmoothWeightKernel<Scalar> >;
-    using FitASODiff = BasketDiff<
-            Basket< Point, SmoothWeightFunc, OrientedSphereFit >,
-            FitSpaceDer,
-            OrientedSphereDer, MlsSphereFitDer,
-            CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+    using SmoothWeightFunc = DistWeightFunc<Point, SmoothWeightKernel<Scalar>>;
+    using FitASODiff =
+        BasketDiff<Basket<Point, SmoothWeightFunc, OrientedSphereFit>, FitSpaceDer, OrientedSphereDer, MlsSphereFitDer,
+                   CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
 
     //! [CNCFitType]
     using FitCNCIndependent = CNC<Point, IndependentGeneration>;
@@ -204,34 +206,35 @@ void callSubTests() {
 
     // Generate sphere point cloud
     KdTreeDense<Point> tree;
-    const int nbPoints = Eigen::internal::random<int>(5000, 7000) ; // Quick testing is requested for coverage
-    const VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
+    const int nbPoints         = Eigen::internal::random<int>(5000, 7000); // Quick testing is requested for coverage
+    const VectorType center    = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
     const Scalar analysisScale = generateSpherePC(tree, nbPoints, center);
-    const Scalar highEpsilon {Scalar(0.1)};
+    const Scalar highEpsilon{Scalar(0.1)};
 
     // Tests validity of compute despite index shuffle
-    CALL_SUBTEST((testBasicFunctionalities<FitCNCIndependent>(tree, analysisScale, highEpsilon) ));
-    CALL_SUBTEST((testBasicFunctionalities<FitCNCUniform>(tree, analysisScale, highEpsilon) ));
+    CALL_SUBTEST((testBasicFunctionalities<FitCNCIndependent>(tree, analysisScale, highEpsilon)));
+    CALL_SUBTEST((testBasicFunctionalities<FitCNCUniform>(tree, analysisScale, highEpsilon)));
 
     // Compare with ASO
-    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCIndependent>(tree, analysisScale) ));
-    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCUniform>(tree, analysisScale) ));
-    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCHexagram, true>(tree, analysisScale, highEpsilon) ));
-    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCAvgHexagram, true>(tree, analysisScale, highEpsilon) ));
+    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCIndependent>(tree, analysisScale)));
+    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCUniform>(tree, analysisScale)));
+    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCHexagram, true>(tree, analysisScale, highEpsilon)));
+    CALL_SUBTEST((testCompareFit<FitASODiff, FitCNCAvgHexagram, true>(tree, analysisScale, highEpsilon)));
 }
 
-int main(const int argc, char** argv) {
-    if(!init_testing(argc, argv))
+int main(const int argc, char** argv)
+{
+    if (!init_testing(argc, argv))
         return EXIT_FAILURE;
 
     cout << "Test for the CorrectedNormalCurrent fit method" << endl;
 
     cout << "Tests CNC functions in 3 dimensions:";
-    cout << "float"              << flush;
+    cout << "float" << flush;
     callSubTests<float, 3>();
-    cout << " (ok), double"      << flush;
+    cout << " (ok), double" << flush;
     callSubTests<double, 3>();
     cout << " (ok), long double" << flush;
     callSubTests<long double, 3>();
-    cout << " (ok)"              << endl;
+    cout << " (ok)" << endl;
 }

--- a/tests/src/curvature_plane.cpp
+++ b/tests/src/curvature_plane.cpp
@@ -27,16 +27,19 @@
 using namespace std;
 using namespace Ponca;
 
-
-template<bool hasFundamentalForms>
-struct FundamentalFormTester {
-    template<typename Fit>
-    static inline void test(const Fit &, typename Fit::Scalar) {}
+template <bool hasFundamentalForms>
+struct FundamentalFormTester
+{
+    template <typename Fit>
+    static inline void test(const Fit&, typename Fit::Scalar)
+    {
+    }
 };
 
-template<>
-template<typename Fit>
-void FundamentalFormTester<true>::test(const Fit &fit, typename Fit::Scalar epsilon) {
+template <>
+template <typename Fit>
+void FundamentalFormTester<true>::test(const Fit& fit, typename Fit::Scalar epsilon)
+{
     using Scalar = typename Fit::Scalar;
 
     VERIFY(std::abs(fit.weingartenCurvatureEstimator().kMean()) < epsilon);
@@ -46,23 +49,18 @@ void FundamentalFormTester<true>::test(const Fit &fit, typename Fit::Scalar epsi
     VERIFY(std::abs(fit.fundamentalFormWeingartenEstimator().GaussianCurvature()) <= epsilon);
 
     // Check that principal curvature are well computed
-    VERIFY((Scalar(.5)*(fit.kmin()+fit.kmax()) - fit.kMean()) < epsilon);
-    VERIFY(((fit.kmin()*fit.kmax()) - fit.GaussianCurvature()) < epsilon);
-    VERIFY(fit.kmin()< epsilon); // we know that curvatures should be 0
-    VERIFY(fit.kmin()< epsilon); // we know that curvatures should be 0
+    VERIFY((Scalar(.5) * (fit.kmin() + fit.kmax()) - fit.kMean()) < epsilon);
+    VERIFY(((fit.kmin() * fit.kmax()) - fit.GaussianCurvature()) < epsilon);
+    VERIFY(fit.kmin() < epsilon); // we know that curvatures should be 0
+    VERIFY(fit.kmin() < epsilon); // we know that curvatures should be 0
 
     // Check that principal curvature directions are well-formed
-    VERIFY(fit.kminDirection().norm()-Scalar(1) < epsilon);
-    VERIFY(fit.kmaxDirection().norm()-Scalar(1) < epsilon);
+    VERIFY(fit.kminDirection().norm() - Scalar(1) < epsilon);
+    VERIFY(fit.kmaxDirection().norm() - Scalar(1) < epsilon);
     VERIFY(fit.kminDirection().dot(fit.kmaxDirection()) < epsilon);
 }
 
-
-
-
-
-
-template<typename DataPoint, typename Fit, typename RefFit>
+template <typename DataPoint, typename Fit, typename RefFit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     constexpr bool hasFundamentalForms = hasFirstFundamentalForm<Fit>::value;
@@ -71,16 +69,16 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(1000, 5000);
 
     // use large width to reduce relative influence of the positional noise
     Scalar width  = Eigen::internal::random<Scalar>(100., 200.);
     Scalar height = width;
 
-    Scalar analysisScale = width; //use a large scale to avoir fitting errors
-    Scalar centerScale   = Eigen::internal::random<Scalar>(1,10000);
-    VectorType center    = VectorType::Zero(); //Random() * centerScale;
+    Scalar analysisScale = width; // use a large scale to avoir fitting errors
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
+    VectorType center    = VectorType::Zero(); // Random() * centerScale;
 
     VectorType direction = VectorType::Random().normalized();
 
@@ -88,13 +86,9 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnPlane<DataPoint>(center,
-                                                     direction,
-                                                     width,
-                                                     _bAddPositionNoise,
-                                                     _bAddNormalNoise);
+        vectorPoints[i] = getPointOnPlane<DataPoint>(center, direction, width, _bAddPositionNoise, _bAddNormalNoise);
     }
 
     KdTreeDense<DataPoint> tree(vectorPoints);
@@ -102,30 +96,29 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
     // Test for several points if principal curvature values are null
     // The points are generated to not be on the border of the generated point cloud
     // to avoid instabilities issues
-    int nbTestPoints = QUICK_TESTS ? 1 :nbPoints/10;
+    int nbTestPoints = QUICK_TESTS ? 1 : nbPoints / 10;
 
-//#pragma omp parallel for
-    for(int i = 0; i < nbTestPoints; ++i)
+    // #pragma omp parallel for
+    for (int i = 0; i < nbTestPoints; ++i)
     {
-        VectorType queryPos = getPointOnPlane<DataPoint>(center,
-                                                         direction,
-                                                         width/Scalar(2), // avoid to test on borders
-                                                         _bAddPositionNoise,
-                                                         _bAddNormalNoise).pos();
+        VectorType queryPos = getPointOnPlane<DataPoint>(center, direction,
+                                                         width / Scalar(2), // avoid to test on borders
+                                                         _bAddPositionNoise, _bAddNormalNoise)
+                                  .pos();
 
         epsilon = testEpsilon<Scalar>();
-        if ( _bAddPositionNoise) // relax a bit the testing threshold
-          epsilon = Scalar(0.01*MAX_NOISE);
+        if (_bAddPositionNoise) // relax a bit the testing threshold
+            epsilon = Scalar(0.01 * MAX_NOISE);
 
-        typename Fit::NeighborFilter nf (queryPos, analysisScale);
+        typename Fit::NeighborFilter nf(queryPos, analysisScale);
 
         Fit fit;
         fit.setNeighborFilter(nf);
-        fit.computeWithIds(tree.rangeNeighbors(queryPos,analysisScale),vectorPoints);
+        fit.computeWithIds(tree.rangeNeighbors(queryPos, analysisScale), vectorPoints);
 
         RefFit refFit;
         refFit.setNeighborFilter(nf);
-        refFit.computeWithIds(tree.rangeNeighbors(queryPos,analysisScale),vectorPoints);
+        refFit.computeWithIds(tree.rangeNeighbors(queryPos, analysisScale), vectorPoints);
 
         // use temporaries to help debugging
         VectorType res    = fit.primitiveGradient(queryPos).normalized();
@@ -133,16 +126,18 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
         VectorType resRef = refFit.primitiveGradient(queryPos).normalized();
         Scalar resDotRef  = resRef.dot(direction);
 
-        if(Scalar(1.) - std::abs( resDot ) > epsilon){
+        if (Scalar(1.) - std::abs(resDot) > epsilon)
+        {
             VectorType res2 = fit.primitiveGradient(queryPos).normalized();
             // std::cout << res2.transpose() << std::endl;
         }
 
-        if( refFit.isStable() ){
+        if (refFit.isStable())
+        {
             VERIFY(fit.isStable());
 
-            VERIFY(Scalar(1.) - std::abs( resDot ) <= epsilon);
-            VERIFY(Scalar(1.) - std::abs( resDotRef ) <= epsilon);
+            VERIFY(Scalar(1.) - std::abs(resDot) <= epsilon);
+            VERIFY(Scalar(1.) - std::abs(resDotRef) <= epsilon);
 
             // use temporaries to help debugging
             Scalar meanCurvature     = fit.kMean();
@@ -153,72 +148,75 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
             VERIFY(std::abs(gaussianCurvature) <= epsilon);
 
             FundamentalFormTester<hasFundamentalForms>::test(fit, epsilon);
-        } else {
+        }
+        else
+        {
             VERIFY(FITTING_FAILED);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     // Covariance-based fits
     //! [Curvature Estimator PCA plane]
-    typedef Basket<Point, WeightSmoothFunc  , CovariancePlaneFit> FitSmoothNormalCovariance;
+    typedef Basket<Point, WeightSmoothFunc, CovariancePlaneFit> FitSmoothNormalCovariance;
     //! [Curvature Estimator PCA plane]
     typedef Basket<Point, WeightConstantFunc, CovariancePlaneFit> FitConstantNormalCovariance;
     // Curvature estimators that runs on top of the covariance fit
     //! [Curvature Tensor PCA normals]
-    typedef BasketDiff< FitSmoothNormalCovariance, FitSpaceDer, CovariancePlaneDer,
-                        CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator> EstimatorSmoothNormalCovariance;
+    typedef BasketDiff<FitSmoothNormalCovariance, FitSpaceDer, CovariancePlaneDer, CurvatureEstimatorDer,
+                       NormalDerivativeWeingartenEstimator>
+        EstimatorSmoothNormalCovariance;
     //! [Curvature Tensor PCA normals]
-    typedef BasketDiff< FitConstantNormalCovariance, FitSpaceDer, CovariancePlaneDer,
-                        CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator> EstimatorConstantNormalCovariance;
+    typedef BasketDiff<FitConstantNormalCovariance, FitSpaceDer, CovariancePlaneDer, CurvatureEstimatorDer,
+                       NormalDerivativeWeingartenEstimator>
+        EstimatorConstantNormalCovariance;
     // Curvature estimators based on MongePatch fitting using generalized quadric
     //! [Curvature Estimator Monge Quadric]
-    typedef Basket<Point, WeightSmoothFunc  , MongePatchQuadraticFit> FitMongeSmooth;
+    typedef Basket<Point, WeightSmoothFunc, MongePatchQuadraticFit> FitMongeSmooth;
     //! [Curvature Estimator Monge Quadric]
     typedef Basket<Point, WeightConstantFunc, MongePatchQuadraticFit> FitMongeConstant;
     // Curvature estimators based on MongePatch fitting using restricted quadric
     //! [Curvature Estimator Monge Quadric Restricted]
-    typedef Basket<Point, WeightSmoothFunc  , MongePatchRestrictedQuadraticFit> FitMongeRestrictedSmooth;
+    typedef Basket<Point, WeightSmoothFunc, MongePatchRestrictedQuadraticFit> FitMongeRestrictedSmooth;
     //! [Curvature Estimator Monge Quadric Restricted]
     typedef Basket<Point, WeightConstantFunc, MongePatchRestrictedQuadraticFit> FitMongeRestrictedConstant;
 
     cout << "Testing with perfect plane..." << flush;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, EstimatorSmoothNormalCovariance, EstimatorSmoothNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, EstimatorConstantNormalCovariance, EstimatorConstantNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeSmooth,FitSmoothNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeConstant, EstimatorConstantNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeRestrictedSmooth,FitSmoothNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeRestrictedConstant, EstimatorConstantNormalCovariance>() ));
+        CALL_SUBTEST((testFunction<Point, EstimatorSmoothNormalCovariance, EstimatorSmoothNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, EstimatorConstantNormalCovariance, EstimatorConstantNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitMongeSmooth, FitSmoothNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitMongeConstant, EstimatorConstantNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitMongeRestrictedSmooth, FitSmoothNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitMongeRestrictedConstant, EstimatorConstantNormalCovariance>()));
     }
     cout << "Ok..." << endl;
 
     cout << "Testing with noisy plane..." << flush;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, EstimatorSmoothNormalCovariance, EstimatorSmoothNormalCovariance>(true) ));
-        CALL_SUBTEST(( testFunction<Point, EstimatorConstantNormalCovariance, EstimatorConstantNormalCovariance>(true) ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeSmooth,EstimatorSmoothNormalCovariance>(true) ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeConstant, EstimatorConstantNormalCovariance>(true) ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeRestrictedSmooth,EstimatorSmoothNormalCovariance>(true) ));
-        CALL_SUBTEST(( testFunction<Point, FitMongeRestrictedConstant, EstimatorConstantNormalCovariance>(true) ));
+        CALL_SUBTEST((testFunction<Point, EstimatorSmoothNormalCovariance, EstimatorSmoothNormalCovariance>(true)));
+        CALL_SUBTEST((testFunction<Point, EstimatorConstantNormalCovariance, EstimatorConstantNormalCovariance>(true)));
+        CALL_SUBTEST((testFunction<Point, FitMongeSmooth, EstimatorSmoothNormalCovariance>(true)));
+        CALL_SUBTEST((testFunction<Point, FitMongeConstant, EstimatorConstantNormalCovariance>(true)));
+        CALL_SUBTEST((testFunction<Point, FitMongeRestrictedSmooth, EstimatorSmoothNormalCovariance>(true)));
+        CALL_SUBTEST((testFunction<Point, FitMongeRestrictedConstant, EstimatorConstantNormalCovariance>(true)));
     }
     cout << "Ok..." << endl;
 }
 
-
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/curvature_sphere.cpp
+++ b/tests/src/curvature_sphere.cpp
@@ -15,19 +15,18 @@
 using namespace std;
 using namespace Grenaille;
 
-
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(10000, 50000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
-//    Scalar curvature = Scalar(1.)/radius;
+    Scalar radius = Eigen::internal::random<Scalar>(1, 10);
+    //    Scalar curvature = Scalar(1.)/radius;
 
     VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
 
@@ -37,7 +36,7 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise);
     }
@@ -47,11 +46,11 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test for each point if principal curvature values are equal to the radius
 #pragma omp parallel for
-    for(int i = 0; i < size; i+=10)
+    for (int i = 0; i < size; i += 10)
     {
         epsilon = testEpsilon<Scalar>();
-        if ( _bAddPositionNoise) // relax a bit the testing threshold
-          epsilon = Scalar(0.001*MAX_NOISE);
+        if (_bAddPositionNoise) // relax a bit the testing threshold
+            epsilon = Scalar(0.001 * MAX_NOISE);
 
         epsilon = 0.25; // large threshold
 
@@ -59,17 +58,18 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if( fit.isStable() )
+        if (fit.isStable())
         {
             // Check if principal curvature values are equal to the inverse radius
-//            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmin()-curvature), Scalar(1.), epsilon) );
-//            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmax()-curvature), Scalar(1.), epsilon) );
+            //            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmin()-curvature), Scalar(1.),
+            //            epsilon) ); VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmax()-curvature),
+            //            Scalar(1.), epsilon) );
 
             // Check if principal curvature directions are tangent to the sphere
-            VectorType normal = (vectorPoints[i].pos()-center).normalized();
+            VectorType normal = (vectorPoints[i].pos() - center).normalized();
 
-            if(!Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(normal)), Scalar(1.), epsilon) ||
-               !Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(normal)), Scalar(1.), epsilon))
+            if (!Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(normal)), Scalar(1.), epsilon) ||
+                !Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(normal)), Scalar(1.), epsilon))
             {
                 Scalar dot1 = std::abs(fit.kminDirection().dot(normal));
                 Scalar dot2 = std::abs(fit.kmaxDirection().dot(normal));
@@ -77,53 +77,57 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
                 cout << "dot2 = " << dot2 << endl;
             }
 
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(normal)), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(normal)), Scalar(1.), epsilon) );
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(fit.kminDirection().dot(normal)), Scalar(1.), epsilon));
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(fit.kmaxDirection().dot(normal)), Scalar(1.), epsilon));
         }
-        else {
+        else
+        {
             VERIFY(FITTING_FAILED);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
-    typedef Basket<Point, WeightSmoothFunc,   CompactPlane, CovariancePlaneFit, NormalCovarianceCurvature> FitSmoothNormalCovariance;
-    typedef Basket<Point, WeightConstantFunc, CompactPlane, CovariancePlaneFit, NormalCovarianceCurvature> FitConstantNormalCovariance;
-    typedef Basket<Point, WeightSmoothFunc,   CompactPlane, CovariancePlaneFit, ProjectedNormalCovarianceCurvature> FitSmoothProjectedNormalCovariance;
-    typedef Basket<Point, WeightConstantFunc, CompactPlane, CovariancePlaneFit, ProjectedNormalCovarianceCurvature> FitConstantProjectedNormalCovariance;
+    typedef Basket<Point, WeightSmoothFunc, CompactPlane, CovariancePlaneFit, NormalCovarianceCurvature>
+        FitSmoothNormalCovariance;
+    typedef Basket<Point, WeightConstantFunc, CompactPlane, CovariancePlaneFit, NormalCovarianceCurvature>
+        FitConstantNormalCovariance;
+    typedef Basket<Point, WeightSmoothFunc, CompactPlane, CovariancePlaneFit, ProjectedNormalCovarianceCurvature>
+        FitSmoothProjectedNormalCovariance;
+    typedef Basket<Point, WeightConstantFunc, CompactPlane, CovariancePlaneFit, ProjectedNormalCovarianceCurvature>
+        FitConstantProjectedNormalCovariance;
 
     cout << "Testing with perfect sphere..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothProjectedNormalCovariance>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantProjectedNormalCovariance>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothProjectedNormalCovariance>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantProjectedNormalCovariance>()));
     }
     cout << "Ok..." << endl;
 
-//    cout << "Testing with noisy sphere..." << endl;
-//    for(int i = 0; i < g_repeat; ++i)
-//    {
-//        CALL_SUBTEST(( testFunction<Point, FitSmoothNormalCovariance>(true, true) ));
-//        CALL_SUBTEST(( testFunction<Point, FitConstantNormalCovariance>(true, true) ));
-//        CALL_SUBTEST(( testFunction<Point, FitSmoothProjectedNormalCovariance>(true, true) ));
-//        CALL_SUBTEST(( testFunction<Point, FitConstantProjectedNormalCovariance>(true, true) ));
-//    }
-//    cout << "Ok..." << endl;
+    //    cout << "Testing with noisy sphere..." << endl;
+    //    for(int i = 0; i < g_repeat; ++i)
+    //    {
+    //        CALL_SUBTEST(( testFunction<Point, FitSmoothNormalCovariance>(true, true) ));
+    //        CALL_SUBTEST(( testFunction<Point, FitConstantNormalCovariance>(true, true) ));
+    //        CALL_SUBTEST(( testFunction<Point, FitSmoothProjectedNormalCovariance>(true, true) ));
+    //        CALL_SUBTEST(( testFunction<Point, FitConstantProjectedNormalCovariance>(true, true) ));
+    //    }
+    //    cout << "Ok..." << endl;
 }
-
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/dnormal_orthogonal_derivatives.cpp
+++ b/tests/src/dnormal_orthogonal_derivatives.cpp
@@ -4,7 +4,6 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
   \file tests/src/dnormal_orthogonal_derivatives.cpp
   \brief Test validity of the spatial differentiation of normal
@@ -30,23 +29,29 @@ using namespace Ponca;
 
 int kmax =
 #ifdef NDEBUG
-        g_repeat;
+    g_repeat;
 #else
-        1;
+    1;
 #endif
 
-
 /// Helper class used to test fits that are restricted to a specific number of dimensions
-template<int Dim>
-struct Helper{
-    template<typename Scalar> void testRestrictedFits(){}
-    template<typename Scalar, typename V, typename M>
-    void testCov(Scalar curvature, Scalar epsilon, const V& normal, const M& dNormal){}
+template <int Dim>
+struct Helper
+{
+    template <typename Scalar>
+    void testRestrictedFits()
+    {
+    }
+    template <typename Scalar, typename V, typename M>
+    void testCov(Scalar curvature, Scalar epsilon, const V& normal, const M& dNormal)
+    {
+    }
 };
 
-template<>
-template<typename Scalar, typename V, typename M>
-void Helper<3>::testCov(Scalar curvature, Scalar epsilon, const V& normal, const M& dN) {
+template <>
+template <typename Scalar, typename V, typename M>
+void Helper<3>::testCov(Scalar curvature, Scalar epsilon, const V& normal, const M& dN)
+{
     Eigen::SelfAdjointEigenSolver<M> solver(dN);
 
     VERIFY(std::abs(solver.eigenvalues()[0]) < epsilon);
@@ -58,121 +63,117 @@ void Helper<3>::testCov(Scalar curvature, Scalar epsilon, const V& normal, const
     VERIFY(std::abs(normal.dot(solver.eigenvectors().col(2))) < epsilon);
 }
 
-
-template<typename FitType, typename Functor>
+template <typename FitType, typename Functor>
 void test_orthoDerivatives(Functor f, bool skipCov = false)
 {
-    using Point = typename FitType::DataPoint;
+    using Point      = typename FitType::DataPoint;
     using VectorType = typename Point::VectorType;
     using MatrixType = typename Point::MatrixType;
-    using Scalar = typename FitType::Scalar;
+    using Scalar     = typename FitType::Scalar;
 
-    //generate samples on a sphere
+    // generate samples on a sphere
     int nbPoints = Eigen::internal::random<int>(1000, 3000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
-    Scalar curvature = Scalar(1.)/radius;
-    VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
+    Scalar radius        = Eigen::internal::random<Scalar>(1, 10);
+    Scalar curvature     = Scalar(1.) / radius;
+    VectorType center    = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
     Scalar analysisScale = Eigen::internal::random<Scalar>(Scalar(0.3), std::sqrt(Scalar(2))) * radius;
-    Scalar epsilon = testEpsilon<Scalar>();
+    Scalar epsilon       = testEpsilon<Scalar>();
 
     vector<Point> vecs(nbPoints);
-    for(unsigned int i = 0; i < vecs.size(); ++i)
+    for (unsigned int i = 0; i < vecs.size(); ++i)
         vecs[i] = getPointOnSphere<Point>(radius, center, false, false);
 
     FitType fit;
 
     // Quick testing is requested for coverage
     int slice = QUICK_TESTS ? 1 : 10;
-    int size = QUICK_TESTS ? 1 : int(vecs.size())/slice;
+    int size  = QUICK_TESTS ? 1 : int(vecs.size()) / slice;
 
 #ifdef NDEBUG
-#pragma omp parallel for private(fit)
+#    pragma omp parallel for private(fit)
 #endif
-    for(int k=0; k<size; ++k)
+    for (int k = 0; k < size; ++k)
     {
-        fit.setNeighborFilter({vecs[k*slice].pos(), analysisScale});
+        fit.setNeighborFilter({vecs[k * slice].pos(), analysisScale});
         fit.compute(vecs);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
-            auto res = f(fit);
-            typename Point::VectorType normal  = res.first;  //fit.primitiveGradient();
-            typename Point::MatrixType dN = res.second.template middleCols<Point::Dim>(FitType::isScaleDer() ? 1: 0);
+            auto res                          = f(fit);
+            typename Point::VectorType normal = res.first; // fit.primitiveGradient();
+            typename Point::MatrixType dN = res.second.template middleCols<Point::Dim>(FitType::isScaleDer() ? 1 : 0);
 
             // check that we have unitary normal vector
-            VERIFY( normal.norm() - Scalar(1) < epsilon );
+            VERIFY(normal.norm() - Scalar(1) < epsilon);
 
             auto proj = (normal.transpose() * dN).eval();
-            VERIFY( (proj.array() < epsilon).all() );
+            VERIFY((proj.array() < epsilon).all());
 
-            if( ! skipCov)
+            if (!skipCov)
                 Helper<Point::Dim>().testCov(curvature, epsilon, normal, dN);
         }
     }
 }
 
-
-template<>
-template<typename Scalar>
-void Helper<3>::testRestrictedFits() {
+template <>
+template <typename Scalar>
+void Helper<3>::testRestrictedFits()
+{
     typedef PointPositionNormal<Scalar, 3> Point;
-    typedef DistWeightFunc<Point,SmoothWeightKernel<Scalar> > WeightFunc;
-    using PlaneFit    = BasketDiff<
-            Basket<Point, WeightFunc, CovariancePlaneFit>,
-            FitScaleSpaceDer, CovariancePlaneDer>;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightFunc;
+    using PlaneFit = BasketDiff<Basket<Point, WeightFunc, CovariancePlaneFit>, FitScaleSpaceDer, CovariancePlaneDer>;
 
-    for(int k=0; k<kmax; ++k) {
-        CALL_SUBTEST(test_orthoDerivatives<PlaneFit>([](auto&fit){
-            return std::make_pair(fit.primitiveGradient(), fit.dNormal());}, true));
+    for (int k = 0; k < kmax; ++k)
+    {
+        CALL_SUBTEST(test_orthoDerivatives<PlaneFit>(
+            [](auto& fit) { return std::make_pair(fit.primitiveGradient(), fit.dNormal()); }, true));
     }
 };
 
-
-template<typename Scalar, int Dim>
-void _testAdimensionalFits(){
+template <typename Scalar, int Dim>
+void _testAdimensionalFits()
+{
     cout << "Test in dimension " << Dim << std::endl;
 
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point,SmoothWeightKernel<Scalar> > WeightFunc;
-    using SphereFit    = BasketDiff<
-            Basket<Point, WeightFunc, OrientedSphereFit>,
-            FitScaleSpaceDer, OrientedSphereDer>;
-    using MlsSphereFit    = BasketDiff<
-            Basket<Point, WeightFunc, OrientedSphereFit>,
-            FitScaleSpaceDer, OrientedSphereDer, MlsSphereFitDer>;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightFunc;
+    using SphereFit = BasketDiff<Basket<Point, WeightFunc, OrientedSphereFit>, FitScaleSpaceDer, OrientedSphereDer>;
+    using MlsSphereFit =
+        BasketDiff<Basket<Point, WeightFunc, OrientedSphereFit>, FitScaleSpaceDer, OrientedSphereDer, MlsSphereFitDer>;
 
-    for(int k=0; k<kmax; ++k) {
-        CALL_SUBTEST(test_orthoDerivatives<SphereFit>([](auto&fit){
-            return std::make_pair(fit.primitiveGradient(), fit.dNormal());}));
-        CALL_SUBTEST(test_orthoDerivatives<MlsSphereFit>([](auto&fit){
-            return std::make_pair(fit.mlsSphereFitDer().primitiveGradient(),
-                                  fit.mlsSphereFitDer().dNormal());}));
+    for (int k = 0; k < kmax; ++k)
+    {
+        CALL_SUBTEST(test_orthoDerivatives<SphereFit>(
+            [](auto& fit) { return std::make_pair(fit.primitiveGradient(), fit.dNormal()); }));
+        CALL_SUBTEST(test_orthoDerivatives<MlsSphereFit>([](auto& fit) {
+            return std::make_pair(fit.mlsSphereFitDer().primitiveGradient(), fit.mlsSphereFitDer().dNormal());
+        }));
     }
 }
 
-template<typename Scalar, int Dim>
-void testFits(){
+template <typename Scalar, int Dim>
+void testFits()
+{
     _testAdimensionalFits<Scalar, Dim>();
     Helper<Dim>().template testRestrictedFits<Scalar>();
 }
 
-
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
         return EXIT_FAILURE;
 
     cout << "Test orthogonality between the normal vector and its derivatives..." << endl;
 
-    CALL_SUBTEST_1((testFits<float,  2>()));
-    CALL_SUBTEST_2((testFits<double,  2>()));
+    CALL_SUBTEST_1((testFits<float, 2>()));
+    CALL_SUBTEST_2((testFits<double, 2>()));
 
-    CALL_SUBTEST_3((testFits<float,  3>()));
-    CALL_SUBTEST_4((testFits<double,  3>()));
+    CALL_SUBTEST_3((testFits<float, 3>()));
+    CALL_SUBTEST_4((testFits<double, 3>()));
 
-    CALL_SUBTEST_5((testFits<float,  4>()));
-    CALL_SUBTEST_6((testFits<double,  4>()));
+    CALL_SUBTEST_5((testFits<float, 4>()));
+    CALL_SUBTEST_6((testFits<double, 4>()));
 
     return EXIT_SUCCESS;
 }

--- a/tests/src/dnormal_plane.cpp
+++ b/tests/src/dnormal_plane.cpp
@@ -17,51 +17,46 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename Fit>
-void testFunction(bool _bAddPositionNoise = false, bool /*_bAddNormalNoise */= false)
+template <typename DataPoint, typename Fit>
+void testFunction(bool _bAddPositionNoise = false, bool /*_bAddNormalNoise */ = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
     typedef typename DataPoint::MatrixType MatrixType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar width  = Eigen::internal::random<Scalar>(1., 10.);
     Scalar height = width;
 
-    Scalar analysisScale = Scalar(20.) * std::sqrt( width * height / nbPoints);
-    Scalar centerScale   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar analysisScale = Scalar(20.) * std::sqrt(width * height / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType center    = VectorType::Random() * centerScale;
     VectorType direction = VectorType::Random().normalized();
     VectorType xAxis, yAxis;
     int i0 = -1, i1 = -1, i2 = -1;
     direction.minCoeff(&i0);
-    i1 = (i0+1)%3;
-    i2 = (i0+2)%3;
+    i1        = (i0 + 1) % 3;
+    i2        = (i0 + 2) % 3;
     xAxis[i0] = 0;
     xAxis[i1] = direction[i2];
     xAxis[i2] = -direction[i1];
-    yAxis[i0] = direction[i1]*direction[i1] + direction[i2]*direction[i2];
-    yAxis[i1] = -direction[i1]*direction[i0];
-    yAxis[i2] = -direction[i2]*direction[i0];
+    yAxis[i0] = direction[i1] * direction[i1] + direction[i2] * direction[i2];
+    yAxis[i1] = -direction[i1] * direction[i0];
+    yAxis[i2] = -direction[i2] * direction[i0];
 
     Scalar epsilon = testEpsilon<Scalar>();
-    if( _bAddPositionNoise ) // relax a bit the testing threshold
+    if (_bAddPositionNoise) // relax a bit the testing threshold
         epsilon = Scalar(.1);
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnRectangularPlane<DataPoint>(center,
-                                                                direction,
-                                                                width,
-                                                                height,
-                                                                xAxis,
-                                                                yAxis,
-                                                                _bAddPositionNoise);
+        vectorPoints[i] =
+            getPointOnRectangularPlane<DataPoint>(center, direction, width, height, xAxis, yAxis, _bAddPositionNoise);
         vectorPoints[i].normal() = direction;
     }
 
@@ -70,56 +65,62 @@ void testFunction(bool _bAddPositionNoise = false, bool /*_bAddNormalNoise */= f
 
     // Test for each point if dNormal is null
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
             MatrixType dN = fit.dNormal().template rightCols<DataPoint::Dim>();
-            Scalar diff = dN.array().abs().maxCoeff();
+            Scalar diff   = dN.array().abs().maxCoeff();
 
-            VERIFY( diff < epsilon );
+            VERIFY(diff < epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothOrientedSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereSpaceDer> FitConstantOrientedSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothOrientedScaleSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantOrientedScaleSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothOrientedSpaceMlsDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantOrientedSpaceMlsDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothOrientedScaleSpaceMlsDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantOrientedScaleSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothOrientedSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantOrientedSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer>
+        FitSmoothOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer>
+        FitConstantOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedScaleSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedScaleSpaceMlsDer;
 
     cout << "Testing with perfect plane (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceMlsDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceMlsDer>()));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/dnormal_sphere.cpp
+++ b/tests/src/dnormal_sphere.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
@@ -25,23 +25,23 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
     typedef typename DataPoint::VectorType VectorType;
     typedef typename DataPoint::MatrixType MatrixType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
-    Scalar curvature = Scalar(1.)/radius;
+    Scalar radius    = Eigen::internal::random<Scalar>(1, 10);
+    Scalar curvature = Scalar(1.) / radius;
 
     VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
 
     Scalar analysisScale = Eigen::internal::random<Scalar>(0.3, std::sqrt(2.f)) * radius;
 
     Scalar epsilon = testEpsilon<Scalar>();
-    if( _bAddPositionNoise ) // relax a bit the testing threshold
+    if (_bAddPositionNoise) // relax a bit the testing threshold
         epsilon = Scalar(0.1);
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise);
     }
@@ -51,65 +51,71 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test for each point if dNormal is correct
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
-            VectorType normal = (vectorPoints[i].pos()-center).normalized();
+            VectorType normal = (vectorPoints[i].pos() - center).normalized();
 
             MatrixType dN = fit.dNormal().template rightCols<DataPoint::Dim>();
 
             Eigen::SelfAdjointEigenSolver<MatrixType> solver(dN);
 
-            VERIFY( std::abs(solver.eigenvalues()[0]) < epsilon );
-            VERIFY( std::abs(solver.eigenvalues()[1]-curvature) < epsilon);
-            VERIFY( std::abs(solver.eigenvalues()[2]-curvature) < epsilon);
+            VERIFY(std::abs(solver.eigenvalues()[0]) < epsilon);
+            VERIFY(std::abs(solver.eigenvalues()[1] - curvature) < epsilon);
+            VERIFY(std::abs(solver.eigenvalues()[2] - curvature) < epsilon);
 
-            VERIFY( std::abs(1-std::abs(normal.dot(solver.eigenvectors().col(0)))) < epsilon );
-            VERIFY( std::abs(normal.dot(solver.eigenvectors().col(1))) < epsilon );
-            VERIFY( std::abs(normal.dot(solver.eigenvectors().col(2))) < epsilon );
+            VERIFY(std::abs(1 - std::abs(normal.dot(solver.eigenvectors().col(0)))) < epsilon);
+            VERIFY(std::abs(normal.dot(solver.eigenvectors().col(1))) < epsilon);
+            VERIFY(std::abs(normal.dot(solver.eigenvectors().col(2))) < epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothOrientedSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereSpaceDer> FitConstantOrientedSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothOrientedScaleSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantOrientedScaleSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothOrientedSpaceMlsDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantOrientedSpaceMlsDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothOrientedScaleSpaceMlsDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantOrientedScaleSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothOrientedSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantOrientedSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer>
+        FitSmoothOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer>
+        FitConstantOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedScaleSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedScaleSpaceMlsDer;
 
     cout << "Testing with perfect plane (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceMlsDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceMlsDer>()));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/dpotential_plane.cpp
+++ b/tests/src/dpotential_plane.cpp
@@ -17,38 +17,34 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar width  = Eigen::internal::random<Scalar>(1., 10.);
     Scalar height = width;
 
-    Scalar analysisScale = Scalar(15.) * std::sqrt( width * height / nbPoints);
-    Scalar centerScale   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar analysisScale = Scalar(15.) * std::sqrt(width * height / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType center    = VectorType::Random() * centerScale;
 
     VectorType direction = VectorType::Random().normalized();
 
     Scalar epsilon = testEpsilon<Scalar>();
-    if( _bAddPositionNoise ) // relax a bit the testing threshold
-        epsilon = Scalar(0.002*MAX_NOISE);
+    if (_bAddPositionNoise) // relax a bit the testing threshold
+        epsilon = Scalar(0.002 * MAX_NOISE);
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnPlane<DataPoint>(center,
-                                                     direction,
-                                                     width,
-                                                     _bAddPositionNoise,
-                                                     _bAddNormalNoise);
+        vectorPoints[i] = getPointOnPlane<DataPoint>(center, direction, width, _bAddPositionNoise, _bAddNormalNoise);
     }
 
     // Quick testing is requested for coverage
@@ -56,79 +52,83 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test for each point if the dPotential is correctly oriented
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
             VectorType estimated = fit.dPotential().template tail<DataPoint::Dim>();
 
-            Scalar norm = estimated.norm();
-            Scalar absdot = std::abs(direction.dot(estimated/norm));
+            Scalar norm   = estimated.norm();
+            Scalar absdot = std::abs(direction.dot(estimated / norm));
 
-            VERIFY( std::abs(absdot-Scalar(1.)) < epsilon );
+            VERIFY(std::abs(absdot - Scalar(1.)) < epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothSpaceDer;
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantSpaceDer;   
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothScaleSpaceDer;   
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantScaleSpaceDer;   
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothSpaceMlsDer;
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantSpaceMlsDer;   
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothScaleSpaceMlsDer;   
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantScaleSpaceMlsDer;   
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothScaleSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantScaleSpaceMlsDer;
 
     cout << "Testing with perfect plane (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceMlsDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceMlsDer>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceMlsDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceMlsDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceMlsDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceMlsDer>(true, true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceMlsDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceMlsDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceMlsDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceMlsDer>(true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }
 
     cout << "Test dPotential" << endl;
 
-    //callSubTests<double, 2>();
+    // callSubTests<double, 2>();
     callSubTests<float, 3>();
     callSubTests<long double, 3>();
     callSubTests<double, 3>();

--- a/tests/src/dpotential_sphere.cpp
+++ b/tests/src/dpotential_sphere.cpp
@@ -17,27 +17,27 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
+    Scalar radius     = Eigen::internal::random<Scalar>(1, 10);
     VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
 
     Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
 
     Scalar epsilon = testEpsilon<Scalar>();
-    //Scalar radisuEpsilon = epsilon * radius;
+    // Scalar radisuEpsilon = epsilon * radius;
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise);
     }
@@ -47,80 +47,84 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test for each point if the dPotential is correctly oriented
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
             VectorType estimated = fit.dPotential().template tail<DataPoint::Dim>();
-            VectorType normal    = (center-vectorPoints[i].pos()).normalized();
+            VectorType normal    = (center - vectorPoints[i].pos()).normalized();
 
-            Scalar norm = estimated.norm();
-            Scalar absdot = std::abs(normal.dot(estimated/norm));
+            Scalar norm   = estimated.norm();
+            Scalar absdot = std::abs(normal.dot(estimated / norm));
 
-            VERIFY( std::abs(absdot-Scalar(1.)) < epsilon );
+            VERIFY(std::abs(absdot - Scalar(1.)) < epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothSpaceDer;
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantSpaceDer;   
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothScaleSpaceDer;   
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantScaleSpaceDer;   
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothSpaceMlsDer;
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantSpaceMlsDer;   
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothScaleSpaceMlsDer;   
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantScaleSpaceMlsDer;   
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothScaleSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantScaleSpaceMlsDer;
 
     cout << "Testing with perfect sphere (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceMlsDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceMlsDer>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothSpaceMlsDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantSpaceMlsDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleSpaceMlsDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleSpaceMlsDer>(true, true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothSpaceMlsDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantSpaceMlsDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleSpaceMlsDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleSpaceMlsDer>(true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }
 
     cout << "Test dPotential" << endl;
 
-    //callSubTests<double, 2>();
+    // callSubTests<double, 2>();
     callSubTests<float, 3>();
     callSubTests<long double, 3>();
     callSubTests<double, 3>();

--- a/tests/src/fit_cov.cpp
+++ b/tests/src/fit_cov.cpp
@@ -6,7 +6,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/src/fit_cov.cpp
  \brief Test validity of the covariance fitting procedures wrt to standard algorithm
@@ -27,9 +26,8 @@
 using namespace std;
 using namespace Ponca;
 
-
 /// Class that perform the covariance fit using standard two-passes procedure
-template < class DataPoint, class _NFilter, typename T>
+template <class DataPoint, class _NFilter, typename T>
 class CovarianceFitTwoPassesBase : public T
 {
     PONCA_FITTING_DECLARE_DEFAULT_TYPES
@@ -48,23 +46,22 @@ public:
 
 protected:
     // computation data
-    MatrixType m_cov {MatrixType::Zero()};     /*!< \brief Covariance matrix */
-    Solver m_solver;  /*!<\brief Solver used to analyse the covariance matrix */
-    bool m_barycenterReady {false};
+    MatrixType m_cov{MatrixType::Zero()}; /*!< \brief Covariance matrix */
+    Solver m_solver;                      /*!<\brief Solver used to analyse the covariance matrix */
+    bool m_barycenterReady{false};
     VectorType m_barycenter;
     Scalar sumW;
 
 public:
-    PONCA_EXPLICIT_CAST_OPERATORS(CovarianceFitTwoPassesBase,covarianceFitTwoPasses)
+    PONCA_EXPLICIT_CAST_OPERATORS(CovarianceFitTwoPassesBase, covarianceFitTwoPasses)
     PONCA_FITTING_DECLARE_INIT_ADD_FINALIZE
 
     /*! \brief Reading access to the Solver used to analyse the covariance matrix */
     PONCA_MULTIARCH inline const Solver& solver() const { return m_solver; }
 };
 
-template < class DataPoint, class _NFilter, typename T>
-void
-CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::init()
+template <class DataPoint, class _NFilter, typename T>
+void CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::init()
 {
     Base::init();
     m_cov.setZero();
@@ -73,68 +70,67 @@ CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::init()
     sumW = Scalar(0);
 }
 
-template < class DataPoint, class _NFilter, typename T>
-bool
-CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w,
-                                                             const VectorType &localQ,
-                                                             const DataPoint &attributes)
+template <class DataPoint, class _NFilter, typename T>
+bool CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::addLocalNeighbor(Scalar w, const VectorType& localQ,
+                                                                          const DataPoint& attributes)
 {
-    if( ! m_barycenterReady )  /// first pass
+    if (!m_barycenterReady) /// first pass
     {
         return Base::addLocalNeighbor(w, localQ, attributes);
     }
-    else {                     /// second pass
+    else
+    {                                         /// second pass
         VectorType q = localQ - m_barycenter; // saved from previous run
-        m_cov  += w * q * q.transpose();
-        sumW   += w;
+        m_cov += w * q * q.transpose();
+        sumW += w;
         return true;
     }
     return false;
 }
 
-
-template < class DataPoint, class _NFilter, typename T>
-FIT_RESULT
-CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::finalize ()
+template <class DataPoint, class _NFilter, typename T>
+FIT_RESULT CovarianceFitTwoPassesBase<DataPoint, _NFilter, T>::finalize()
 {
-    if( ! m_barycenterReady ){   /// end of the first pass
+    if (!m_barycenterReady)
+    { /// end of the first pass
         auto ret = Base::finalize();
-        if(ret == STABLE) {
+        if (ret == STABLE)
+        {
             m_barycenterReady = true;
-            m_barycenter = Base::barycenterLocal();
+            m_barycenter      = Base::barycenterLocal();
             return NEED_OTHER_PASS;
         }
         // handle specific configurations
-        if( ret != STABLE)
+        if (ret != STABLE)
             return Base::m_eCurrentState;
-        }
-    else {                       /// end of the second pass
+    }
+    else
+    { /// end of the second pass
         // Normalize covariance matrix
-        m_cov /= sumW ;  /// \warning There is a bug in the pass system that prevents to call Base::getWeightSum();
+        m_cov /= sumW; /// \warning There is a bug in the pass system that prevents to call Base::getWeightSum();
 
         m_solver.compute(m_cov);
-        Base::m_eCurrentState = ( m_solver.info() == Eigen::Success ? STABLE : UNDEFINED );
+        Base::m_eCurrentState = (m_solver.info() == Eigen::Success ? STABLE : UNDEFINED);
     }
 
     return Base::m_eCurrentState;
 }
 
-
-template<typename DataPoint, typename Fit, typename FitRef>
+template <typename DataPoint, typename Fit, typename FitRef>
 void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar width  = Eigen::internal::random<Scalar>(1., 10.);
     Scalar height = width;
 
-    Scalar analysisScale = Scalar(15.) * std::sqrt( width * height / nbPoints);
-    Scalar centerScale   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar analysisScale = Scalar(15.) * std::sqrt(width * height / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType center    = VectorType::Random() * centerScale;
 
     VectorType direction = VectorType::Random().normalized();
@@ -142,26 +138,22 @@ void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bo
     Scalar epsilon = testEpsilon<Scalar>();
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnPlane<DataPoint>(center,
-                                                     direction,
-                                                     width,
-                                                     _bAddPositionNoise,
-                                                     _bAddNormalNoise,
-                                                     _bUnoriented);
+        vectorPoints[i] =
+            getPointOnPlane<DataPoint>(center, direction, width, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
     }
 
     epsilon = testEpsilon<Scalar>();
-    if ( _bAddPositionNoise) // relax a bit the testing threshold
-      epsilon = Scalar(0.01*MAX_NOISE);
+    if (_bAddPositionNoise) // relax a bit the testing threshold
+        epsilon = Scalar(0.01 * MAX_NOISE);
 
     // Quick testing is requested for coverage
     int size = QUICK_TESTS ? 1 : int(vectorPoints.size());
 
     // Test for each point if the fitted plane correspond to the theoretical plane
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
 
         Fit fit;
@@ -174,29 +166,27 @@ void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bo
 
         VERIFY(fitState == refState);
 
-        auto checkVectors = [](const VectorType& x, const VectorType& y){
-            Scalar values =  std::min(
-                    (x.array() - y.array()).abs().matrix().squaredNorm(),
-                    (x.array() + y.array()).abs().matrix().squaredNorm()); // deal with sign ambiguity
-            VERIFY( Eigen::internal::isApproxOrLessThan(values, Scalar(1e-5)) );
+        auto checkVectors = [](const VectorType& x, const VectorType& y) {
+            Scalar values = std::min((x.array() - y.array()).abs().matrix().squaredNorm(),
+                                     (x.array() + y.array()).abs().matrix().squaredNorm()); // deal with sign ambiguity
+            VERIFY(Eigen::internal::isApproxOrLessThan(values, Scalar(1e-5)));
         };
 
         // check we get the same decomposition
-        checkVectors(fit.covarianceFit().solver().eigenvalues(),
-                     ref.covarianceFitTwoPasses().solver().eigenvalues());
+        checkVectors(fit.covarianceFit().solver().eigenvalues(), ref.covarianceFitTwoPasses().solver().eigenvalues());
         for (int d = 0; d != 3; ++d)
             checkVectors(fit.covarianceFit().solver().eigenvectors().col(d),
                          ref.covarianceFitTwoPasses().solver().eigenvectors().col(d));
-        }
+    }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     typedef Basket<Point, WeightSmoothFunc, MeanPosition, CovarianceFitBase> CovFitSmooth;
     typedef Basket<Point, WeightConstantFunc, MeanPosition, CovarianceFitBase> CovFitConstant;
@@ -204,28 +194,27 @@ void callSubTests()
     typedef Basket<Point, WeightSmoothFunc, PrimitiveBase, MeanPosition, CovarianceFitTwoPassesBase> RefFitSmooth;
     typedef Basket<Point, WeightConstantFunc, PrimitiveBase, MeanPosition, CovarianceFitTwoPassesBase> RefFitConstant;
 
-
     cout << "Testing with data sampling a perfect plane..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect plane
-        CALL_SUBTEST(( testFunction<Point, CovFitSmooth, RefFitSmooth>() ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant, RefFitConstant>() ));
+        // Test with perfect plane
+        CALL_SUBTEST((testFunction<Point, CovFitSmooth, RefFitSmooth>()));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant, RefFitConstant>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position" << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, CovFitSmooth, RefFitSmooth>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant, RefFitConstant>(false, true, true) ));
+        CALL_SUBTEST((testFunction<Point, CovFitSmooth, RefFitSmooth>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant, RefFitConstant>(false, true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/fit_line.cpp
+++ b/tests/src/fit_line.cpp
@@ -1,7 +1,7 @@
 
 /*
  Copyright (C) 2021 aniket agarwalla <aniketagarwalla37@gmail.com>
- 
+
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -26,26 +26,25 @@
 using namespace std;
 using namespace Ponca;
 
-
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled line
+    // generate sampled line
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     VectorType _direction = VectorType::Random().normalized();
 
-    Scalar epsilon = testEpsilon<Scalar>();
+    Scalar epsilon      = testEpsilon<Scalar>();
     auto noiseMagnitude = static_cast<Scalar>(0.001);
 
     vector<DataPoint> vectorPoints(nbPoints);
-    std::generate(vectorPoints.begin(), vectorPoints.end(), [&_direction,_bAddPositionNoise,noiseMagnitude]() {
-        return DataPoint(_direction * Eigen::internal::random<Scalar>(Scalar(0.1),Scalar(2))
-                + ( _bAddPositionNoise ? (VectorType::Random() * noiseMagnitude).eval() : VectorType::Zero() ));
+    std::generate(vectorPoints.begin(), vectorPoints.end(), [&_direction, _bAddPositionNoise, noiseMagnitude]() {
+        return DataPoint(_direction * Eigen::internal::random<Scalar>(Scalar(0.1), Scalar(2)) +
+                         (_bAddPositionNoise ? (VectorType::Random() * noiseMagnitude).eval() : VectorType::Zero()));
     });
 
     epsilon = testEpsilon<Scalar>();
@@ -54,57 +53,55 @@ void testFunction(bool _bAddPositionNoise = false)
     int size = QUICK_TESTS ? 1 : int(vectorPoints.size());
 
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
-        fit.setNeighborFilter({vectorPoints[i].pos(),10});
+        fit.setNeighborFilter({vectorPoints[i].pos(), 10});
         fit.compute(vectorPoints);
 
-        VERIFY( fit.isStable() );
+        VERIFY(fit.isStable());
 
-        if(_bAddPositionNoise)
-            VERIFY((fit.distance(vectorPoints[i].pos())) <= Scalar(4)*noiseMagnitude );
+        if (_bAddPositionNoise)
+            VERIFY((fit.distance(vectorPoints[i].pos())) <= Scalar(4) * noiseMagnitude);
         else
             VERIFY((fit.distance(vectorPoints[i].pos())) <= epsilon);
 
-        VERIFY( Scalar(1) - std::abs( fit.direction().dot(_direction) ) <= epsilon );
+        VERIFY(Scalar(1) - std::abs(fit.direction().dot(_direction)) <= epsilon);
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPosition<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     typedef Basket<Point, WeightSmoothFunc, CovarianceLineFit> LeastSquareFitSmooth;
     typedef Basket<Point, WeightConstantFunc, CovarianceLineFit> LeastSquareFitConstant;
 
-
     cout << "Testing with perfect line..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect line
-        CALL_SUBTEST(( testFunction<Point, LeastSquareFitSmooth>() ));
-        CALL_SUBTEST(( testFunction<Point, LeastSquareFitConstant>() ));
-
+        // Test with perfect line
+        CALL_SUBTEST((testFunction<Point, LeastSquareFitSmooth>()));
+        CALL_SUBTEST((testFunction<Point, LeastSquareFitConstant>()));
     }
     cout << "Ok!" << endl;
 
-     cout << "Testing with noise on position" << endl;
-     for(int i = 0; i < g_repeat; ++i)
-     {
-         CALL_SUBTEST(( testFunction<Point, LeastSquareFitSmooth>(true) ));
-         CALL_SUBTEST(( testFunction<Point, LeastSquareFitConstant>(true) ));
-     }
-     cout << "Ok!" << endl;
+    cout << "Testing with noise on position" << endl;
+    for (int i = 0; i < g_repeat; ++i)
+    {
+        CALL_SUBTEST((testFunction<Point, LeastSquareFitSmooth>(true)));
+        CALL_SUBTEST((testFunction<Point, LeastSquareFitConstant>(true)));
+    }
+    cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/fit_monge_patch.cpp
+++ b/tests/src/fit_monge_patch.cpp
@@ -6,7 +6,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/fit_monge_patch.cpp
  \brief Test validity of monge patch fitting procedure(s)
@@ -17,7 +16,7 @@
 
 #include <Ponca/src/Fitting/basket.h>
 #include <Ponca/src/Fitting/covariancePlaneFit.h>
-//#include <Ponca/src/Fitting/meanPlaneFit.h>
+// #include <Ponca/src/Fitting/meanPlaneFit.h>
 #include <Ponca/src/Fitting/mongePatch.h>
 #include <Ponca/src/Fitting/weightFunc.h>
 #include <Ponca/src/Fitting/weightKernel.h>
@@ -28,21 +27,20 @@
 using namespace std;
 using namespace Ponca;
 
-
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
-    Scalar width  = Eigen::internal::random<Scalar>(1., 10.);
+    Scalar width = Eigen::internal::random<Scalar>(1., 10.);
 
     // we want a large scale to avoid fitting errors
-    Scalar analysisScale = Scalar(4.) * width;//std::sqrt( width * height / nbPoints);
+    Scalar analysisScale = Scalar(4.) * width; // std::sqrt( width * height / nbPoints);
 
     Scalar epsilon = testEpsilon<Scalar>();
 
@@ -52,24 +50,23 @@ void testFunction(bool _bAddPositionNoise = false)
     // we need to use small magnitude for quadratic terms, otherwise the plane fitting is going to be wrong
     const Scalar standardMagnitude = Scalar(1);
     const Scalar smallMagnitude    = Scalar(0.1);
-    auto quadParams = Eigen::Matrix<Scalar, 6, 1>(
-            Eigen::internal::random<Scalar>(-smallMagnitude,smallMagnitude),
-            Eigen::internal::random<Scalar>(-smallMagnitude,smallMagnitude),
-            Eigen::internal::random<Scalar>(-smallMagnitude,smallMagnitude),
-            Eigen::internal::random<Scalar>(-standardMagnitude,standardMagnitude),
-            Eigen::internal::random<Scalar>(-standardMagnitude,standardMagnitude),
-            Eigen::internal::random<Scalar>(-standardMagnitude,standardMagnitude));
+    auto quadParams =
+        Eigen::Matrix<Scalar, 6, 1>(Eigen::internal::random<Scalar>(-smallMagnitude, smallMagnitude),
+                                    Eigen::internal::random<Scalar>(-smallMagnitude, smallMagnitude),
+                                    Eigen::internal::random<Scalar>(-smallMagnitude, smallMagnitude),
+                                    Eigen::internal::random<Scalar>(-standardMagnitude, standardMagnitude),
+                                    Eigen::internal::random<Scalar>(-standardMagnitude, standardMagnitude),
+                                    Eigen::internal::random<Scalar>(-standardMagnitude, standardMagnitude));
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
         vectorPoints[i] = getPointOnParaboloid<DataPoint>(quadParams, width, _bAddPositionNoise);
     }
 
-    epsilon = Scalar(0.1)*width;
-    if ( _bAddPositionNoise) // relax a bit the testing threshold
-      epsilon = std::max(Scalar(0.5*MAX_NOISE), epsilon*2);
+    epsilon = Scalar(0.1) * width;
+    if (_bAddPositionNoise) // relax a bit the testing threshold
+        epsilon = std::max(Scalar(0.5 * MAX_NOISE), epsilon * 2);
     // Test for each point if the fitted plane correspond to the theoretical plane
-
 
     // evaluate only for the point located at 0,0
     const auto queryPos = VectorType::Zero();
@@ -78,31 +75,33 @@ void testFunction(bool _bAddPositionNoise = false)
     fit.setNeighborFilter({queryPos, analysisScale});
     fit.compute(vectorPoints);
 
-    VERIFY( fit.isStable() );
+    VERIFY(fit.isStable());
     {
         // compute RMSE
-        Scalar error {0};
-        unsigned int nbTestSamples = (unsigned int)(vectorPoints.size())/5; // test on fewer samples to speed things up
+        Scalar error{0};
+        unsigned int nbTestSamples =
+            (unsigned int)(vectorPoints.size()) / 5; // test on fewer samples to speed things up
 
         std::vector<VectorType> testPoints(nbTestSamples);
 
-        for(unsigned int i = 0; i < nbTestSamples; ++i)
+        for (unsigned int i = 0; i < nbTestSamples; ++i)
         {
             // get samples on points closer to the center, to avoid over-estimated error near the border
-            const auto point = getPointOnParaboloid<DataPoint>(quadParams, width/2, false).pos();
+            const auto point = getPointOnParaboloid<DataPoint>(quadParams, width / 2, false).pos();
             error += (point - fit.project(point)).norm();
-            testPoints[i]=point;
+            testPoints[i] = point;
         }
         error /= nbTestSamples;
 
-        if(error > epsilon) {
+        if (error > epsilon)
+        {
             std::cerr << "Precision test failed (" << error << "). Dumping files\n";
 #ifndef PONCA_COVERAGE_ENABLED
             {
                 std::ofstream inFile, projFile;
-                inFile.open ("input.xyz");
-                projFile.open ("projected.xyz");
-                for(unsigned int i = 0; i < testPoints.size(); ++i)
+                inFile.open("input.xyz");
+                projFile.open("projected.xyz");
+                for (unsigned int i = 0; i < testPoints.size(); ++i)
                 {
                     inFile << testPoints[i].transpose() << endl;
                     projFile << fit.project(testPoints[i]).transpose() << std::endl;
@@ -116,37 +115,37 @@ void testFunction(bool _bAddPositionNoise = false)
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPosition<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     typedef Basket<Point, WeightSmoothFunc, MongePatchQuadraticFit> CovFitSmooth;
     typedef Basket<Point, WeightConstantFunc, MongePatchQuadraticFit> CovFitConstant;
 
     cout << "Testing with perfect plane..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, CovFitSmooth>() ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant>() ));
+        CALL_SUBTEST((testFunction<Point, CovFitSmooth>()));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with plane noise on position" << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, CovFitSmooth>(true) ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant>(true) ));
+        CALL_SUBTEST((testFunction<Point, CovFitSmooth>(true)));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant>(true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/fit_plane.cpp
+++ b/tests/src/fit_plane.cpp
@@ -6,7 +6,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/fit_plane.cpp
  \brief Test validity of plane fitting procedure(s)
@@ -30,68 +29,66 @@ using namespace std;
 using namespace Ponca;
 
 template <bool check>
-struct CheckSurfaceVariation {
+struct CheckSurfaceVariation
+{
     template <typename Fit, typename Scalar>
-    static inline void run(const Fit& fit, Scalar epsilon){
+    static inline void run(const Fit& fit, Scalar epsilon)
+    {
         VERIFY(fit.surfaceVariation() < epsilon);
     }
 };
 
 template <>
 template <typename Fit, typename Scalar>
-void CheckSurfaceVariation<false>::run(const Fit& /*fit*/, Scalar /*epsilon*/){ }
+void CheckSurfaceVariation<false>::run(const Fit& /*fit*/, Scalar /*epsilon*/)
+{
+}
 
-
-template<typename DataPoint, typename Fit, bool _cSurfVar>
-void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bool _bAddNormalNoise = false, bool conflictAnnounced = false)
+template <typename DataPoint, typename Fit, bool _cSurfVar>
+void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bool _bAddNormalNoise = false,
+                  bool conflictAnnounced = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     // use large width to reduce relative influence of the positional noise
     Scalar width  = Eigen::internal::random<Scalar>(100., 200.);
     Scalar height = width;
 
-    Scalar analysisScale = Scalar(15.) * std::sqrt( width * height / nbPoints);
-    Scalar centerScale   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar analysisScale = Scalar(15.) * std::sqrt(width * height / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType center    = VectorType::Random() * centerScale;
 
     VectorType direction = VectorType::Random().normalized();
 
     Scalar epsilon = testEpsilon<Scalar>();
     // epsilon is relative to the radius size
-    //Scalar radiusEpsilon = epsilon * radius;
+    // Scalar radiusEpsilon = epsilon * radius;
 
-
-//    // Create a local basis on the plane by crossing with global XYZ basis
-//    // This test can be useful to check if we can retrieve the local basis
-//    static const VectorType yAxis(0., 1., 0.);
-//    static const VectorType zAxis(0., 0., 1.);
-//    VectorType localxAxis =
-//            Scalar(1.) - direction.dot(yAxis) > Scalar(0.1) // angle sufficient to cross
-//            ? direction.cross(yAxis)
-//            : direction.cross(zAxis);
-//    VectorType localyAxis = direction.cross(localxAxis);
-
+    //    // Create a local basis on the plane by crossing with global XYZ basis
+    //    // This test can be useful to check if we can retrieve the local basis
+    //    static const VectorType yAxis(0., 1., 0.);
+    //    static const VectorType zAxis(0., 0., 1.);
+    //    VectorType localxAxis =
+    //            Scalar(1.) - direction.dot(yAxis) > Scalar(0.1) // angle sufficient to cross
+    //            ? direction.cross(yAxis)
+    //            : direction.cross(zAxis);
+    //    VectorType localyAxis = direction.cross(localxAxis);
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnPlane<DataPoint>(center,
-                                                     direction,
-                                                     width,
-                                                     _bAddPositionNoise,
-                                                     _bAddNormalNoise,
-                                                     _bUnoriented);
+        vectorPoints[i] =
+            getPointOnPlane<DataPoint>(center, direction, width, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
     }
 
     epsilon = testEpsilon<Scalar>();
-    if ( _bAddPositionNoise) // relax a bit the testing threshold
-      epsilon = Scalar(0.01*MAX_NOISE);
+    if (_bAddPositionNoise) // relax a bit the testing threshold
+        epsilon = Scalar(0.01 * MAX_NOISE);
     // Test for each point if the fitted plane correspond to the theoretical plane
 
     KdTreeDense<DataPoint> tree(vectorPoints);
@@ -100,50 +97,52 @@ void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bo
     int size = QUICK_TESTS ? 1 : int(vectorPoints.size());
 
 #ifdef DEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
 
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
-        fit.computeWithIds(tree.rangeNeighbors(vectorPoints[i].pos(),analysisScale),vectorPoints);
+        fit.computeWithIds(tree.rangeNeighbors(vectorPoints[i].pos(), analysisScale), vectorPoints);
 
         auto ret = fit.getCurrentState();
 
-        switch (ret){
-            case STABLE: {
-                // Check if the plane orientation is equal to the generation direction
-                auto primGrad = fit.primitiveGradient(vectorPoints[i].pos());
-                auto gen_dir = std::abs(primGrad.dot(direction));
+        switch (ret)
+        {
+        case STABLE: {
+            // Check if the plane orientation is equal to the generation direction
+            auto primGrad = fit.primitiveGradient(vectorPoints[i].pos());
+            auto gen_dir  = std::abs(primGrad.dot(direction));
 
-                VERIFY(Scalar(1.) - gen_dir <= epsilon);
+            VERIFY(Scalar(1.) - gen_dir <= epsilon);
 
-                // Check if the surface variation is small
-                CheckSurfaceVariation<_cSurfVar>::run(fit, _bAddPositionNoise ? epsilon*Scalar(10.): epsilon);
+            // Check if the surface variation is small
+            CheckSurfaceVariation<_cSurfVar>::run(fit, _bAddPositionNoise ? epsilon * Scalar(10.) : epsilon);
 
-                // Check if the query point is on the plane
-                if(!_bAddPositionNoise)
-                    VERIFY(std::abs(fit.potential(vectorPoints[i].pos())) <= epsilon);
-                break;
-            }
-            case CONFLICT_ERROR_FOUND:
-                VERIFY(conflictAnnounced); // raise error only if conflict is detected but not announced
-                break;
-            default:
-                VERIFY(MULTIPASS_PLANE_FITTING_FAILED);
+            // Check if the query point is on the plane
+            if (!_bAddPositionNoise)
+                VERIFY(std::abs(fit.potential(vectorPoints[i].pos())) <= epsilon);
+            break;
+        }
+        case CONFLICT_ERROR_FOUND:
+            VERIFY(conflictAnnounced); // raise error only if conflict is detected but not announced
+            break;
+        default:
+            VERIFY(MULTIPASS_PLANE_FITTING_FAILED);
         };
-        if(conflictAnnounced) VERIFY(ret == CONFLICT_ERROR_FOUND); //check if we did not detect the conflict
+        if (conflictAnnounced)
+            VERIFY(ret == CONFLICT_ERROR_FOUND); // check if we did not detect the conflict
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef Ponca::DistWeightFunc<Point, Ponca::ConstantWeightKernel<Scalar> > WeightConstantFuncLocal;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef Ponca::DistWeightFunc<Point, Ponca::ConstantWeightKernel<Scalar>> WeightConstantFuncLocal;
     typedef Ponca::NoWeightFuncGlobal<Point> NoWeightFuncGlobal;
     typedef Ponca::NoWeightFunc<Point> NoWeightFunc;
 
@@ -159,46 +158,47 @@ void callSubTests()
 
     // test if conflicts are detected
     //! [Conflicting type]
-    typedef Basket<Point, NoWeightFuncGlobal, Plane,
-            MeanNormal, MeanPosition, MeanPlaneFitImpl,
-            CovarianceFitBase, CovariancePlaneFitImpl> Hybrid1; //test conflict detection in one direction
+    typedef Basket<Point, NoWeightFuncGlobal, Plane, MeanNormal, MeanPosition, MeanPlaneFitImpl, CovarianceFitBase,
+                   CovariancePlaneFitImpl>
+        Hybrid1; // test conflict detection in one direction
     //! [Conflicting type]
-    typedef Basket<Point, NoWeightFuncGlobal, Plane,
-            MeanPosition, CovarianceFitBase, CovariancePlaneFitImpl,
-            MeanNormal, MeanPlaneFitImpl> Hybrid2;  //test conflict detection in the second direction
+    typedef Basket<Point, NoWeightFuncGlobal, Plane, MeanPosition, CovarianceFitBase, CovariancePlaneFitImpl,
+                   MeanNormal, MeanPlaneFitImpl>
+        Hybrid2; // test conflict detection in the second direction
 
     cout << "Testing with perfect plane..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect plane
-        CALL_SUBTEST(( testFunction<Point, CovFitSmooth, true>() ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant, true>() ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant2, true>() ));
-        CALL_SUBTEST(( testFunction<Point, MeanFitConstantGlobal, false>() ));
-        CALL_SUBTEST(( testFunction<Point, MeanFitSmooth, false>() ));
-        CALL_SUBTEST(( testFunction<Point, MeanFitConstant, false>() ));
-        CALL_SUBTEST(( testFunction<Point, MeanFitConstant2, false>() ));
-        CALL_SUBTEST(( testFunction<Point, MeanFitConstantGlobal, false>() ));
+        // Test with perfect plane
+        CALL_SUBTEST((testFunction<Point, CovFitSmooth, true>()));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant, true>()));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant2, true>()));
+        CALL_SUBTEST((testFunction<Point, MeanFitConstantGlobal, false>()));
+        CALL_SUBTEST((testFunction<Point, MeanFitSmooth, false>()));
+        CALL_SUBTEST((testFunction<Point, MeanFitConstant, false>()));
+        CALL_SUBTEST((testFunction<Point, MeanFitConstant2, false>()));
+        CALL_SUBTEST((testFunction<Point, MeanFitConstantGlobal, false>()));
         // Check if fitting conflict is detected
-        CALL_SUBTEST(( testFunction<Point, Hybrid1, false>(false, false, false, true) ));
-        CALL_SUBTEST(( testFunction<Point, Hybrid2, false>(false, false, false, true) ));
+        CALL_SUBTEST((testFunction<Point, Hybrid1, false>(false, false, false, true)));
+        CALL_SUBTEST((testFunction<Point, Hybrid2, false>(false, false, false, true)));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position" << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, CovFitSmooth, true>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant, true>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, CovFitConstant2, true>(false, true, true) ));
-        // CALL_SUBTEST(( testFunction<Point, CovFitConstantGlobal, WeightConstantFuncGlobal, true>(false, true, true) ));
+        CALL_SUBTEST((testFunction<Point, CovFitSmooth, true>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant, true>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, CovFitConstant2, true>(false, true, true)));
+        // CALL_SUBTEST(( testFunction<Point, CovFitConstantGlobal, WeightConstantFuncGlobal, true>(false, true, true)
+        // ));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/fit_radius_curvature_center.cpp
+++ b/tests/src/fit_radius_curvature_center.cpp
@@ -4,12 +4,10 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/fit_radius_curvature_center.cpp
  \brief Test validity of algebraic sphere procedure and GLS kappa
  */
-
 
 #include "../split_test_helper.h"
 #include "../common/testing.h"
@@ -31,65 +29,56 @@ using namespace std;
 using namespace Ponca;
 
 template <bool isSpaceDer, int Dim>
-struct subTestSpatial{
-    template<typename Scalar, typename Fit>
-    static
-    inline void eval(const Fit& /*_fit*/,
-                     Scalar /*_radiusMin*/,
-                     Scalar /*_radiusMax*/,
-                     Scalar /*_radiusEpsilon*/,
-                     Scalar /*_fitRadiusKappa*/,
-                     Scalar /*_fitRadiusAlgebraic*/) { }
+struct subTestSpatial
+{
+    template <typename Scalar, typename Fit>
+    static inline void eval(const Fit& /*_fit*/, Scalar /*_radiusMin*/, Scalar /*_radiusMax*/,
+                            Scalar /*_radiusEpsilon*/, Scalar /*_fitRadiusKappa*/, Scalar /*_fitRadiusAlgebraic*/)
+    {
+    }
 };
 
 template <>
-template<typename Scalar, typename Fit>
-void
-subTestSpatial<true, 3>::eval(const Fit& _fit,
-                           Scalar _radiusMin,
-                           Scalar _radiusMax,
-                           Scalar _radiusEpsilon,
-                           Scalar /*_fitRadiusKappa*/,
-                           Scalar /*_fitRadiusAlgebraic*/){
+template <typename Scalar, typename Fit>
+void subTestSpatial<true, 3>::eval(const Fit& _fit, Scalar _radiusMin, Scalar _radiusMax, Scalar _radiusEpsilon,
+                                   Scalar /*_fitRadiusKappa*/, Scalar /*_fitRadiusAlgebraic*/)
+{
 
-    Scalar kmin      = _fit.kmin();
-    Scalar kmax      = _fit.kmax();
-    Scalar kmean   = (kmin + kmax) / Scalar (2.);
-    Scalar radius  = Scalar(1.) / kmean;
+    Scalar kmin   = _fit.kmin();
+    Scalar kmax   = _fit.kmax();
+    Scalar kmean  = (kmin + kmax) / Scalar(2.);
+    Scalar radius = Scalar(1.) / kmean;
 
-    //Test value
-    VERIFY( (radius > _radiusMin - _radiusEpsilon) &&
-            (radius < _radiusMax + _radiusEpsilon) );
+    // Test value
+    VERIFY((radius > _radiusMin - _radiusEpsilon) && (radius < _radiusMax + _radiusEpsilon));
 }
 
-
-
-template<typename DataPoint, typename Fit, bool isSpaceDer>
+template <typename DataPoint, typename Fit, bool isSpaceDer>
 void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar radius = Eigen::internal::random<Scalar>(2., 10.);
 
-    Scalar analysisScale = Scalar(10.) * std::sqrt( Scalar(4. * M_PI) * radius * radius / nbPoints);
-    Scalar centerScale = Eigen::internal::random<Scalar>(1,10000);
-    VectorType center = VectorType::Random() * centerScale;
+    Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
+    VectorType center    = VectorType::Random() * centerScale;
 
     Scalar epsilon = testEpsilon<Scalar>();
     // epsilon is relative to the radius size
     Scalar radiusEpsilon = epsilon * radius;
 
-
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
+        vectorPoints[i] =
+            getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
     }
 
     // Quick testing is requested for coverage
@@ -97,134 +86,143 @@ void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bo
 
     // Test for each point if the fitted sphere correspond to the theoretical sphere
 #ifdef NDEBUG
-#pragma omp parallel for
+#    pragma omp parallel for
 #endif
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
-            Scalar fitRadiusKappa = Scalar(std::abs(Scalar(1.) / fit.kappa()));
+            Scalar fitRadiusKappa     = Scalar(std::abs(Scalar(1.) / fit.kappa()));
             Scalar fitRadiusAlgebraic = fit.radius();
-            VectorType fitCenter (fit.center());
+            VectorType fitCenter(fit.center());
 
             Scalar radiusMax = radius * Scalar(MAX_NOISE);
             Scalar radiusMin = radius * Scalar(MIN_NOISE);
 
             // Test procedure
-            VERIFY( (fitCenter - center).norm() < (radiusMax - radius) + radiusEpsilon );
-            VERIFY( (fitRadiusAlgebraic > radiusMin - radiusEpsilon) && (fitRadiusAlgebraic < radiusMax + radiusEpsilon) );
+            VERIFY((fitCenter - center).norm() < (radiusMax - radius) + radiusEpsilon);
+            VERIFY((fitRadiusAlgebraic > radiusMin - radiusEpsilon) &&
+                   (fitRadiusAlgebraic < radiusMax + radiusEpsilon));
             // Test re-parameterization
-            VERIFY( (fitRadiusKappa > radiusMin - radiusEpsilon) && (fitRadiusKappa < radiusMax + radiusEpsilon) );
-            //Test coherence
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(fitRadiusAlgebraic - fitRadiusKappa), Scalar(1.), epsilon) );
+            VERIFY((fitRadiusKappa > radiusMin - radiusEpsilon) && (fitRadiusKappa < radiusMax + radiusEpsilon));
+            // Test coherence
+            VERIFY(
+                Eigen::internal::isMuchSmallerThan(std::abs(fitRadiusAlgebraic - fitRadiusKappa), Scalar(1.), epsilon));
 
-            //Test using spatial derivatives if defined
-            subTestSpatial<isSpaceDer, DataPoint::Dim>::eval(fit, radiusMin, radiusMax, radiusEpsilon, fitRadiusKappa, fitRadiusAlgebraic);
+            // Test using spatial derivatives if defined
+            subTestSpatial<isSpaceDer, DataPoint::Dim>::eval(fit, radiusMin, radiusMax, radiusEpsilon, fitRadiusKappa,
+                                                             fitRadiusAlgebraic);
 
-            //Test on eta
-            if(!_bAddPositionNoise && !_bAddNormalNoise)
+            // Test on eta
+            if (!_bAddPositionNoise && !_bAddNormalNoise)
             {
-                //sometimes eta can be reversed
-                VectorType fitEta (fit.eta().normalized().array().abs());
-                VectorType expectedEta (vectorPoints[i].normal().array().abs());
+                // sometimes eta can be reversed
+                VectorType fitEta(fit.eta().normalized().array().abs());
+                VectorType expectedEta(vectorPoints[i].normal().array().abs());
 
-                VERIFY( Eigen::internal::isMuchSmallerThan((fitEta - expectedEta).norm(), Scalar(1.), epsilon)  );
+                VERIFY(Eigen::internal::isMuchSmallerThan((fitEta - expectedEta).norm(), Scalar(1.), epsilon));
             }
         }
     }
 }
 
-#define DECLARE_DEFAULT_TYPES                                                                      \
-    typedef PointPositionNormal<Scalar, Dim> Point;                                                \
-                                                                                                   \
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;                   \
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;               \
-                                                                                                   \
-    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, GLSParam> FitSmoothOriented;        \
-    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, GLSParam> FitConstantOriented;    \
-    typedef Basket<Point, WeightSmoothFunc, UnorientedSphereFit, GLSParam> FitSmoothUnoriented;    \
+#define DECLARE_DEFAULT_TYPES                                                                   \
+    typedef PointPositionNormal<Scalar, Dim> Point;                                             \
+                                                                                                \
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;                 \
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;             \
+                                                                                                \
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, GLSParam> FitSmoothOriented;     \
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, GLSParam> FitConstantOriented; \
+    typedef Basket<Point, WeightSmoothFunc, UnorientedSphereFit, GLSParam> FitSmoothUnoriented; \
     typedef Basket<Point, WeightConstantFunc, UnorientedSphereFit, GLSParam> FitConstantUnoriented;
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     DECLARE_DEFAULT_TYPES
 
     cout << "Testing with perfect sphere (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect sphere
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented, false>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented, false>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented, false>(true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented, false>(true) ));
+        // Test with perfect sphere
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented, false>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented, false>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented, false>(true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented, false>(true)));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented, false>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented, false>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented, false>(true, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented, false>(true, true, true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented, false>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented, false>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented, false>(true, true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented, false>(true, true, true)));
     }
     cout << "Ok!" << endl;
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callDerivativeSubTests()
 {
     DECLARE_DEFAULT_TYPES
 
     //! [Curvature Estimator APSS]
-    using FitSmoothOrientedSpatial   = BasketDiff<FitSmoothOriented, FitSpaceDer, OrientedSphereDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+    using FitSmoothOrientedSpatial =
+        BasketDiff<FitSmoothOriented, FitSpaceDer, OrientedSphereDer, CurvatureEstimatorDer,
+                   NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
     //! [Curvature Estimator APSS]
-    using FitConstantOrientedSpatial = BasketDiff<FitConstantOriented, FitSpaceDer, OrientedSphereDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+    using FitConstantOrientedSpatial =
+        BasketDiff<FitConstantOriented, FitSpaceDer, OrientedSphereDer, CurvatureEstimatorDer,
+                   NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
     //! [Curvature Estimator ASO]
-    using ASOSmooth                  = BasketDiff<FitSmoothOriented, FitSpaceDer, OrientedSphereDer, MlsSphereFitDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+    using ASOSmooth =
+        BasketDiff<FitSmoothOriented, FitSpaceDer, OrientedSphereDer, MlsSphereFitDer, CurvatureEstimatorDer,
+                   NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
     //! [Curvature Estimator ASO]
 
     cout << "Testing with perfect sphere (oriented / unoriented) with spatial derivatives..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect sphere
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpatial, true>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpatial, true>() ));
-        CALL_SUBTEST(( testFunction<Point, ASOSmooth, true>() ));
+        // Test with perfect sphere
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpatial, true>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpatial, true>()));
+        CALL_SUBTEST((testFunction<Point, ASOSmooth, true>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented) with spatial derivatives..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpatial, true>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpatial, true>(false, true, true) ));
-        CALL_SUBTEST(( testFunction<Point, ASOSmooth, true>(false, true, true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpatial, true>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpatial, true>(false, true, true)));
+        CALL_SUBTEST((testFunction<Point, ASOSmooth, true>(false, true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }
 
     cout << "Test sphere fitting (radius / center) and GLS curvature for different baskets..." << endl;
 
-    CALL_SUBTEST_1(( callSubTests<float,       2>() ));
-    CALL_SUBTEST_2(( callSubTests<float,       3>() ));
-    CALL_SUBTEST_3(( callSubTests<double,      3>() ));
-    CALL_SUBTEST_4(( callSubTests<long double, 2>() ));
-    CALL_SUBTEST_5(( callSubTests<long double, 3>() ));
+    CALL_SUBTEST_1((callSubTests<float, 2>()));
+    CALL_SUBTEST_2((callSubTests<float, 3>()));
+    CALL_SUBTEST_3((callSubTests<double, 3>()));
+    CALL_SUBTEST_4((callSubTests<long double, 2>()));
+    CALL_SUBTEST_5((callSubTests<long double, 3>()));
 
-    CALL_SUBTEST_6(( callDerivativeSubTests<float,       3>() ));
-    CALL_SUBTEST_7(( callDerivativeSubTests<double,      3>() ));
-    CALL_SUBTEST_8(( callDerivativeSubTests<long double, 3>() ));
+    CALL_SUBTEST_6((callDerivativeSubTests<float, 3>()));
+    CALL_SUBTEST_7((callDerivativeSubTests<double, 3>()));
+    CALL_SUBTEST_8((callDerivativeSubTests<long double, 3>()));
 }

--- a/tests/src/fit_unoriented.cpp
+++ b/tests/src/fit_unoriented.cpp
@@ -4,12 +4,10 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/fit_unoriented.cpp
  \brief Test coherance of unoriented sphere fitting
  */
-
 
 #include "../common/testing.h"
 #include "../common/testUtils.h"
@@ -31,34 +29,33 @@ using namespace Ponca;
 // if CheckCurvatures is true, then the test checks the coherence of kmin and kmax
 // it requires the use of BasketDiff in 3D, with the fitting extension CurvatureEstimatorDer
 //
-template<typename DataPoint, typename Fit, bool CheckCurvatures = false>
+template <typename DataPoint, typename Fit, bool CheckCurvatures = false>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar radius = Eigen::internal::random<Scalar>(Scalar(0.1), Scalar(10.));
 
     Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
-    Scalar centerScale = Eigen::internal::random<Scalar>(1,10);
-    VectorType center = VectorType::Random() * centerScale;
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10);
+    VectorType center    = VectorType::Random() * centerScale;
 
     Scalar epsilon = testEpsilon<Scalar>();
     // epsilon is relative to the radius size
-//    Scalar radiusEpsilon = epsilon * radius;
-
+    //    Scalar radiusEpsilon = epsilon * radius;
 
     vector<DataPoint> vectorPoints(nbPoints);
     vector<DataPoint> vectorReversedNormals100(nbPoints);
     vector<DataPoint> vectorReversedNormalsRandom(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        //reverse random normals
+        // reverse random normals
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise);
     }
 
@@ -70,7 +67,7 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test sphere descriptors coherance for each points
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit, fitReverse100, fitReverseRandom;
 
@@ -83,7 +80,7 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
         fitReverseRandom.setNeighborFilter({vectorReversedNormalsRandom[i].pos(), analysisScale});
         fitReverseRandom.compute(vectorPoints);
 
-        if(fit.isStable() && fitReverse100.isStable() && fitReverseRandom.isStable())
+        if (fit.isStable() && fitReverse100.isStable() && fitReverseRandom.isStable())
         {
             Scalar kappa1 = std::abs(fit.kappa());
             Scalar kappa2 = std::abs(fitReverse100.kappa());
@@ -98,18 +95,18 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
             VectorType eta3 = fitReverseRandom.eta().normalized().array().abs();
 
             // Check kappa coherance
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(kappa1 - kappa2), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(kappa1 - kappa3), Scalar(1.), epsilon) );
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(kappa1 - kappa2), Scalar(1.), epsilon));
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(kappa1 - kappa3), Scalar(1.), epsilon));
 
             // Check tau coherance
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(tau1 - tau2), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(tau1 - tau3), Scalar(1.), epsilon) );
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(tau1 - tau2), Scalar(1.), epsilon));
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(tau1 - tau3), Scalar(1.), epsilon));
 
             // Check eta coherance
-            VERIFY( Eigen::internal::isMuchSmallerThan((eta1 - eta2).norm(), Scalar(1.), epsilon) );
-            VERIFY( Eigen::internal::isMuchSmallerThan((eta1 - eta3).norm(), Scalar(1.), epsilon) );
+            VERIFY(Eigen::internal::isMuchSmallerThan((eta1 - eta2).norm(), Scalar(1.), epsilon));
+            VERIFY(Eigen::internal::isMuchSmallerThan((eta1 - eta3).norm(), Scalar(1.), epsilon));
 
-            if constexpr(CheckCurvatures)
+            if constexpr (CheckCurvatures)
             {
                 const Scalar kmin1 = std::abs(fit.kmin());
                 const Scalar kmin2 = std::abs(fitReverse100.kmin());
@@ -119,53 +116,55 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
                 const Scalar kmax3 = std::abs(fitReverseRandom.kmax());
 
                 // Check curvatures coherance
-                VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(kmin1 - kmin2), Scalar(1.), epsilon) );
-                VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(kmin1 - kmin3), Scalar(1.), epsilon) );
-                VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(kmax1 - kmax2), Scalar(1.), epsilon) );
-                VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(kmax1 - kmax3), Scalar(1.), epsilon) );
+                VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(kmin1 - kmin2), Scalar(1.), epsilon));
+                VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(kmin1 - kmin3), Scalar(1.), epsilon));
+                VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(kmax1 - kmax2), Scalar(1.), epsilon));
+                VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(kmax1 - kmax3), Scalar(1.), epsilon));
             }
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     typedef Basket<Point, WeightSmoothFunc, UnorientedSphereFit, GLSParam> FitSmoothUnoriented;
     typedef Basket<Point, WeightConstantFunc, UnorientedSphereFit, GLSParam> FitConstantUnoriented;
 
-    typedef BasketDiff<FitSmoothUnoriented, FitScaleSpaceDer, UnorientedSphereDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer> FitSmoothUnorientedDiff;
+    typedef BasketDiff<FitSmoothUnoriented, FitScaleSpaceDer, UnorientedSphereDer, CurvatureEstimatorDer,
+                       NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>
+        FitSmoothUnorientedDiff;
 
     cout << "Testing with perfect sphere (unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect sphere
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>() ));
-        if constexpr(Dim == 3)
-            CALL_SUBTEST(( testFunction<Point, FitSmoothUnorientedDiff, true>() ));
+        // Test with perfect sphere
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>()));
+        if constexpr (Dim == 3)
+            CALL_SUBTEST((testFunction<Point, FitSmoothUnorientedDiff, true>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>(true, true) ));
-        if constexpr(Dim == 3)
-            CALL_SUBTEST(( testFunction<Point, FitSmoothUnorientedDiff, true>(true, true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>(true, true)));
+        if constexpr (Dim == 3)
+            CALL_SUBTEST((testFunction<Point, FitSmoothUnorientedDiff, true>(true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/gls_compare.cpp
+++ b/tests/src/gls_compare.cpp
@@ -4,12 +4,10 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/gls_compare.cpp
  \brief Test coherance of gls compareTo
  */
-
 
 #include "../common/testing.h"
 #include "../common/testUtils.h"
@@ -25,20 +23,20 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar radius1 = Eigen::internal::random<Scalar>(1, 5);
     Scalar radius2 = Eigen::internal::random<Scalar>(10, 50);
 
-    Scalar analysisScale = Scalar(Scalar(10.) * std::sqrt( Scalar(4.) * Scalar(M_PI) * radius2 * radius2 / nbPoints));
+    Scalar analysisScale = Scalar(Scalar(10.) * std::sqrt(Scalar(4.) * Scalar(M_PI) * radius2 * radius2 / nbPoints));
 
     VectorType center = VectorType::Zero();
 
@@ -47,67 +45,67 @@ void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bo
     vector<DataPoint> sphere1(nbPoints);
     vector<DataPoint> sphere2(nbPoints);
 
-    for(int i = 0; i < nbPoints; ++i)
+    for (int i = 0; i < nbPoints; ++i)
     {
         sphere1[i] = getPointOnSphere<DataPoint>(radius1, center, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
         sphere2[i] = getPointOnSphere<DataPoint>(radius2, center, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
     }
 
     // Quick testing is requested for coverage
-    int size = QUICK_TESTS ? 1 : (nbPoints-1);
+    int size = QUICK_TESTS ? 1 : (nbPoints - 1);
 
     // Test for each point if the fitted sphere correspond to the theorical sphere
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit1, fit2, fit3;
         fit1.setNeighborFilter({sphere1[i].pos(), analysisScale});
-        fit2.setNeighborFilter({sphere1[i+1].pos(), analysisScale});
+        fit2.setNeighborFilter({sphere1[i + 1].pos(), analysisScale});
         fit3.setNeighborFilter({sphere2[i].pos(), analysisScale});
 
         fit1.compute(sphere1);
         fit2.compute(sphere1);
         fit3.compute(sphere2);
 
-        if(fit1.isStable() && fit2.isStable() && fit3.isStable())
+        if (fit1.isStable() && fit2.isStable() && fit3.isStable())
         {
             Scalar value1 = fit1.compareTo(fit2);
             Scalar value2 = fit1.compareTo(fit3);
 
-            VERIFY( Eigen::internal::isMuchSmallerThan(value1, Scalar(1.), epsilon) );
-            VERIFY( value2 > epsilon );
+            VERIFY(Eigen::internal::isMuchSmallerThan(value1, Scalar(1.), epsilon));
+            VERIFY(value2 > epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
 
     typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, GLSParam> FitSmoothOriented;
 
     cout << "Testing with perfect spheres (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        //Test with perfect sphere
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>() ));
+        // Test with perfect sphere
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>(false, true, true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>(false, true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/gls_paraboloid_der.cpp
+++ b/tests/src/gls_paraboloid_der.cpp
@@ -4,13 +4,12 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/gls_paraboloid_der.cpp
  \brief Test validity of GLS derivatives for a paraboloid
  */
 #ifdef NDEBUG
-#undef NDEBUG
+#    undef NDEBUG
 #endif
 
 #include "../common/testing.h"
@@ -33,7 +32,7 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename Fit, typename RefFit, typename TestFit>
+template <typename Fit, typename RefFit, typename TestFit>
 void testFunction()
 {
     // Define related structure
@@ -42,36 +41,37 @@ void testFunction()
     typedef typename TestDataPoint::Scalar TestScalar;
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
-    //typedef typename DataPoint::MatrixType MatrixType;
+    // typedef typename DataPoint::MatrixType MatrixType;
 
-    //generate sampled paraboloid
+    // generate sampled paraboloid
     int nbPoints = Eigen::internal::random<int>(10000, 20000);
 
-    Scalar paraboloidA = Eigen::internal::random<Scalar>(-0.5,0.5);
-    Scalar paraboloidB = Eigen::internal::random<Scalar>(-0.5,0.5);
+    Scalar paraboloidA = Eigen::internal::random<Scalar>(-0.5, 0.5);
+    Scalar paraboloidB = Eigen::internal::random<Scalar>(-0.5, 0.5);
 
-    Scalar analysisScale = static_cast<Scalar>(.1);// / std::max(std::abs(vCoef.x()), std::abs(vCoef.y()));
+    Scalar analysisScale = static_cast<Scalar>(.1); // / std::max(std::abs(vCoef.x()), std::abs(vCoef.y()));
 
-    Scalar rotationAngle = Eigen::internal::random<Scalar>(Scalar(0.), Scalar(2 * M_PI));
+    Scalar rotationAngle     = Eigen::internal::random<Scalar>(Scalar(0.), Scalar(2 * M_PI));
     VectorType vRotationAxis = VectorType::Random().normalized();
 
-    Scalar epsilon = testEpsilon<Scalar>();
+    Scalar epsilon       = testEpsilon<Scalar>();
     Scalar approxEpsilon = static_cast<Scalar>(.1);
 
     vector<DataPoint> vectorPoints(nbPoints);
     vector<DataPoint> vectorPointsOrigin(nbPoints);
     vector<TestDataPoint> testVectorPoints(nbPoints);
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-      vectorPointsOrigin[i] = getPointOnParaboloid<DataPoint>(paraboloidA, paraboloidB, 0, 0, 0, 0,analysisScale*Scalar(1.2), false);
-      // Add noise:
-      // vectorPointsOrigin[i].pos() += VectorType::Random()*1e-6;
-      //vectorPointsOrigin[i].normal() = (vectorPointsOrigin[i].normal() + VectorType::Random()*1e-6).normalized();
-      vectorPoints[i].pos() = vectorPointsOrigin[i].pos();
-      vectorPoints[i].normal() = vectorPointsOrigin[i].normal();
+        vectorPointsOrigin[i] =
+            getPointOnParaboloid<DataPoint>(paraboloidA, paraboloidB, 0, 0, 0, 0, analysisScale * Scalar(1.2), false);
+        // Add noise:
+        // vectorPointsOrigin[i].pos() += VectorType::Random()*1e-6;
+        // vectorPointsOrigin[i].normal() = (vectorPointsOrigin[i].normal() + VectorType::Random()*1e-6).normalized();
+        vectorPoints[i].pos()    = vectorPointsOrigin[i].pos();
+        vectorPoints[i].normal() = vectorPointsOrigin[i].normal();
 
-      testVectorPoints[i].pos()    = vectorPoints[i].pos().template cast<TestScalar>();
-      testVectorPoints[i].normal() = vectorPoints[i].normal().template cast<TestScalar>();
+        testVectorPoints[i].pos()    = vectorPoints[i].pos().template cast<TestScalar>();
+        testVectorPoints[i].normal() = vectorPoints[i].normal().template cast<TestScalar>();
     }
 
     VectorType theoricNormal;
@@ -85,75 +85,81 @@ void testFunction()
     const VectorType vFittingPoint = VectorType::Zero();
     fit.setNeighborFilter({vFittingPoint.template cast<TestScalar>(), analysisScale});
     fit.init();
-    for(typename vector<TestDataPoint>::iterator it = testVectorPoints.begin();
-        it != testVectorPoints.end();
-        ++it)
+    for (typename vector<TestDataPoint>::iterator it = testVectorPoints.begin(); it != testVectorPoints.end(); ++it)
     {
         fit.addNeighbor(*it);
     }
     fit.finalize();
 
-    Scalar flip_fit = (fit.isSigned() || (fit.primitiveGradient().template cast<Scalar>().dot(theoricNormal) > 0 )) ? Scalar(1) : Scalar(-1);
+    Scalar flip_fit = (fit.isSigned() || (fit.primitiveGradient().template cast<Scalar>().dot(theoricNormal) > 0))
+                          ? Scalar(1)
+                          : Scalar(-1);
     {
-      // Check derivatives wrt numerical differentiation
-      // Use long double for stable numerical differentiation
-      typedef long double RefScalar;
-      typedef PointPositionNormal<RefScalar, 3> RefPoint;
+        // Check derivatives wrt numerical differentiation
+        // Use long double for stable numerical differentiation
+        typedef long double RefScalar;
+        typedef PointPositionNormal<RefScalar, 3> RefPoint;
 
-      vector<RefPoint> refVectorPoints(nbPoints);
-      for(unsigned int i = 0; i < vectorPoints.size(); ++i)
-      {
-        refVectorPoints[i].pos() = vectorPoints[i].pos().template cast<RefScalar>();
-        refVectorPoints[i].normal() = vectorPoints[i].normal().template cast<RefScalar>();
-      }
+        vector<RefPoint> refVectorPoints(nbPoints);
+        for (unsigned int i = 0; i < vectorPoints.size(); ++i)
+        {
+            refVectorPoints[i].pos()    = vectorPoints[i].pos().template cast<RefScalar>();
+            refVectorPoints[i].normal() = vectorPoints[i].normal().template cast<RefScalar>();
+        }
 
-      // Centered fit:
-      RefFit ref_fit;
-      ref_fit.setNeighborFilter({vFittingPoint.template cast<RefScalar>(), analysisScale});
-      ref_fit.init();
-      for(typename vector<RefPoint>::iterator it = refVectorPoints.begin();
-          it != refVectorPoints.end();
-          ++it)
-      {
-          ref_fit.addNeighbor(*it);
-      }
-      ref_fit.finalize();
-      RefScalar flip_ref = (ref_fit.isSigned() || (ref_fit.primitiveGradient().dot(theoricNormal.template cast<RefScalar>()) > 0 )) ? RefScalar(1) : RefScalar(-1);
+        // Centered fit:
+        RefFit ref_fit;
+        ref_fit.setNeighborFilter({vFittingPoint.template cast<RefScalar>(), analysisScale});
+        ref_fit.init();
+        for (typename vector<RefPoint>::iterator it = refVectorPoints.begin(); it != refVectorPoints.end(); ++it)
+        {
+            ref_fit.addNeighbor(*it);
+        }
+        ref_fit.finalize();
+        RefScalar flip_ref =
+            (ref_fit.isSigned() || (ref_fit.primitiveGradient().dot(theoricNormal.template cast<RefScalar>()) > 0))
+                ? RefScalar(1)
+                : RefScalar(-1);
 
-      RefScalar der_epsilon = epsilon*10;
-      if(Eigen::internal::is_same<Scalar,float>::value)
-        der_epsilon = epsilon*100;
-      // FIXME check whether numerical accuracy can be improved with float
-      typename RefFit::VectorArray /*dUl,*/ dN;
-//      typename RefFit::VectorArray dSumP;
-      typename RefFit::ScalarArray dPotential/*, dUc, dUq, dTau, dKappa*/;
-      RefScalar h = RefScalar(0.000001)*RefScalar(analysisScale);
+        RefScalar der_epsilon = epsilon * 10;
+        if (Eigen::internal::is_same<Scalar, float>::value)
+            der_epsilon = epsilon * 100;
+        // FIXME check whether numerical accuracy can be improved with float
+        typename RefFit::VectorArray /*dUl,*/ dN;
+        //      typename RefFit::VectorArray dSumP;
+        typename RefFit::ScalarArray dPotential /*, dUc, dUq, dTau, dKappa*/;
+        RefScalar h = RefScalar(0.000001) * RefScalar(analysisScale);
 
-      // Differentiation along scale, x, y, z:
-      for(int k = 0; k<4; ++k)
-      {
-        RefFit f;
-        typename RefPoint::VectorType p = vFittingPoint.template cast<RefScalar>();
-        auto scale = static_cast<RefScalar>(analysisScale);
-        if(k==0)
-          scale += h;
-        else
-          p(k-1) += h;
-        f.setNeighborFilter({p, scale});
-        f.compute(refVectorPoints);
+        // Differentiation along scale, x, y, z:
+        for (int k = 0; k < 4; ++k)
+        {
+            RefFit f;
+            typename RefPoint::VectorType p = vFittingPoint.template cast<RefScalar>();
+            auto scale                      = static_cast<RefScalar>(analysisScale);
+            if (k == 0)
+                scale += h;
+            else
+                p(k - 1) += h;
+            f.setNeighborFilter({p, scale});
+            f.compute(refVectorPoints);
 
-        RefScalar flip_f   = (f.isSigned() || (f.primitiveGradient().dot(theoricNormal.template cast<RefScalar>()) > 0 )) ? RefScalar(1) : RefScalar(-1);
-        dPotential(k) = ( flip_f*f.potential() - flip_ref * ref_fit.potential()   ) / h;
-        dN.col(k)     = ( flip_f*f.primitiveGradient().normalized() - flip_ref * ref_fit.primitiveGradient().normalized() ) / h;
-      }
+            RefScalar flip_f =
+                (f.isSigned() || (f.primitiveGradient().dot(theoricNormal.template cast<RefScalar>()) > 0))
+                    ? RefScalar(1)
+                    : RefScalar(-1);
+            dPotential(k) = (flip_f * f.potential() - flip_ref * ref_fit.potential()) / h;
+            dN.col(k) =
+                (flip_f * f.primitiveGradient().normalized() - flip_ref * ref_fit.primitiveGradient().normalized()) / h;
+        }
 
-//       std::cout << "== Numerical differentiation ==\n";
-      VERIFY( dPotential.template cast<Scalar>().isApprox( flip_fit*fit.dPotential().template cast<Scalar>(), Scalar(der_epsilon) ) );
-      VERIFY( dN.template cast<Scalar>().isApprox( flip_fit*fit.dNormal().template cast<Scalar>(), Scalar(der_epsilon) ) );
+        //       std::cout << "== Numerical differentiation ==\n";
+        VERIFY(dPotential.template cast<Scalar>().isApprox(flip_fit * fit.dPotential().template cast<Scalar>(),
+                                                           Scalar(der_epsilon)));
+        VERIFY(
+            dN.template cast<Scalar>().isApprox(flip_fit * fit.dNormal().template cast<Scalar>(), Scalar(der_epsilon)));
     }
 
     VERIFY(fit.isStable());
-
 
     Scalar theoricPotential = 0;
 
@@ -162,34 +168,35 @@ void testFunction()
         Scalar tK1 = Scalar(2) * paraboloidA;
         Scalar tK2 = Scalar(2) * paraboloidB;
 
-        theoricK1 = flip_fit * (std::abs(tK1)<std::abs(tK2) ? tK2 : tK1);
-        theoricK2 = flip_fit * (std::abs(tK1)<std::abs(tK2) ? tK1 : tK2);
+        theoricK1 = flip_fit * (std::abs(tK1) < std::abs(tK2) ? tK2 : tK1);
+        theoricK2 = flip_fit * (std::abs(tK1) < std::abs(tK2) ? tK1 : tK2);
     }
     Scalar theoricGaussian = theoricK1 * theoricK2;
-    Scalar theoricKmean    = Scalar(0.5)*(theoricK1+theoricK2);
+    Scalar theoricKmean    = Scalar(0.5) * (theoricK1 + theoricK2);
 
     Scalar potential  = flip_fit * fit.potential();
     VectorType normal = flip_fit * fit.primitiveGradient().template cast<Scalar>();
 
     // principal curvatures k1,k2 are used here such that |k1| > |k2| (instead of kmin < kmax)
-    Scalar kmin = fit.kmin();
-    Scalar kmax = fit.kmax();
-    Scalar kappa1 = flip_fit * (std::abs(kmin)<std::abs(kmax) ? kmax : kmin);
-    Scalar kappa2 = flip_fit * (std::abs(kmin)<std::abs(kmax) ? kmin : kmax);
+    Scalar kmin          = fit.kmin();
+    Scalar kmax          = fit.kmax();
+    Scalar kappa1        = flip_fit * (std::abs(kmin) < std::abs(kmax) ? kmax : kmin);
+    Scalar kappa2        = flip_fit * (std::abs(kmin) < std::abs(kmax) ? kmin : kmax);
     Scalar kmeanFromK1K2 = (kappa1 + kappa2) * Scalar(.5);
-    Scalar gaussian = fit.GaussianCurvature();
+    Scalar gaussian      = fit.GaussianCurvature();
 
-    VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(potential - theoricPotential), Scalar(1.), approxEpsilon) );
-    VERIFY( Eigen::internal::isMuchSmallerThan((theoricNormal - normal).norm(), Scalar(1.), approxEpsilon ) );
+    VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(potential - theoricPotential), Scalar(1.), approxEpsilon));
+    VERIFY(Eigen::internal::isMuchSmallerThan((theoricNormal - normal).norm(), Scalar(1.), approxEpsilon));
 
 #ifndef PONCA_COVERAGE_ENABLED
-    if(! Eigen::internal::isMuchSmallerThan(std::abs(theoricKmean - kmeanFromK1K2), std::abs(theoricK1), approxEpsilon)) {
+    if (!Eigen::internal::isMuchSmallerThan(std::abs(theoricKmean - kmeanFromK1K2), std::abs(theoricK1), approxEpsilon))
+    {
         std::cerr << "Precision test failed. Dumping files\n";
         {
             std::ofstream inFile, projFile;
-            inFile.open ("input.xyz");
-            projFile.open ("projected.xyz");
-            for(unsigned int i = 0; i < testVectorPoints.size(); ++i)
+            inFile.open("input.xyz");
+            projFile.open("projected.xyz");
+            for (unsigned int i = 0; i < testVectorPoints.size(); ++i)
             {
                 inFile << testVectorPoints[i].pos().transpose() << endl;
                 projFile << fit.project(testVectorPoints[i].pos()).transpose() << std::endl;
@@ -201,65 +208,69 @@ void testFunction()
 #endif
 
     // The error in mean curvature estimation must be smaller in magnitude wrt the largest curvature
-    VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(theoricKmean - kmeanFromK1K2), std::abs(theoricK1), approxEpsilon));
+    VERIFY(
+        Eigen::internal::isMuchSmallerThan(std::abs(theoricKmean - kmeanFromK1K2), std::abs(theoricK1), approxEpsilon));
 
-    if(std::abs(std::abs(theoricK1)-std::abs(theoricK2))>approxEpsilon*std::abs(theoricK1))
+    if (std::abs(std::abs(theoricK1) - std::abs(theoricK2)) > approxEpsilon * std::abs(theoricK1))
     {
         // absolute curvatures are clearly different
-        VERIFY( Eigen::internal::isApprox(kappa1, theoricK1, approxEpsilon) );
-        VERIFY( std::abs(kappa2-theoricK2) < approxEpsilon*std::abs(kappa1) );
+        VERIFY(Eigen::internal::isApprox(kappa1, theoricK1, approxEpsilon));
+        VERIFY(std::abs(kappa2 - theoricK2) < approxEpsilon * std::abs(kappa1));
     }
     else
     {
         // absolute curvatures are close to each other and therefore their order should be ignored
-        VERIFY( Eigen::internal::isApprox(std::abs(kappa1), std::abs(theoricK1), approxEpsilon) );
-        VERIFY( std::abs(std::abs(kappa2)-std::abs(theoricK2)) < approxEpsilon*std::abs(kappa1) );
+        VERIFY(Eigen::internal::isApprox(std::abs(kappa1), std::abs(theoricK1), approxEpsilon));
+        VERIFY(std::abs(std::abs(kappa2) - std::abs(theoricK2)) < approxEpsilon * std::abs(kappa1));
     }
 
     // The errors on k1 and k2 are expected to be of the same order, we thus compare the accuracy of k_gauss to k1^2
-    VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(gaussian-theoricGaussian), theoricK1*theoricK1, approxEpsilon) );
+    VERIFY(
+        Eigen::internal::isMuchSmallerThan(std::abs(gaussian - theoricGaussian), theoricK1 * theoricK1, approxEpsilon));
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef long double RefScalar;
     typedef PointPositionNormal<RefScalar, 3> RefPoint;
-    typedef DistWeightFunc<RefPoint, SmoothWeightKernel<RefScalar> > RefWeightFunc;
+    typedef DistWeightFunc<RefPoint, SmoothWeightKernel<RefScalar>> RefWeightFunc;
 
-    typedef ScalarPrecisionCheck<Scalar,RefScalar> TestScalar;
+    typedef ScalarPrecisionCheck<Scalar, RefScalar> TestScalar;
     TestScalar::check_enabled = false; // set it to true to track diverging computations
-//    typedef PointPositionNormal<TestScalar, 3> TestPoint;
-//    typedef DistWeightFunc<TestPoint, SmoothWeightKernel<TestScalar> > TestWeightFunc;
+                                       //    typedef PointPositionNormal<TestScalar, 3> TestPoint;
+    //    typedef DistWeightFunc<TestPoint, SmoothWeightKernel<TestScalar> > TestWeightFunc;
 
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
 
-    using FitSphereOriented    = BasketDiff<
-            Basket<Point, WeightSmoothFunc, OrientedSphereFit>,
-            FitScaleSpaceDer, OrientedSphereDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
-    using RefFitSphereOriented = BasketDiff<
-            Basket<RefPoint, RefWeightFunc, OrientedSphereFit>,
-            FitScaleSpaceDer, OrientedSphereDer, CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
-//    using TestFitSphereOriented = BasketDiff<Basket<TestPoint, TestWeightFunc, OrientedSphereFit>,
-//            internal::FitScaleDer | internal::FitScaleDer, OrientedSphereDer, NormalDerivativesCurvatureEstimator>;
+    using FitSphereOriented =
+        BasketDiff<Basket<Point, WeightSmoothFunc, OrientedSphereFit>, FitScaleSpaceDer, OrientedSphereDer,
+                   CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+    using RefFitSphereOriented =
+        BasketDiff<Basket<RefPoint, RefWeightFunc, OrientedSphereFit>, FitScaleSpaceDer, OrientedSphereDer,
+                   CurvatureEstimatorDer, NormalDerivativeWeingartenEstimator, WeingartenCurvatureEstimatorDer>;
+    //    using TestFitSphereOriented = BasketDiff<Basket<TestPoint, TestWeightFunc, OrientedSphereFit>,
+    //            internal::FitScaleDer | internal::FitScaleDer, OrientedSphereDer,
+    //            NormalDerivativesCurvatureEstimator>;
 
-    CALL_SUBTEST(( testFunction<FitSphereOriented, RefFitSphereOriented, /*TestFitSphereOriented*/FitSphereOriented>() ));
+    CALL_SUBTEST(
+        (testFunction<FitSphereOriented, RefFitSphereOriented, /*TestFitSphereOriented*/ FitSphereOriented>()));
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }
 
     cout << "Test paraboloid fitting..." << endl;
 
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-      callSubTests<float, 3>();
-      callSubTests<double, 3>();
-      callSubTests<long double, 3>();
+        callSubTests<float, 3>();
+        callSubTests<double, 3>();
+        callSubTests<long double, 3>();
     }
 }

--- a/tests/src/gls_sphere_der.cpp
+++ b/tests/src/gls_sphere_der.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/Grenaille/gls_sphere_der.cpp
     \brief Test validity of GLS derivatives for a sphere
@@ -26,7 +25,7 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
@@ -35,20 +34,20 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     typedef typename Fit::ScalarArray ScalarArray;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
+    Scalar radius     = Eigen::internal::random<Scalar>(1, 10);
     VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
 
     Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
 
     Scalar epsilon = testEpsilon<Scalar>();
-    //Scalar radisuEpsilon = epsilon * radius;
+    // Scalar radisuEpsilon = epsilon * radius;
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise);
     }
@@ -61,41 +60,39 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
     // Test for each point if the Derivatives of kappa are equal to 0
     int nbStable = 0;
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
-        fit.computeWithIds(tree.rangeNeighbors(vectorPoints[i].pos(),analysisScale),vectorPoints);
+        fit.computeWithIds(tree.rangeNeighbors(vectorPoints[i].pos(), analysisScale), vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
             ScalarArray dkappa = fit.dkappa();
 
-            for(int i = 0; i < dkappa.size(); ++i)
+            for (int i = 0; i < dkappa.size(); ++i)
             {
-                VERIFY( Eigen::internal::isMuchSmallerThan(dkappa[i], Scalar(1.), epsilon) );
+                VERIFY(Eigen::internal::isMuchSmallerThan(dkappa[i], Scalar(1.), epsilon));
             }
 #pragma omp critical
             nbStable++;
         }
     }
-    VERIFY (nbStable!= 0);
+    VERIFY(nbStable != 0);
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    using FitSmoothOriented = BasketDiff<
-            Basket<Point, WeightSmoothFunc, OrientedSphereFit, GLSParam>,
-            FitScaleSpaceDer, OrientedSphereDer, GLSDer>;
-
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    using FitSmoothOriented = BasketDiff<Basket<Point, WeightSmoothFunc, OrientedSphereFit, GLSParam>, FitScaleSpaceDer,
+                                         OrientedSphereDer, GLSDer>;
 
     cout << "Testing with perfect sphere (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>()));
     }
     cout << "Ok!" << endl;
 
@@ -109,7 +106,7 @@ void callSubTests()
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/gls_tau.cpp
+++ b/tests/src/gls_tau.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/Grenaille/gls_tau.cpp
     \brief Test validity GLS tau param
@@ -25,34 +24,34 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
     vector<DataPoint> vectorPoints(nbPoints);
 
-    //Random plane parameters
-    Scalar centerScale =  Eigen::internal::random<Scalar>(0, 10000);
-    VectorType vCenter = VectorType::Random() * centerScale;
+    // Random plane parameters
+    Scalar centerScale      = Eigen::internal::random<Scalar>(0, 10000);
+    VectorType vCenter      = VectorType::Random() * centerScale;
     VectorType vPlaneNormal = VectorType::Random().normalized();
 
-
-    Scalar range = Eigen::internal::random<Scalar>(1, 10);
+    Scalar range   = Eigen::internal::random<Scalar>(1, 10);
     Scalar epsilon = testEpsilon<Scalar>();
-    if(_bAddPositionNoise || _bAddNormalNoise)
+    if (_bAddPositionNoise || _bAddNormalNoise)
         epsilon *= 10;
 
     Scalar analysisScale = Scalar(100.) * std::sqrt(Scalar(4. * M_PI) * range * range / nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        Scalar radius = Eigen::internal::random<Scalar>(-range, range);
-        vectorPoints[i] = getPointOnPlane<DataPoint>(vCenter, vPlaneNormal, radius, _bAddPositionNoise, _bAddNormalNoise, _bUnoriented);
+        Scalar radius   = Eigen::internal::random<Scalar>(-range, range);
+        vectorPoints[i] = getPointOnPlane<DataPoint>(vCenter, vPlaneNormal, radius, _bAddPositionNoise,
+                                                     _bAddNormalNoise, _bUnoriented);
     }
 
     // Quick testing is requested for coverage
@@ -60,35 +59,35 @@ void testFunction(bool _bUnoriented = false, bool _bAddPositionNoise = false, bo
 
     // Test for each point if the point moved from distance d correspond to tau
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         // Take a random distance to the plane, not too large to have few points in weighting analysis
-        Scalar distanceToPlane = Eigen::internal::random<Scalar>(-range, range);
+        Scalar distanceToPlane      = Eigen::internal::random<Scalar>(-range, range);
         VectorType vEvaluationPoint = vectorPoints[i].pos() + distanceToPlane * vPlaneNormal;
 
         Fit fit;
         fit.setNeighborFilter({vEvaluationPoint, analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
-            Scalar fitTau = fit.tau();
-            fitTau = std::abs(fitTau);
+            Scalar fitTau   = fit.tau();
+            fitTau          = std::abs(fitTau);
             distanceToPlane = std::abs(distanceToPlane);
 
             // Test Tau
-            VERIFY( Eigen::internal::isMuchSmallerThan(std::abs(distanceToPlane - fitTau), Scalar(1.), epsilon) );
+            VERIFY(Eigen::internal::isMuchSmallerThan(std::abs(distanceToPlane - fitTau), Scalar(1.), epsilon));
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
     //! [GLSFitTypes]
     typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, GLSParam> FitSmoothOriented;
@@ -98,12 +97,12 @@ void callSubTests()
     //! [GLSFitTypes]
 
     cout << "Testing with perfect plane (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>()));
     }
     cout << "Ok..." << endl;
 
@@ -120,7 +119,7 @@ void callSubTests()
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/mls.cpp
+++ b/tests/src/mls.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/mls.cpp
     \brief Test basket utility functions
@@ -27,8 +26,9 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint, typename Fit>
-void testFunction() {
+template <typename DataPoint, typename Fit>
+void testFunction()
+{
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
@@ -36,7 +36,7 @@ void testFunction() {
     // Generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
+    Scalar radius     = Eigen::internal::random<Scalar>(1, 10);
     VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
 
     Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
@@ -45,7 +45,8 @@ void testFunction() {
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i) {
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
+    {
         // Add noise to the point cloud
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, true, true);
     }
@@ -66,24 +67,25 @@ void testFunction() {
         fitMLS.setNeighborFilter({pos, analysisScale});
         fitMLS.computeMLS(vectorPoints, 1000);
 
-        if(fit.isStable()) {
+        if (fit.isStable())
+        {
             // Tests the primitiveGradient
-            const VectorType& estimated = fit.primitiveGradient(pos).normalized();
+            const VectorType& estimated    = fit.primitiveGradient(pos).normalized();
             const VectorType& estimatedMLS = fitMLS.primitiveGradient(pos).normalized();
-            VectorType theoriticalNormal = (pos-center).normalized();
+            VectorType theoriticalNormal   = (pos - center).normalized();
 
-            Scalar absdot = std::abs(estimated.dot(theoriticalNormal));
+            Scalar absdot    = std::abs(estimated.dot(theoriticalNormal));
             Scalar absdotMLS = std::abs(estimatedMLS.dot(theoriticalNormal));
 
             // Verify that mls gives better result than single projection when comparing with the theoretical values
-            // By checking if absdotMLS is closer to 1 than asbdot (taking into account approximation error using the epsilon)
-            // Dot product of normalized vector can't be greater than 1
-            VERIFY( (absdot + epsilon >= absdotMLS && absdotMLS >= 1 - epsilon) );
+            // By checking if absdotMLS is closer to 1 than asbdot (taking into account approximation error using the
+            // epsilon) Dot product of normalized vector can't be greater than 1
+            VERIFY((absdot + epsilon >= absdotMLS && absdotMLS >= 1 - epsilon));
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     //! [SpecializedPointType]
@@ -94,13 +96,13 @@ void callSubTests()
     //! [WeightFunction]
     typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightFunc;
     //! [WeightFunction]
-    typedef Basket<Point, WeightFunc, OrientedSphereFit>      Sphere;
+    typedef Basket<Point, WeightFunc, OrientedSphereFit> Sphere;
     //! [PlaneFitType]
-    typedef Basket<Point, WeightFunc, CovariancePlaneFit>      Plane;
+    typedef Basket<Point, WeightFunc, CovariancePlaneFit> Plane;
     //! [PlaneFitType]
 
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit> FitSmoothOriented;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit> FitSmoothOriented;
 
     // //! [PlaneFitDerTypes]
     // using PlaneScaleDiff = BasketDiff<Plane, FitScaleDer, CovariancePlaneDer>;
@@ -108,15 +110,15 @@ void callSubTests()
     // using PlaneScaleSpaceDiff = BasketDiff<Plane, FitScaleSpaceDer, CovariancePlaneDer>;
     // //! [PlaneFitDerTypes]
 
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, Sphere>() ));
+        CALL_SUBTEST((testFunction<Point, Sphere>()));
     }
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/normal_plane.cpp
+++ b/tests/src/normal_plane.cpp
@@ -17,38 +17,34 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled plane
+    // generate sampled plane
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
     Scalar width  = Eigen::internal::random<Scalar>(1., 10.);
     Scalar height = width;
 
-    Scalar analysisScale = Scalar(15.) * std::sqrt( width * height / nbPoints);
-    Scalar centerScale   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar analysisScale = Scalar(15.) * std::sqrt(width * height / nbPoints);
+    Scalar centerScale   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType center    = VectorType::Random() * centerScale;
 
     VectorType direction = VectorType::Random().normalized();
 
     Scalar epsilon = testEpsilon<Scalar>();
-    if( _bAddPositionNoise ) // relax a bit the testing threshold
-        epsilon = Scalar(0.002*MAX_NOISE);
+    if (_bAddPositionNoise) // relax a bit the testing threshold
+        epsilon = Scalar(0.002 * MAX_NOISE);
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
-        vectorPoints[i] = getPointOnPlane<DataPoint>(center,
-                                                     direction,
-                                                     width,
-                                                     _bAddPositionNoise,
-                                                     _bAddNormalNoise);
+        vectorPoints[i] = getPointOnPlane<DataPoint>(center, direction, width, _bAddPositionNoise, _bAddNormalNoise);
     }
 
     // Quick testing is requested for coverage
@@ -56,81 +52,84 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test for each point if the normal is correct
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
             VectorType estimated = fit.normal();
 
-            Scalar norm = estimated.norm();
+            Scalar norm   = estimated.norm();
             Scalar absdot = std::abs(estimated.dot(direction));
 
-            VERIFY( std::abs(norm-Scalar(1.)) < epsilon );
-            VERIFY( std::abs(absdot-Scalar(1.)) < epsilon );
+            VERIFY(std::abs(norm - Scalar(1.)) < epsilon);
+            VERIFY(std::abs(absdot - Scalar(1.)) < epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit> FitSmoothOriented;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit> FitConstantOriented;
-    typedef Basket<Point,WeightSmoothFunc,UnorientedSphereFit> FitSmoothUnoriented;
-    typedef Basket<Point,WeightConstantFunc,UnorientedSphereFit> FitConstantUnoriented;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothOrientedSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantOrientedSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothOrientedScaleSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit> FitSmoothOriented;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit> FitConstantOriented;
+    typedef Basket<Point, WeightSmoothFunc, UnorientedSphereFit> FitSmoothUnoriented;
+    typedef Basket<Point, WeightConstantFunc, UnorientedSphereFit> FitConstantUnoriented;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedScaleSpaceDer;
 
     cout << "Testing with perfect plane (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceDer>()));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceDer>(true, true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceDer>(true, true) ));
-
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceDer>(true, true)));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }
 
     cout << "Test normal estimation" << endl;
 
-    //callSubTests<double, 2>();
+    // callSubTests<double, 2>();
     callSubTests<float, 3>();
     callSubTests<long double, 3>();
     callSubTests<double, 3>();

--- a/tests/src/normal_sphere.cpp
+++ b/tests/src/normal_sphere.cpp
@@ -17,27 +17,27 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false)
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    //generate sampled sphere
+    // generate sampled sphere
     int nbPoints = Eigen::internal::random<int>(100, 1000);
 
-    Scalar radius = Eigen::internal::random<Scalar>(1,10);
+    Scalar radius     = Eigen::internal::random<Scalar>(1, 10);
     VectorType center = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
 
     Scalar analysisScale = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radius * radius / nbPoints);
 
     Scalar epsilon = testEpsilon<Scalar>();
-    //Scalar radisuEpsilon = epsilon * radius;
+    // Scalar radisuEpsilon = epsilon * radius;
 
     vector<DataPoint> vectorPoints(nbPoints);
 
-    for(unsigned int i = 0; i < vectorPoints.size(); ++i)
+    for (unsigned int i = 0; i < vectorPoints.size(); ++i)
     {
         vectorPoints[i] = getPointOnSphere<DataPoint>(radius, center, _bAddPositionNoise, _bAddNormalNoise);
     }
@@ -47,74 +47,78 @@ void testFunction(bool _bAddPositionNoise = false, bool _bAddNormalNoise = false
 
     // Test for each point if the normal is correct
 #pragma omp parallel for
-    for(int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
     {
         Fit fit;
         fit.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fit.compute(vectorPoints);
 
-        if(fit.isStable())
+        if (fit.isStable())
         {
-            VectorType estimated = fit.normal();
-            VectorType theoritical = (vectorPoints[i].pos()-center).normalized();
+            VectorType estimated   = fit.normal();
+            VectorType theoritical = (vectorPoints[i].pos() - center).normalized();
 
-            Scalar norm = estimated.norm();
+            Scalar norm   = estimated.norm();
             Scalar absdot = std::abs(estimated.dot(theoritical));
 
-            VERIFY( std::abs(norm-Scalar(1.)) < epsilon );
-            VERIFY( std::abs(absdot-Scalar(1.)) < epsilon );
+            VERIFY(std::abs(norm - Scalar(1.)) < epsilon);
+            VERIFY(std::abs(absdot - Scalar(1.)) < epsilon);
         }
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit> FitSmoothOriented;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit> FitConstantOriented;
-    typedef Basket<Point,WeightSmoothFunc,UnorientedSphereFit> FitSmoothUnoriented;
-    typedef Basket<Point,WeightConstantFunc,UnorientedSphereFit> FitConstantUnoriented;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothOrientedSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantOrientedSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothOrientedScaleSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit> FitSmoothOriented;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit> FitConstantOriented;
+    typedef Basket<Point, WeightSmoothFunc, UnorientedSphereFit> FitSmoothUnoriented;
+    typedef Basket<Point, WeightConstantFunc, UnorientedSphereFit> FitConstantUnoriented;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothOrientedScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantOrientedScaleSpaceDer;
 
     cout << "Testing with perfect sphere (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceDer>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceDer>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceDer>(true,true) ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceDer>(true,true) ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceDer>(true, true)));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceDer>(true, true)));
     }
     cout << "Ok!" << endl;
 
     cout << "Testing with noise on position and normals (oriented / unoriented)..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothUnoriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantUnoriented>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothOrientedScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantOrientedScaleSpaceDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOriented>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothUnoriented>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantUnoriented>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothOrientedScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitConstantOrientedScaleSpaceDer>()));
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/plane_primitive.cpp
+++ b/tests/src/plane_primitive.cpp
@@ -4,7 +4,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
     \file test/Grenaille/okabe_primitive.cpp
     \brief Test validity Plane Primitive
@@ -23,57 +22,57 @@
 using namespace std;
 using namespace Ponca;
 
-template<typename DataPoint, typename Fit>
+template <typename DataPoint, typename Fit>
 void testFunction()
 {
     // Define related structure
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
 
-    Scalar epsilon = testEpsilon<Scalar>();
+    Scalar epsilon   = testEpsilon<Scalar>();
     VectorType query = VectorType::Random();
 
     Fit f;
     f.setPlane(VectorType::Random(), query);
 
     // Test that the point on the plane returns a potential of 0
-    VERIFY( std::abs(f.potential(query)) <= epsilon);
+    VERIFY(std::abs(f.potential(query)) <= epsilon);
 
     // Use a random position in space
     query = VectorType::Random();
 
     // Check if we get the same point when projecting points x and x+gradient.
-    VectorType proj1 = f.project( query );
-    VectorType proj2 = f.project( query + f.primitiveGradient( query ) );
+    VectorType proj1 = f.project(query);
+    VectorType proj2 = f.project(query + f.primitiveGradient(query));
 
-    VERIFY( ( proj1 - proj2 ).norm() <= epsilon);
+    VERIFY((proj1 - proj2).norm() <= epsilon);
 
     // Check that the potential value is equal to the distance between the query
     // and its projection
-    VERIFY( std::abs( std::abs(f.potential(query)) - (query - proj1).norm()) <= epsilon);
+    VERIFY(std::abs(std::abs(f.potential(query)) - (query - proj1).norm()) <= epsilon);
 
     // Check that the potential value of a projected point is equal to 0
-    VERIFY( std::abs( f.potential(proj1) ) <= epsilon);
+    VERIFY(std::abs(f.potential(proj1)) <= epsilon);
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPosition<Scalar, Dim> Point;
 
     // We test only primitive functions and not the fitting procedure
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > NeighborFilter;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> NeighborFilter;
     typedef Basket<Point, NeighborFilter, Plane> Plane;
 
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, Plane>() ));
+        CALL_SUBTEST((testFunction<Point, Plane>()));
     }
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/projection.cpp
+++ b/tests/src/projection.cpp
@@ -6,7 +6,6 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 /*!
  \file test/Grenaille/projection.cpp
  \brief Test validity of the direct projection on an algebraic sphere
@@ -33,21 +32,22 @@ using namespace Ponca;
 /*
  * Test the OrientedSphereFit on a paraboloid using a given neighborhood filter
  */
-template<typename Fit>
-void testFunction(typename Fit::Scalar lowPrecisionEpsilon = typename Fit::Scalar(0.001)) // Lesser precision for the paraboloid test
+template <typename Fit>
+void testFunction(
+    typename Fit::Scalar lowPrecisionEpsilon = typename Fit::Scalar(0.001)) // Lesser precision for the paraboloid test
 {
     // Define related structure
     typedef typename Fit::Scalar Scalar;
     typedef typename Fit::VectorType VectorType;
     typedef typename Fit::DataPoint DataPoint;
 
-    //generate samples
-    int nbPoints = QUICK_TESTS ? 1 : Eigen::internal::random<int>(100, 1000);
+    // generate samples
+    int nbPoints    = QUICK_TESTS ? 1 : Eigen::internal::random<int>(100, 1000);
     int nbPointsFit = 50;
 
     // equal probability of having a plane or a random quadric
     VectorType coeff = 5 * VectorType::Random();
-    if(Eigen::internal::random<Scalar>(0., 1.) < Scalar(0.5))
+    if (Eigen::internal::random<Scalar>(0., 1.) < Scalar(0.5))
     {
         coeff = VectorType::Zero();
     }
@@ -57,100 +57,96 @@ void testFunction(typename Fit::Scalar lowPrecisionEpsilon = typename Fit::Scala
     Scalar width = Eigen::internal::random<Scalar>(1., 10.);
     // maximum offset is <5 unit, and always smaller than 2*width.
     // It is plenty enough to test local/global basis robustness, without introducing rounding errors
-    Scalar offset = Eigen::internal::random<Scalar>(1., std::min(Scalar(5.), Scalar(.5)*width));
-    VectorType center = offset*VectorType::Random();
+    Scalar offset     = Eigen::internal::random<Scalar>(1., std::min(Scalar(5.), Scalar(.5) * width));
+    VectorType center = offset * VectorType::Random();
 
-    Scalar zmax = std::abs((coeff[0] + coeff[1]) * width*width);
-    Scalar analysisScale = std::sqrt(zmax*zmax + width*width + offset);
+    Scalar zmax          = std::abs((coeff[0] + coeff[1]) * width * width);
+    Scalar analysisScale = std::sqrt(zmax * zmax + width * width + offset);
 
     Fit fit;
     fit.setNeighborFilter({center, analysisScale});
     fit.init();
 
-    for(int i = 0; i < nbPointsFit; ++i)
+    for (int i = 0; i < nbPointsFit; ++i)
     {
-        DataPoint p = getPointOnParaboloid<DataPoint>(coeff.x(),
-                                                      coeff.y(),
-                                                      0,0,0,0,
-                                                      width,
-                                                      false);           // noise
+        DataPoint p = getPointOnParaboloid<DataPoint>(coeff.x(), coeff.y(), 0, 0, 0, 0, width,
+                                                      false); // noise
         p.pos() += center;
 
         fit.addNeighbor(p);
     }
     fit.finalize();
 
-    if(fit.isStable())
+    if (fit.isStable())
     {
         for (int i = 0; i < nbPoints; ++i)
         {
             const VectorType p = center + analysisScale * VectorType::Random();
 
             // check that the projected point is on the surface
-            VectorType projD = fit.projectDescent( p, 1000 );
-            VERIFY( std::abs(fit.potential(projD)) < lowPrecisionEpsilon );
+            VectorType projD = fit.projectDescent(p, 1000);
+            VERIFY(std::abs(fit.potential(projD)) < lowPrecisionEpsilon);
 
-            VectorType proj = fit.project( p );
-            Scalar p1 = std::abs(fit.potential(proj));
-            Scalar p2 = std::abs(fit.potential(p));
+            VectorType proj = fit.project(p);
+            Scalar p1       = std::abs(fit.potential(proj));
+            Scalar p2       = std::abs(fit.potential(p));
             // check the direct projection did not move the point away from the surface (can be stationary if already
             // on the surface)
-            VERIFY( p1 <= p2 );
+            VERIFY(p1 <= p2);
         }
 
         // Disable this test: not true with apple-clang 12.
 #ifdef COMPARE_PROJECTION_TIMINGS
         auto start1 = std::chrono::system_clock::now();
-        for( const auto& p: samples )
-          fit.project( p );
+        for (const auto& p : samples)
+            fit.project(p);
         auto end1 = std::chrono::system_clock::now();
 
         auto start2 = std::chrono::system_clock::now();
-        for( const auto& p: samples )
-          fit.projectDescent( p );
+        for (const auto& p : samples)
+            fit.projectDescent(p);
         auto end2 = std::chrono::system_clock::now();
 
-        std::chrono::duration<double> elapsed_seconds1 = end1-start1;
-        std::chrono::duration<double> elapsed_seconds2 = end2-start2;
+        std::chrono::duration<double> elapsed_seconds1 = end1 - start1;
+        std::chrono::duration<double> elapsed_seconds2 = end2 - start2;
         std::cout << "Default: " << elapsed_seconds1.count() << " Descent: " << elapsed_seconds2.count() << "s\n";
-        VERIFY( elapsed_seconds1 <= elapsed_seconds2 );
+        VERIFY(elapsed_seconds1 <= elapsed_seconds2);
 #endif
     }
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
-    using Point = PointPositionNormal<Scalar, Dim> ;
+    using Point = PointPositionNormal<Scalar, Dim>;
 
     using WeightSmoothFunc        = DistWeightFunc<Point, SmoothWeightKernel<Scalar>>;
     using WeightConstantFuncLocal = Ponca::DistWeightFunc<Point, Ponca::ConstantWeightKernel<Scalar>>;
-    using NoWeightFuncGlobal      = Ponca::NoWeightFuncGlobal<Point> ;
-    using NoWeightFunc            = Ponca::NoWeightFunc<Point> ;
+    using NoWeightFuncGlobal      = Ponca::NoWeightFuncGlobal<Point>;
+    using NoWeightFunc            = Ponca::NoWeightFunc<Point>;
 
-#define MAKE_FIT_TYPE(Fit,Weight) Basket<Point, Weight, Fit>
+#define MAKE_FIT_TYPE(Fit, Weight) Basket<Point, Weight, Fit>
 
-#define TEST_FIT(Fit) \
-        CALL_SUBTEST(( testFunction<MAKE_FIT_TYPE(Fit,WeightSmoothFunc)>() )); \
-        CALL_SUBTEST(( testFunction<MAKE_FIT_TYPE(Fit,WeightConstantFuncLocal)>() )); \
-        CALL_SUBTEST(( testFunction<MAKE_FIT_TYPE(Fit,NoWeightFunc)>() ));
+#define TEST_FIT(Fit)                                                            \
+    CALL_SUBTEST((testFunction<MAKE_FIT_TYPE(Fit, WeightSmoothFunc)>()));        \
+    CALL_SUBTEST((testFunction<MAKE_FIT_TYPE(Fit, WeightConstantFuncLocal)>())); \
+    CALL_SUBTEST((testFunction<MAKE_FIT_TYPE(Fit, NoWeightFunc)>()));
 
     cout << "Testing with " << typeid(Scalar).name() << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
         TEST_FIT(OrientedSphereFit) // AlgebraicSphere requires local basis
         TEST_FIT(CovariancePlaneFit)
-        CALL_SUBTEST(( testFunction<MAKE_FIT_TYPE(CovariancePlaneFit,NoWeightFuncGlobal)>() ));
+        CALL_SUBTEST((testFunction<MAKE_FIT_TYPE(CovariancePlaneFit, NoWeightFuncGlobal)>()));
         TEST_FIT(UnorientedSphereFit)
         TEST_FIT(SphereFit)
-
     }
     cout << "Ok!" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/queries_knearest.cpp
+++ b/tests/src/queries_knearest.cpp
@@ -18,111 +18,111 @@
 using namespace Ponca;
 
 //! Test kNearestNeighbors query
-template<bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
-auto testKNearestNeighbors( AcceleratingStructure& structure,
-	PointContainer& points,
-	std::vector<int>& sample,
-	const int k
-) {
-	using DataPoint      = typename AcceleratingStructure::DataPoint;
+template <bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
+auto testKNearestNeighbors(AcceleratingStructure& structure, PointContainer& points, std::vector<int>& sample,
+                           const int k)
+{
+    using DataPoint = typename AcceleratingStructure::DataPoint;
 
-	return testQuery<doIndexQuery, DataPoint>(points,
-	[&structure]() {
-			if constexpr (doIndexQuery) {
-				return structure.kNearestNeighborsIndexQuery();
-			} else {
-				return structure.kNearestNeighborsQuery();
-			}
-		}, [&structure](auto &queryInput, const int _k) {
-			return structure.kNearestNeighbors(queryInput, _k);
-		}, [&points, &sample, &k](auto& queryInput, auto& queryResults) {
-			return checkKNearestNeighbors<DataPoint>(points, sample, queryInput, k, queryResults);
-		}, g_repeat, k
-	);
+    return testQuery<doIndexQuery, DataPoint>(
+        points,
+        [&structure]() {
+            if constexpr (doIndexQuery)
+            {
+                return structure.kNearestNeighborsIndexQuery();
+            }
+            else
+            {
+                return structure.kNearestNeighborsQuery();
+            }
+        },
+        [&structure](auto& queryInput, const int _k) { return structure.kNearestNeighbors(queryInput, _k); },
+        [&points, &sample, &k](auto& queryInput, auto& queryResults) {
+            return checkKNearestNeighbors<DataPoint>(points, sample, queryInput, k, queryResults);
+        },
+        g_repeat, k);
 }
 
-//! Test kNearestNeighbors query without the k argument (the size of the iterator depends on the acceleration structure (e.g. when using the knnGraph(kdtreeDense, k))
-template<typename AcceleratingStructure, typename PointContainer>
-auto testKNearestNeighborsEntirePointSet( AcceleratingStructure& structure,
-	PointContainer& points,
-	const int k
-) {
-	using DataPoint      = typename AcceleratingStructure::DataPoint;
+//! Test kNearestNeighbors query without the k argument (the size of the iterator depends on the acceleration structure
+//! (e.g. when using the knnGraph(kdtreeDense, k))
+template <typename AcceleratingStructure, typename PointContainer>
+auto testKNearestNeighborsEntirePointSet(AcceleratingStructure& structure, PointContainer& points, const int k)
+{
+    using DataPoint = typename AcceleratingStructure::DataPoint;
 
-	return testQuery<true, DataPoint>(points,
-	[&structure]() {
-			return structure.kNearestNeighborsIndexQuery();
-		}, [&structure](auto &queryInput) {
-			return structure.kNearestNeighbors(queryInput);
-		}, [&points, &k](auto& queryInput, auto& queryResults) {
-			return checkKNearestNeighbors<DataPoint>(points, queryInput, k, queryResults);
-		}, g_repeat
-	);
+    return testQuery<true, DataPoint>(
+        points, [&structure]() { return structure.kNearestNeighborsIndexQuery(); },
+        [&structure](auto& queryInput) { return structure.kNearestNeighbors(queryInput); },
+        [&points, &k](auto& queryInput, auto& queryResults) {
+            return checkKNearestNeighbors<DataPoint>(points, queryInput, k, queryResults);
+        },
+        g_repeat);
 }
 
-template<template <typename> class KdTreeType, typename P>
-inline KdTreeType<P> testKdTree(std::vector<P> & points, std::vector<int> & sample, const int k) {
-	KdTreeType<P> kdtree = *testBuildKdTree<P, KdTreeType>(points, sample);
+template <template <typename> class KdTreeType, typename P>
+inline KdTreeType<P> testKdTree(std::vector<P>& points, std::vector<int>& sample, const int k)
+{
+    KdTreeType<P> kdtree = *testBuildKdTree<P, KdTreeType>(points, sample);
 
-	std::chrono::milliseconds timing = testKNearestNeighbors<true>(kdtree, points, sample, k);  // Index query test
+    std::chrono::milliseconds timing = testKNearestNeighbors<true>(kdtree, points, sample, k); // Index query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KdTree index query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KdTree index query : " << timing.count() << "ms" << endl;
 #endif
-	timing = testKNearestNeighbors<false>(kdtree, points, sample, k); // Position query test
+    timing = testKNearestNeighbors<false>(kdtree, points, sample, k); // Position query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KdTree position query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KdTree position query : " << timing.count() << "ms" << endl;
 #endif
-	return kdtree;
+    return kdtree;
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void testKNearestNeighborsForAllStructures(const bool quick = QUICK_TESTS)
 {
-	using P = PointPositionNormal<Scalar, Dim>;
-	const int N = quick ? 100 : 1000;
-	const int k = quick ? 2 : 15;
+    using P     = PointPositionNormal<Scalar, Dim>;
+    const int N = quick ? 100 : 1000;
+    const int k = quick ? 2 : 15;
 
-	//////////// Generate data
-	std::vector<P> points(N);
-	generateData(points);
+    //////////// Generate data
+    std::vector<P> points(N);
+    generateData(points);
 
-	cout << endl;
-	//////////// Test KdTree STL-like containers
-	std::vector<int> sampleDense;
-	KdTreeDense<P> kdtreeDense = testKdTree<KdTreeDense>(points, sampleDense, k);
-	std::vector<int> sampleSparse;
-	testKdTree<KdTreeSparse>(points, sampleSparse, k);
+    cout << endl;
+    //////////// Test KdTree STL-like containers
+    std::vector<int> sampleDense;
+    KdTreeDense<P> kdtreeDense = testKdTree<KdTreeDense>(points, sampleDense, k);
+    std::vector<int> sampleSparse;
+    testKdTree<KdTreeSparse>(points, sampleSparse, k);
 
-	//////////// Test KnnGraph
-	KnnGraph<P> knnGraph(kdtreeDense, k);
+    //////////// Test KnnGraph
+    KnnGraph<P> knnGraph(kdtreeDense, k);
 
-	std::chrono::milliseconds timing = testKNearestNeighborsEntirePointSet(knnGraph, points, k);  // Index query test
+    std::chrono::milliseconds timing = testKNearestNeighborsEntirePointSet(knnGraph, points, k); // Index query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KnnGraph index query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KnnGraph index query : " << timing.count() << "ms" << endl;
 #endif
-	cout << "  (ok)" << endl;
+    cout << "  (ok)" << endl;
 }
 
 int main(const int argc, char** argv)
 {
-	if (!init_testing(argc, argv))
-		return EXIT_FAILURE;
+    if (!init_testing(argc, argv))
+        return EXIT_FAILURE;
 
-	cout << "Test kNearestNeighbors query for KdTree and KnnGraph in 3D : " << endl;
-	cout << "  float : " << endl;
-	CALL_SUBTEST_1((testKNearestNeighborsForAllStructures<float, 3>()));
-	cout << "  double : " << endl;
-	CALL_SUBTEST_2((testKNearestNeighborsForAllStructures<double, 3>()));
-	cout << "  long : " << endl;
-	CALL_SUBTEST_3((testKNearestNeighborsForAllStructures<long double, 3>()));
+    cout << "Test kNearestNeighbors query for KdTree and KnnGraph in 3D : " << endl;
+    cout << "  float : " << endl;
+    CALL_SUBTEST_1((testKNearestNeighborsForAllStructures<float, 3>()));
+    cout << "  double : " << endl;
+    CALL_SUBTEST_2((testKNearestNeighborsForAllStructures<double, 3>()));
+    cout << "  long : " << endl;
+    CALL_SUBTEST_3((testKNearestNeighborsForAllStructures<long double, 3>()));
 
-	cout << "Test kNearestNeighbors query for KdTree and KnnGraph in 4D : " << endl;
-	cout << "  float : " << endl;
-	CALL_SUBTEST_1((testKNearestNeighborsForAllStructures<float, 4>()));
-	cout << "  double : " << endl;
-	CALL_SUBTEST_2((testKNearestNeighborsForAllStructures<double, 4>()));
-	cout << "  long : " << endl;
-	CALL_SUBTEST_3((testKNearestNeighborsForAllStructures<long double, 4>()));
+    cout << "Test kNearestNeighbors query for KdTree and KnnGraph in 4D : " << endl;
+    cout << "  float : " << endl;
+    CALL_SUBTEST_1((testKNearestNeighborsForAllStructures<float, 4>()));
+    cout << "  double : " << endl;
+    CALL_SUBTEST_2((testKNearestNeighborsForAllStructures<double, 4>()));
+    cout << "  long : " << endl;
+    CALL_SUBTEST_3((testKNearestNeighborsForAllStructures<long double, 4>()));
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/tests/src/queries_nearest.cpp
+++ b/tests/src/queries_nearest.cpp
@@ -17,101 +17,98 @@
 
 using namespace Ponca;
 
-template<bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
-auto testNearestNeighbor( AcceleratingStructure& structure,
-	PointContainer& points,
-	std::vector<int>& sample
-) {
-	using DataPoint      = typename AcceleratingStructure::DataPoint;
+template <bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
+auto testNearestNeighbor(AcceleratingStructure& structure, PointContainer& points, std::vector<int>& sample)
+{
+    using DataPoint = typename AcceleratingStructure::DataPoint;
 
-	return testQuery<doIndexQuery, DataPoint>(points, [&structure](auto &queryInput) {
-			return structure.nearestNeighbor(queryInput);
-		}, [&points, &sample](auto& queryInput, auto& queryResults) {
-			VERIFY((queryResults.size() == 1));
-			return checkNearestNeighbor<DataPoint>(points, sample, queryInput, queryResults.front());
-		}, g_repeat
-	);
+    return testQuery<doIndexQuery, DataPoint>(
+        points, [&structure](auto& queryInput) { return structure.nearestNeighbor(queryInput); },
+        [&points, &sample](auto& queryInput, auto& queryResults) {
+            VERIFY((queryResults.size() == 1));
+            return checkNearestNeighbor<DataPoint>(points, sample, queryInput, queryResults.front());
+        },
+        g_repeat);
 }
 
-template<bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
-auto testFrontOfKNearestNeighbors( AcceleratingStructure& structure,
-	PointContainer& points,
-	std::vector<int>& sample
-) {
-	using DataPoint      = typename AcceleratingStructure::DataPoint;
+template <bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
+auto testFrontOfKNearestNeighbors(AcceleratingStructure& structure, PointContainer& points, std::vector<int>& sample)
+{
+    using DataPoint = typename AcceleratingStructure::DataPoint;
 
-	return testQuery<doIndexQuery, DataPoint>(points, [&structure]() {
-			return structure.kNearestNeighborsIndexQuery();
-		}, [&structure](auto &queryInput) {
-			return structure.kNearestNeighbors(queryInput);
-		}, [&points, &sample](auto& queryInput, auto& queryResults) {
-			VERIFY((queryResults.size() == 1));
-			return checkNearestNeighbor<DataPoint>(points, sample, queryInput, queryResults.front());
-		}, g_repeat
-	);
+    return testQuery<doIndexQuery, DataPoint>(
+        points, [&structure]() { return structure.kNearestNeighborsIndexQuery(); },
+        [&structure](auto& queryInput) { return structure.kNearestNeighbors(queryInput); },
+        [&points, &sample](auto& queryInput, auto& queryResults) {
+            VERIFY((queryResults.size() == 1));
+            return checkNearestNeighbor<DataPoint>(points, sample, queryInput, queryResults.front());
+        },
+        g_repeat);
 }
 
-template<template <typename> class KdTreeType, typename P>
-inline KdTreeType<P> testKdTree(std::vector<P> & points, std::vector<int> & sample) {
-	KdTreeType<P> kdtree = *testBuildKdTree<P, KdTreeType>(points, sample);
+template <template <typename> class KdTreeType, typename P>
+inline KdTreeType<P> testKdTree(std::vector<P>& points, std::vector<int>& sample)
+{
+    KdTreeType<P> kdtree = *testBuildKdTree<P, KdTreeType>(points, sample);
 
-	std::chrono::milliseconds timing = testNearestNeighbor<true>(kdtree, points, sample);  // Index query test
+    std::chrono::milliseconds timing = testNearestNeighbor<true>(kdtree, points, sample); // Index query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KdTree index query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KdTree index query : " << timing.count() << "ms" << endl;
 #endif
-	timing = testNearestNeighbor<false>(kdtree, points, sample); // Position query test
+    timing = testNearestNeighbor<false>(kdtree, points, sample); // Position query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KdTree position query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KdTree position query : " << timing.count() << "ms" << endl;
 #endif
-	return kdtree;
+    return kdtree;
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void testNearestNeighborForAllStructures(const bool quick = QUICK_TESTS)
 {
-	using P = PointPositionNormal<Scalar, Dim>;
-	const int N = quick ? 100 : 5000;
+    using P     = PointPositionNormal<Scalar, Dim>;
+    const int N = quick ? 100 : 5000;
 
-	//////////// Generate data
-	std::vector<P> points(N);
-	generateData(points);
+    //////////// Generate data
+    std::vector<P> points(N);
+    generateData(points);
 
-	//////////// Test KdTree STL-like containers
-	std::vector<int> sampleDense;
-	KdTreeDense<P> kdtreeDense = testKdTree<KdTreeDense>(points, sampleDense);
-	std::vector<int> sampleSparse;
-	testKdTree<KdTreeSparse>(points, sampleSparse);
+    //////////// Test KdTree STL-like containers
+    std::vector<int> sampleDense;
+    KdTreeDense<P> kdtreeDense = testKdTree<KdTreeDense>(points, sampleDense);
+    std::vector<int> sampleSparse;
+    testKdTree<KdTreeSparse>(points, sampleSparse);
 
-	//////////// Test KnnGraph
-	KnnGraph<P> knnGraph(kdtreeDense, 1);
-	std::chrono::milliseconds timing = testFrontOfKNearestNeighbors<true>(knnGraph, points, sampleDense);  // Index query test
+    //////////// Test KnnGraph
+    KnnGraph<P> knnGraph(kdtreeDense, 1);
+    std::chrono::milliseconds timing =
+        testFrontOfKNearestNeighbors<true>(knnGraph, points, sampleDense); // Index query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KnnGraph index query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KnnGraph index query : " << timing.count() << "ms" << endl;
 #endif
 
-	cout << "(ok)";
+    cout << "(ok)";
 }
 
 int main(const int argc, char** argv)
 {
-	if (!init_testing(argc, argv))
-		return EXIT_FAILURE;
+    if (!init_testing(argc, argv))
+        return EXIT_FAILURE;
 
-	cout << "Test nearestNeighbor query for KdTree and KnnGraph in 3D : " << flush;
-	cout << endl << " float : " << flush;
-	CALL_SUBTEST_1((testNearestNeighborForAllStructures<float, 3>()));
-	cout << endl << " double : " << flush;
-	CALL_SUBTEST_2((testNearestNeighborForAllStructures<double, 3>()));
-	cout << endl << " long : " << flush;
-	CALL_SUBTEST_3((testNearestNeighborForAllStructures<long double, 3>()));
+    cout << "Test nearestNeighbor query for KdTree and KnnGraph in 3D : " << flush;
+    cout << endl << " float : " << flush;
+    CALL_SUBTEST_1((testNearestNeighborForAllStructures<float, 3>()));
+    cout << endl << " double : " << flush;
+    CALL_SUBTEST_2((testNearestNeighborForAllStructures<double, 3>()));
+    cout << endl << " long : " << flush;
+    CALL_SUBTEST_3((testNearestNeighborForAllStructures<long double, 3>()));
 
-	cout << "Test nearestNeighbor query for KdTree and KnnGraph in 4D : " << flush;
-	cout << endl << " float : " << flush;
-	CALL_SUBTEST_1((testNearestNeighborForAllStructures<float, 4>()));
-	cout << endl << " double : " << flush;
-	CALL_SUBTEST_2((testNearestNeighborForAllStructures<double, 4>()));
-	cout << endl << " long : " << flush;
-	CALL_SUBTEST_3((testNearestNeighborForAllStructures<long double, 4>()));
+    cout << "Test nearestNeighbor query for KdTree and KnnGraph in 4D : " << flush;
+    cout << endl << " float : " << flush;
+    CALL_SUBTEST_1((testNearestNeighborForAllStructures<float, 4>()));
+    cout << endl << " double : " << flush;
+    CALL_SUBTEST_2((testNearestNeighborForAllStructures<double, 4>()));
+    cout << endl << " long : " << flush;
+    CALL_SUBTEST_3((testNearestNeighborForAllStructures<long double, 4>()));
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/tests/src/queries_range.cpp
+++ b/tests/src/queries_range.cpp
@@ -16,94 +16,97 @@
 
 using namespace Ponca;
 
-template<bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
-auto testRangeNeighbors( AcceleratingStructure& structure,
-	PointContainer& points,
-	std::vector<int>& sample
-) {
-	using DataPoint      = typename AcceleratingStructure::DataPoint;
-	using Scalar         = typename DataPoint::Scalar;
+template <bool doIndexQuery, typename AcceleratingStructure, typename PointContainer>
+auto testRangeNeighbors(AcceleratingStructure& structure, PointContainer& points, std::vector<int>& sample)
+{
+    using DataPoint = typename AcceleratingStructure::DataPoint;
+    using Scalar    = typename DataPoint::Scalar;
 
-	const Scalar r = Eigen::internal::random<Scalar>(Scalar(0.01), Scalar(0.5));
+    const Scalar r = Eigen::internal::random<Scalar>(Scalar(0.01), Scalar(0.5));
 
-	return testQuery<doIndexQuery, DataPoint>(points,
-		[&structure]() {
-			if constexpr (doIndexQuery) {
-				return structure.rangeNeighborsIndexQuery();
-			} else {
-				return structure.rangeNeighborsQuery();
-			}
-		}, [&structure](auto& queryInput, const Scalar _r) {
-			return structure.rangeNeighbors(queryInput, _r);
-		}, [&points, &sample, &r](auto& queryInput, auto& queryResults) {
-			return checkRangeNeighbors<DataPoint>(points, sample, queryInput, r, queryResults);
-		}, g_repeat, r
-	);
+    return testQuery<doIndexQuery, DataPoint>(
+        points,
+        [&structure]() {
+            if constexpr (doIndexQuery)
+            {
+                return structure.rangeNeighborsIndexQuery();
+            }
+            else
+            {
+                return structure.rangeNeighborsQuery();
+            }
+        },
+        [&structure](auto& queryInput, const Scalar _r) { return structure.rangeNeighbors(queryInput, _r); },
+        [&points, &sample, &r](auto& queryInput, auto& queryResults) {
+            return checkRangeNeighbors<DataPoint>(points, sample, queryInput, r, queryResults);
+        },
+        g_repeat, r);
 }
 
-template<template <typename> class KdTreeType, typename P>
-inline KdTreeType<P> testKdTree(std::vector<P> & points, std::vector<int> & sample) {
-	KdTreeType<P> kdtree = std::move(*testBuildKdTree<P, KdTreeType>(points, sample));
+template <template <typename> class KdTreeType, typename P>
+inline KdTreeType<P> testKdTree(std::vector<P>& points, std::vector<int>& sample)
+{
+    KdTreeType<P> kdtree = std::move(*testBuildKdTree<P, KdTreeType>(points, sample));
 
-	std::chrono::milliseconds timing = testRangeNeighbors<true>(kdtree, points, sample);  // Index query test
+    std::chrono::milliseconds timing = testRangeNeighbors<true>(kdtree, points, sample); // Index query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KdTree index query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KdTree index query : " << timing.count() << "ms" << endl;
 #endif
-	timing = testRangeNeighbors<false>(kdtree, points, sample); // Position query test
+    timing = testRangeNeighbors<false>(kdtree, points, sample); // Position query test
 #ifdef PRINT_TIMING
-	cout << "    Compute Time KdTree position query : " <<  timing.count() << "ms" << endl;
+    cout << "    Compute Time KdTree position query : " << timing.count() << "ms" << endl;
 #endif
-	return kdtree;
+    return kdtree;
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void testRangeNeighborsForAllStructures(const bool quick = QUICK_TESTS)
 {
-	using P = PointPositionNormal<Scalar, Dim>;
-	const int N = quick ? 100 : 1000;
+    using P     = PointPositionNormal<Scalar, Dim>;
+    const int N = quick ? 100 : 1000;
 
-	//////////// Generate data
-	std::vector<P> points(N);
-	generateData(points);
+    //////////// Generate data
+    std::vector<P> points(N);
+    generateData(points);
 
-	//////////// Test KdTree STL-like containers
-	std::vector<int> sampleDense;
-	KdTreeDense<P> kdtreeDense = testKdTree<KdTreeDense>(points, sampleDense);
-	std::vector<int> sampleSparse;
-	testKdTree<KdTreeSparse>(points, sampleSparse);
+    //////////// Test KdTree STL-like containers
+    std::vector<int> sampleDense;
+    KdTreeDense<P> kdtreeDense = testKdTree<KdTreeDense>(points, sampleDense);
+    std::vector<int> sampleSparse;
+    testKdTree<KdTreeSparse>(points, sampleSparse);
 
-	////////// Test KnnGraph
-	 KnnGraph<P> knnGraph(kdtreeDense, N/4); /* We need a large graph, otherwise we might miss some points
-	 										   (which is the goal of the graph: to replace full Euclidean
-	 										   collection by geodesic-like region growing bounded by
-	 										   the Euclidean ball). */
-	 std::chrono::milliseconds timing = testRangeNeighbors<true>(knnGraph, points, sampleDense);  // Index query test
- #ifdef PRINT_TIMING
- 	cout << "    Compute Time KnnGraph index query : " <<  timing.count() << "ms" << endl;
- #endif
-	cout << "  (ok)" << endl;
+    ////////// Test KnnGraph
+    KnnGraph<P> knnGraph(kdtreeDense, N / 4); /* We need a large graph, otherwise we might miss some points
+                                                (which is the goal of the graph: to replace full Euclidean
+                                                collection by geodesic-like region growing bounded by
+                                                the Euclidean ball). */
+    std::chrono::milliseconds timing = testRangeNeighbors<true>(knnGraph, points, sampleDense); // Index query test
+#ifdef PRINT_TIMING
+    cout << "    Compute Time KnnGraph index query : " << timing.count() << "ms" << endl;
+#endif
+    cout << "  (ok)" << endl;
 }
 
 int main(const int argc, char** argv)
 {
-	if (!init_testing(argc, argv))
-		return EXIT_FAILURE;
+    if (!init_testing(argc, argv))
+        return EXIT_FAILURE;
 
-	cout << "Test rangeNeighbors query for KdTree and KnnGraph in 3D : " << endl;
-	cout << "  float : " << endl;
-	CALL_SUBTEST_1((testRangeNeighborsForAllStructures<float, 3>()));
-	cout << "  double : " << endl;
-	CALL_SUBTEST_2((testRangeNeighborsForAllStructures<double, 3>()));
-	cout << "  long : " << endl;
-	CALL_SUBTEST_3((testRangeNeighborsForAllStructures<long double, 3>()));
+    cout << "Test rangeNeighbors query for KdTree and KnnGraph in 3D : " << endl;
+    cout << "  float : " << endl;
+    CALL_SUBTEST_1((testRangeNeighborsForAllStructures<float, 3>()));
+    cout << "  double : " << endl;
+    CALL_SUBTEST_2((testRangeNeighborsForAllStructures<double, 3>()));
+    cout << "  long : " << endl;
+    CALL_SUBTEST_3((testRangeNeighborsForAllStructures<long double, 3>()));
 
-	cout << "Test rangeNeighbors query for KdTree and KnnGraph in 4D : " << endl;
-	cout << "  float : " << endl;
-	CALL_SUBTEST_1((testRangeNeighborsForAllStructures<float, 4>()));
-	cout << "  double : " << endl;
-	CALL_SUBTEST_2((testRangeNeighborsForAllStructures<double, 4>()));
-	cout << "  long : " << endl;
-	CALL_SUBTEST_3((testRangeNeighborsForAllStructures<long double, 4>()));
+    cout << "Test rangeNeighbors query for KdTree and KnnGraph in 4D : " << endl;
+    cout << "  float : " << endl;
+    CALL_SUBTEST_1((testRangeNeighborsForAllStructures<float, 4>()));
+    cout << "  double : " << endl;
+    CALL_SUBTEST_2((testRangeNeighborsForAllStructures<double, 4>()));
+    cout << "  long : " << endl;
+    CALL_SUBTEST_3((testRangeNeighborsForAllStructures<long double, 4>()));
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/tests/src/scale_space_consistency.cpp
+++ b/tests/src/scale_space_consistency.cpp
@@ -17,24 +17,25 @@
 using namespace std;
 using namespace Grenaille;
 
-template<typename DataPoint, typename FitScaleDer, typename FitSpaceDer, typename FitScaleSpaceDer>
-void checkConsistency(const vector<DataPoint> vectorPoints, typename DataPoint::Scalar analysisScale, typename DataPoint::Scalar epsilon)
+template <typename DataPoint, typename FitScaleDer, typename FitSpaceDer, typename FitScaleSpaceDer>
+void checkConsistency(const vector<DataPoint> vectorPoints, typename DataPoint::Scalar analysisScale,
+                      typename DataPoint::Scalar epsilon)
 {
     typedef typename DataPoint::Scalar Scalar;
     typedef typename DataPoint::VectorType VectorType;
     typedef typename DataPoint::MatrixType MatrixType;
 
     // input type check
-    VERIFY(  FitScaleDer::isScaleDer()      && !FitScaleDer::isSpaceDer() );
-    VERIFY( !FitSpaceDer::isScaleDer()      &&  FitSpaceDer::isSpaceDer() );
-    VERIFY(  FitScaleSpaceDer::isScaleDer() &&  FitScaleSpaceDer::isSpaceDer() );
+    VERIFY(FitScaleDer::isScaleDer() && !FitScaleDer::isSpaceDer());
+    VERIFY(!FitSpaceDer::isScaleDer() && FitSpaceDer::isSpaceDer());
+    VERIFY(FitScaleSpaceDer::isScaleDer() && FitScaleSpaceDer::isSpaceDer());
 
     // Quick testing is requested for coverage
     int nbPoints = QUICK_TESTS ? 1 : int(vectorPoints.size());
 
     // test that dPotential and dNormal wrt scale, space and both are the same regardless of the derivation type
 #pragma omp parallel for
-    for(int i=0; i<nbPoints; ++i)
+    for (int i = 0; i < nbPoints; ++i)
     {
         FitScaleDer fitScaleDer;
         fitScaleDer.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
@@ -48,15 +49,16 @@ void checkConsistency(const vector<DataPoint> vectorPoints, typename DataPoint::
         fitScaleSpaceDer.setNeighborFilter({vectorPoints[i].pos(), analysisScale});
         fitScaleSpaceDer.compute(vectorPoints);
 
-        VERIFY( fitScaleDer.isStable()==fitSpaceDer.isStable() && fitScaleDer.isStable()==fitScaleSpaceDer.isStable() );
+        VERIFY(fitScaleDer.isStable() == fitSpaceDer.isStable() &&
+               fitScaleDer.isStable() == fitScaleSpaceDer.isStable());
 
-        if(fitScaleDer.isStable() && fitSpaceDer.isStable() && fitScaleSpaceDer.isStable())
+        if (fitScaleDer.isStable() && fitSpaceDer.isStable() && fitScaleSpaceDer.isStable())
         {
-            typename FitScaleDer::ScalarArray dPotentialScaleDer = fitScaleDer.dPotential();
-            typename FitSpaceDer::ScalarArray dPotentialSpaceDer = fitSpaceDer.dPotential();
+            typename FitScaleDer::ScalarArray dPotentialScaleDer           = fitScaleDer.dPotential();
+            typename FitSpaceDer::ScalarArray dPotentialSpaceDer           = fitSpaceDer.dPotential();
             typename FitScaleSpaceDer::ScalarArray dPotentialScaleSpaceDer = fitScaleSpaceDer.dPotential();
 
-            typename FitSpaceDer::VectorArray dNormalSpaceDer = fitSpaceDer.dNormal();
+            typename FitSpaceDer::VectorArray dNormalSpaceDer           = fitSpaceDer.dNormal();
             typename FitScaleSpaceDer::VectorArray dNormalScaleSpaceDer = fitScaleSpaceDer.dNormal();
 
             Scalar dt_potential1 = dPotentialScaleDer[0];
@@ -68,12 +70,12 @@ void checkConsistency(const vector<DataPoint> vectorPoints, typename DataPoint::
             MatrixType dx_normal1 = dNormalSpaceDer.template rightCols<DataPoint::Dim>();
             MatrixType dx_normal2 = dNormalScaleSpaceDer.template rightCols<DataPoint::Dim>();
 
-            VERIFY( std::abs(dt_potential1-dt_potential2) < epsilon );
-            VERIFY( (dx_potential1-dx_potential2).norm() < epsilon );
+            VERIFY(std::abs(dt_potential1 - dt_potential2) < epsilon);
+            VERIFY((dx_potential1 - dx_potential2).norm() < epsilon);
 
-            for(int i=0; i<DataPoint::Dim; ++i)
+            for (int i = 0; i < DataPoint::Dim; ++i)
             {
-                VERIFY( (dx_normal1.col(i)-dx_normal2.col(i)).norm() < epsilon );
+                VERIFY((dx_normal1.col(i) - dx_normal2.col(i)).norm() < epsilon);
             }
         }
         else
@@ -83,9 +85,7 @@ void checkConsistency(const vector<DataPoint> vectorPoints, typename DataPoint::
     }
 }
 
-
-
-template<typename DataPoint, typename Fit1, typename Fit2, typename Fit3>
+template <typename DataPoint, typename Fit1, typename Fit2, typename Fit3>
 void testFunction(bool _bAddNoise = false)
 {
     // Define related structure
@@ -94,129 +94,127 @@ void testFunction(bool _bAddNoise = false)
     typedef typename DataPoint::QuaternionType QuaternionType;
 
     int nbPointsParaboloid = Eigen::internal::random<int>(100, 1000);
-    int nbPointsPlane = Eigen::internal::random<int>(100, 1000);
-    int nbPointsSphere = Eigen::internal::random<int>(100, 1000);
-    int nbPointsRectangle = Eigen::internal::random<int>(100, 1000);
+    int nbPointsPlane      = Eigen::internal::random<int>(100, 1000);
+    int nbPointsSphere     = Eigen::internal::random<int>(100, 1000);
+    int nbPointsRectangle  = Eigen::internal::random<int>(100, 1000);
 
-    VectorType coefParaboloid = 10 * VectorType(Eigen::internal::random<Scalar>(-1,1), Eigen::internal::random<Scalar>(-1,1), 0);
+    VectorType coefParaboloid =
+        10 * VectorType(Eigen::internal::random<Scalar>(-1, 1), Eigen::internal::random<Scalar>(-1, 1), 0);
     Scalar analysisScaleParaboloid = Scalar(0.001);
     QuaternionType qParaboloid;
 
-    Scalar widthPlane  = Eigen::internal::random<Scalar>(1., 10.);
-    Scalar heightPlane = widthPlane;
-    Scalar analysisScalePlane = Scalar(50.) * std::sqrt( widthPlane * heightPlane / nbPointsPlane);
-    Scalar centerScalePlane   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar widthPlane         = Eigen::internal::random<Scalar>(1., 10.);
+    Scalar heightPlane        = widthPlane;
+    Scalar analysisScalePlane = Scalar(50.) * std::sqrt(widthPlane * heightPlane / nbPointsPlane);
+    Scalar centerScalePlane   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType centerPlane    = VectorType::Random() * centerScalePlane;
     VectorType directionPlane = VectorType::Random().normalized();
 
-    Scalar radiusSphere = Eigen::internal::random<Scalar>(1,10);
+    Scalar radiusSphere     = Eigen::internal::random<Scalar>(1, 10);
     VectorType centerSphere = VectorType::Random() * Eigen::internal::random<Scalar>(1, 10000);
-    Scalar analysisScaleSphere = Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radiusSphere * radiusSphere / nbPointsSphere);
+    Scalar analysisScaleSphere =
+        Scalar(10.) * std::sqrt(Scalar(4. * M_PI) * radiusSphere * radiusSphere / nbPointsSphere);
 
-    Scalar widthRectangle  = Eigen::internal::random<Scalar>(1., 10.);
-    Scalar heightRectangle = widthRectangle;
-    Scalar analysisScaleRectangle = Scalar(20.) * std::sqrt( widthRectangle * heightRectangle / nbPointsRectangle);
-    Scalar centerScaleRectangle   = Eigen::internal::random<Scalar>(1,10000);
+    Scalar widthRectangle         = Eigen::internal::random<Scalar>(1., 10.);
+    Scalar heightRectangle        = widthRectangle;
+    Scalar analysisScaleRectangle = Scalar(20.) * std::sqrt(widthRectangle * heightRectangle / nbPointsRectangle);
+    Scalar centerScaleRectangle   = Eigen::internal::random<Scalar>(1, 10000);
     VectorType centerRectangle    = VectorType::Random() * centerScaleRectangle;
     VectorType directionRectangle = VectorType::Random().normalized();
     VectorType xAxisRectangle, yAxisRectangle;
     int i0 = -1, i1 = -1, i2 = -1;
     directionRectangle.minCoeff(&i0);
-    i1 = (i0+1)%3;
-    i2 = (i0+2)%3;
+    i1                 = (i0 + 1) % 3;
+    i2                 = (i0 + 2) % 3;
     xAxisRectangle[i0] = 0;
     xAxisRectangle[i1] = directionRectangle[i2];
     xAxisRectangle[i2] = -directionRectangle[i1];
-    yAxisRectangle[i0] = directionRectangle[i1]*directionRectangle[i1] + directionRectangle[i2]*directionRectangle[i2];
-    yAxisRectangle[i1] = -directionRectangle[i1]*directionRectangle[i0];
-    yAxisRectangle[i2] = -directionRectangle[i2]*directionRectangle[i0];
+    yAxisRectangle[i0] =
+        directionRectangle[i1] * directionRectangle[i1] + directionRectangle[i2] * directionRectangle[i2];
+    yAxisRectangle[i1] = -directionRectangle[i1] * directionRectangle[i0];
+    yAxisRectangle[i2] = -directionRectangle[i2] * directionRectangle[i0];
 
     Scalar epsilon = testEpsilon<Scalar>();
-    if( _bAddNoise ) // relax a bit the testing threshold
-        epsilon = Scalar(0.002*MAX_NOISE);
+    if (_bAddNoise) // relax a bit the testing threshold
+        epsilon = Scalar(0.002 * MAX_NOISE);
 
     vector<DataPoint> vectorPointsParaboloid(nbPointsParaboloid);
     vector<DataPoint> vectorPointsPlane(nbPointsParaboloid);
     vector<DataPoint> vectorPointsSphere(nbPointsParaboloid);
     vector<DataPoint> vectorPointsRectangle(nbPointsRectangle);
 
-    for(unsigned int i = 0; i < vectorPointsParaboloid.size(); ++i)
+    for (unsigned int i = 0; i < vectorPointsParaboloid.size(); ++i)
     {
-        vectorPointsParaboloid[i] = getPointOnParaboloid<DataPoint>(VectorType::Zero(),
-                                                                    coefParaboloid,
-                                                                    qParaboloid,
-                                                                    Scalar(1.2)*analysisScaleParaboloid,
-                                                                    _bAddNoise);
+        vectorPointsParaboloid[i] = getPointOnParaboloid<DataPoint>(VectorType::Zero(), coefParaboloid, qParaboloid,
+                                                                    Scalar(1.2) * analysisScaleParaboloid, _bAddNoise);
     }
-    for(unsigned int i = 0; i < vectorPointsPlane.size(); ++i)
+    for (unsigned int i = 0; i < vectorPointsPlane.size(); ++i)
     {
-        vectorPointsPlane[i] = getPointOnPlane<DataPoint>(centerPlane,
-                                                          directionPlane,
-                                                          widthPlane,
-                                                          _bAddNoise,
-                                                          _bAddNoise);
+        vectorPointsPlane[i] =
+            getPointOnPlane<DataPoint>(centerPlane, directionPlane, widthPlane, _bAddNoise, _bAddNoise);
     }
-    for(unsigned int i = 0; i < vectorPointsParaboloid.size(); ++i)
+    for (unsigned int i = 0; i < vectorPointsParaboloid.size(); ++i)
     {
-        vectorPointsSphere[i] = getPointOnSphere<DataPoint>(radiusSphere,
-                                                            centerSphere,
-                                                            _bAddNoise,
-                                                            _bAddNoise);
+        vectorPointsSphere[i] = getPointOnSphere<DataPoint>(radiusSphere, centerSphere, _bAddNoise, _bAddNoise);
     }
-    for(unsigned int i = 0; i < vectorPointsRectangle.size(); ++i)
+    for (unsigned int i = 0; i < vectorPointsRectangle.size(); ++i)
     {
-        vectorPointsRectangle[i] = getPointOnRectangularPlane<DataPoint>(centerRectangle,
-                                                                directionRectangle,
-                                                                widthRectangle,
-                                                                heightRectangle,
-                                                                xAxisRectangle,
-                                                                yAxisRectangle,
-                                                                _bAddNoise);
+        vectorPointsRectangle[i] =
+            getPointOnRectangularPlane<DataPoint>(centerRectangle, directionRectangle, widthRectangle, heightRectangle,
+                                                  xAxisRectangle, yAxisRectangle, _bAddNoise);
         vectorPointsRectangle[i].normal() = directionRectangle;
     }
 
-    checkConsistency<DataPoint, Fit1, Fit2, Fit3>(vectorPointsParaboloid, Scalar(1.2)*analysisScaleParaboloid, epsilon);
+    checkConsistency<DataPoint, Fit1, Fit2, Fit3>(vectorPointsParaboloid, Scalar(1.2) * analysisScaleParaboloid,
+                                                  epsilon);
     checkConsistency<DataPoint, Fit1, Fit2, Fit3>(vectorPointsPlane, analysisScalePlane, epsilon);
     checkConsistency<DataPoint, Fit1, Fit2, Fit3>(vectorPointsSphere, analysisScaleSphere, epsilon);
     checkConsistency<DataPoint, Fit1, Fit2, Fit3>(vectorPointsRectangle, analysisScaleRectangle, epsilon);
 }
 
-template<typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 void callSubTests()
 {
     typedef PointPositionNormal<Scalar, Dim> Point;
-    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar> > WeightSmoothFunc;
-    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar> > WeightConstantFunc;
+    typedef DistWeightFunc<Point, SmoothWeightKernel<Scalar>> WeightSmoothFunc;
+    typedef DistWeightFunc<Point, ConstantWeightKernel<Scalar>> WeightConstantFunc;
 
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit,OrientedSphereScaleDer> FitConstantScaleDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit,OrientedSphereSpaceDer> FitConstantSpaceDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit,OrientedSphereScaleSpaceDer> FitConstantScaleSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleDer> FitConstantScaleDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitConstantSpaceDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitConstantScaleSpaceDer;
 
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit,OrientedSphereScaleDer, MlsSphereFitDer> FitConstantScaleMlsDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit,OrientedSphereSpaceDer, MlsSphereFitDer> FitConstantSpaceMlsDer;
-    typedef Basket<Point,WeightConstantFunc,OrientedSphereFit,OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitConstantScaleSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleDer, MlsSphereFitDer>
+        FitConstantScaleMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitConstantSpaceMlsDer;
+    typedef Basket<Point, WeightConstantFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitConstantScaleSpaceMlsDer;
 
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit,OrientedSphereScaleDer> FitSmoothScaleDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit,OrientedSphereSpaceDer> FitSmoothSpaceDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit,OrientedSphereScaleSpaceDer> FitSmoothScaleSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleDer> FitSmoothScaleDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer> FitSmoothSpaceDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer> FitSmoothScaleSpaceDer;
 
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit,OrientedSphereScaleDer, MlsSphereFitDer> FitSmoothScaleMlsDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit,OrientedSphereSpaceDer, MlsSphereFitDer> FitSmoothSpaceMlsDer;
-    typedef Basket<Point,WeightSmoothFunc,OrientedSphereFit,OrientedSphereScaleSpaceDer, MlsSphereFitDer> FitSmoothScaleSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleDer, MlsSphereFitDer>
+        FitSmoothScaleMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereSpaceDer, MlsSphereFitDer>
+        FitSmoothSpaceMlsDer;
+    typedef Basket<Point, WeightSmoothFunc, OrientedSphereFit, OrientedSphereScaleSpaceDer, MlsSphereFitDer>
+        FitSmoothScaleSpaceMlsDer;
 
     cout << "Testing with perfect primitives..." << endl;
-    for(int i = 0; i < g_repeat; ++i)
+    for (int i = 0; i < g_repeat; ++i)
     {
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleDer, FitConstantSpaceDer, FitConstantScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitConstantScaleMlsDer, FitConstantSpaceMlsDer, FitConstantScaleSpaceMlsDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleDer, FitSmoothSpaceDer, FitSmoothScaleSpaceDer>() ));
-        CALL_SUBTEST(( testFunction<Point, FitSmoothScaleMlsDer, FitSmoothSpaceMlsDer, FitSmoothScaleSpaceMlsDer>() ));
+        CALL_SUBTEST((testFunction<Point, FitConstantScaleDer, FitConstantSpaceDer, FitConstantScaleSpaceDer>()));
+        CALL_SUBTEST(
+            (testFunction<Point, FitConstantScaleMlsDer, FitConstantSpaceMlsDer, FitConstantScaleSpaceMlsDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleDer, FitSmoothSpaceDer, FitSmoothScaleSpaceDer>()));
+        CALL_SUBTEST((testFunction<Point, FitSmoothScaleMlsDer, FitSmoothSpaceMlsDer, FitSmoothScaleSpaceMlsDer>()));
     }
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }

--- a/tests/src/weight_kernel.cpp
+++ b/tests/src/weight_kernel.cpp
@@ -21,28 +21,28 @@
 using namespace std;
 using namespace Ponca;
 
-template<class Kernel>
+template <class Kernel>
 void testFunctionAutoDiff()
 {
     typedef typename Kernel::Scalar ScalarDiff;
     typedef typename ScalarDiff::Scalar Scalar;
 
     Scalar step = Scalar(0.05);
-    int n = int(Scalar(1)/Scalar(step));
+    int n       = int(Scalar(1) / Scalar(step));
 
     Kernel k;
     Scalar epsilon = testEpsilon<Scalar>();
 
     // compare to automatic differentiation
-    for(int i=1; i<=n; ++i)
+    for (int i = 1; i <= n; ++i)
     {
-        ScalarDiff a(i*step, 1, 0);
+        ScalarDiff a(i * step, 1, 0);
 
         ScalarDiff f   = k.f(a);
         ScalarDiff df  = k.df(a);
         ScalarDiff ddf = k.ddf(a);
 
-        Scalar diff1 = std::abs( f.derivatives()[0] - df.value());
+        Scalar diff1 = std::abs(f.derivatives()[0] - df.value());
         Scalar diff2 = std::abs(df.derivatives()[0] - ddf.value());
 
         VERIFY(diff1 < epsilon);
@@ -50,44 +50,46 @@ void testFunctionAutoDiff()
     }
 }
 
-template<class Kernel>
+template <class Kernel>
 void testFunction(typename Kernel::Scalar mmin = 0, typename Kernel::Scalar mmax = 1)
 {
     typedef typename Kernel::Scalar Scalar;
 
     Scalar step = Scalar(0.05);
-    int n = int((mmax - mmin)/Scalar(step));
+    int n       = int((mmax - mmin) / Scalar(step));
 
     Kernel k;
-    Scalar h = Scalar(1e-6);
-    Scalar epsilon = Scalar(100)*testEpsilon<Scalar>();
+    Scalar h       = Scalar(1e-6);
+    Scalar epsilon = Scalar(100) * testEpsilon<Scalar>();
 
     // compare to finite difference approximations
-    for(int i=1; i<n; ++i)
+    for (int i = 1; i < n; ++i)
     {
-        Scalar a = mmin + i*step;
+        Scalar a = mmin + i * step;
 
-        Scalar f    = k.f(a);
-        Scalar fr   = k.f(a+h);
-        Scalar fl   = k.f(a-h);
+        Scalar f  = k.f(a);
+        Scalar fr = k.f(a + h);
+        Scalar fl = k.f(a - h);
 
-        if (k.isDValid){ // test first order derivative
-            Scalar df   = k.df(a);
-            Scalar df_  = (fr - fl)/(Scalar(2.)*h);
-            Scalar diff1 = std::abs(df-df_);
+        if (k.isDValid)
+        { // test first order derivative
+            Scalar df    = k.df(a);
+            Scalar df_   = (fr - fl) / (Scalar(2.) * h);
+            Scalar diff1 = std::abs(df - df_);
             VERIFY(diff1 < epsilon);
         }
 
-        if (k.isDDValid){
-            Scalar ddf  = k.ddf(a);
-            Scalar ddf_ = (fr - Scalar(2.)*f + fl)/(h*h);
-            Scalar diff2 = std::abs(ddf-ddf_);
+        if (k.isDDValid)
+        {
+            Scalar ddf   = k.ddf(a);
+            Scalar ddf_  = (fr - Scalar(2.) * f + fl) / (h * h);
+            Scalar diff2 = std::abs(ddf - ddf_);
             VERIFY(diff2 < epsilon);
         }
     }
 }
 
-template<typename W1, typename W2>
+template <typename W1, typename W2>
 void testKernelDiff(int nbSteps = 1000)
 {
     W1 kernel1;
@@ -96,7 +98,7 @@ void testKernelDiff(int nbSteps = 1000)
     typedef typename W1::Scalar Scalar;
     Scalar epsilon = Scalar(0.0001); // Current tolerance
 
-    for(int i=1; i<=nbSteps; ++i)
+    for (int i = 1; i <= nbSteps; ++i)
     {
         Scalar x = Scalar(i) / Scalar(nbSteps);
         // Compare both kernel (should be equal)
@@ -110,9 +112,9 @@ void testKernelDiff(int nbSteps = 1000)
     // do more tests to highlight timings differences
     nbSteps *= nbSteps;
 
-    auto runComputation = [nbSteps](auto kernel ){
+    auto runComputation = [nbSteps](auto kernel) {
         Scalar sum = 0;
-        for(int i=1; i<=nbSteps; ++i)
+        for (int i = 1; i <= nbSteps; ++i)
         {
             Scalar x = Scalar(i) / Scalar(nbSteps);
             sum += kernel.f(x) + kernel.df(x) + kernel.ddf(x);
@@ -121,46 +123,45 @@ void testKernelDiff(int nbSteps = 1000)
     };
 
     // test timings
-    auto start = std::chrono::system_clock::now();
-    auto res1 = runComputation( kernel1 );
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> w1Time = (end-start);
+    auto start                           = std::chrono::system_clock::now();
+    auto res1                            = runComputation(kernel1);
+    auto end                             = std::chrono::system_clock::now();
+    std::chrono::duration<double> w1Time = (end - start);
 
-    start = std::chrono::system_clock::now();
-    auto res2 = runComputation( kernel2 );
-    end = std::chrono::system_clock::now();
-    std::chrono::duration<double> w2Time = (end-start);
+    start                                = std::chrono::system_clock::now();
+    auto res2                            = runComputation(kernel2);
+    end                                  = std::chrono::system_clock::now();
+    std::chrono::duration<double> w2Time = (end - start);
 
     // print output values to avoid that the compiler optimizes by deleting the functions
     std::cout << "res: " << res1 << " " << res2 << std::endl;
     std::cout << "time:" << w1Time.count() << " " << w2Time.count() << std::endl;
 
     // we do not verify anything here, as the timings my evolve very differently depending on the compilation
-
 }
 
-template<typename Scalar, template <typename > class KernelT>
+template <typename Scalar, template <typename> class KernelT>
 void callSubTests(Scalar mmin = 0, Scalar mmax = 1)
 {
-    typedef Eigen::AutoDiffScalar<Eigen::Matrix<Scalar,1,1>> ScalarDiff;
+    typedef Eigen::AutoDiffScalar<Eigen::Matrix<Scalar, 1, 1>> ScalarDiff;
     typedef KernelT<Scalar> Kernel;
-    CALL_SUBTEST(( testFunction<Kernel>(mmin, mmax) ));
+    CALL_SUBTEST((testFunction<Kernel>(mmin, mmax)));
 
     cout << "ok" << endl;
 }
-template<typename Scalar, template <typename > class KernelT>
+template <typename Scalar, template <typename> class KernelT>
 void callAutoDiffSubTests()
 {
-    typedef Eigen::AutoDiffScalar<Eigen::Matrix<Scalar,1,1>> ScalarDiff;
+    typedef Eigen::AutoDiffScalar<Eigen::Matrix<Scalar, 1, 1>> ScalarDiff;
     typedef KernelT<ScalarDiff> KernelAutoDiff;
-    CALL_SUBTEST(( testFunctionAutoDiff<KernelAutoDiff>() ));
+    CALL_SUBTEST((testFunctionAutoDiff<KernelAutoDiff>()));
 
     cout << "ok" << endl;
 }
 
 int main(int argc, char** argv)
 {
-    if(!init_testing(argc, argv))
+    if (!init_testing(argc, argv))
     {
         return EXIT_FAILURE;
     }
@@ -193,5 +194,4 @@ int main(int argc, char** argv)
     testKernelDiff<PolynomialSmoothWeightKernel<double, 2, 2>, SmoothWeightKernel<double>>();
     testKernelDiff<PolynomialSmoothWeightKernel<float, 2, 2>, SmoothWeightKernel<float>>();
     testKernelDiff<PolynomialSmoothWeightKernel<long double, 2, 2>, SmoothWeightKernel<long double>>();
-
 }


### PR DESCRIPTION
Hi, 

Here is my initial guess at creating a standard formatter for  Ponca. I suggest using Clang Format, one of the most customisable formatters available. 

@nmellado and @Me-k-01, please take a look at the current commit and let me know if there are any lines that don't look right to you. 

To test a new configuration for the entire repository: "find Ponca/ | xargs clang-format -i".
Alternatively, you can use the online tool at https://zed0.co.uk/clang-format-configurator/ (upload the .clang-format file) to quickly view the rules. Be mindful of spaces in and out of parentheses, templates, etc. There are plenty of alignment options, but bear in mind that they are enforced by the formatter. For example, if you select the option to align consecutive assignments, they will always be aligned, no matter what. 

Send me back the new formatter and I will rewrite the commits so that this is easier to see global changes.

Also, the old guidelines state that parameters should start with '_', but there is no rule to enforce this within Clang Format. However, we could also add a Clang Tidy check that can do this (and much more).

Once the formatter is set, we can add a GitHub action check to maintain consistency, but this may cause more problems than it solves.