### PR TITLE
Fix cxx20 warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,9 @@ Ponca changelog
 Current head (v.2.0.alpha3 RC)
 This release will introduce a refactoring of the requirement library using cpp20::concepts.
 
--CI/Actions
+- Bug-fixes and code improvements
+   - [Fitting] Fix warnings introduced when bumping to cxx20 (#303)
+- CI/Actions
     - [ci] Fix Issue with Eigen build in buildAsSubmodule (#299)
 
 

--- a/Ponca/src/Fitting/covariancePlaneFit.h
+++ b/Ponca/src/Fitting/covariancePlaneFit.h
@@ -108,7 +108,7 @@ namespace Ponca
     protected:
         enum
         {
-            Check = Base::PROVIDES_PLANE & Base::PROVIDES_POSITION_COVARIANCE_DERIVATIVE,
+            Check = Base::PROVIDES_PLANE && Base::PROVIDES_POSITION_COVARIANCE_DERIVATIVE,
             PROVIDES_COVARIANCE_PLANE_DERIVATIVE, /*!< \brief Provides derivatives for hyper-planes */
             PROVIDES_NORMAL_DERIVATIVE
         };

--- a/Ponca/src/Fitting/gls.h
+++ b/Ponca/src/Fitting/gls.h
@@ -126,7 +126,7 @@ namespace Ponca
     protected:
         enum
         {
-            Check = Base::PROVIDES_GLS_PARAMETRIZATION & Base::PROVIDES_PRIMITIVE_DERIVATIVE &
+            Check = Base::PROVIDES_GLS_PARAMETRIZATION && Base::PROVIDES_PRIMITIVE_DERIVATIVE &&
                     Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
             PROVIDES_GLS_DERIVATIVE,
             PROVIDES_GLS_GEOM_VAR

--- a/Ponca/src/Fitting/mlsSphereFitDer.h
+++ b/Ponca/src/Fitting/mlsSphereFitDer.h
@@ -27,7 +27,7 @@ namespace Ponca
     protected:
         enum
         {
-            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE & Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
+            Check = Base::PROVIDES_PRIMITIVE_DERIVATIVE && Base::PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
             PROVIDES_NORMAL_DERIVATIVE
         };
 

--- a/Ponca/src/Fitting/orientedSphereFit.h
+++ b/Ponca/src/Fitting/orientedSphereFit.h
@@ -64,7 +64,7 @@ namespace Ponca
     protected:
         enum
         {
-            Check = Base::PROVIDES_ALGEBRAIC_SPHERE & Base::PROVIDES_MEAN_POSITION_DERIVATIVE &
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE && Base::PROVIDES_MEAN_POSITION_DERIVATIVE &&
                     Base::PROVIDES_PRIMITIVE_DERIVATIVE,
             PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
             PROVIDES_NORMAL_DERIVATIVE

--- a/Ponca/src/Fitting/unorientedSphereFit.h
+++ b/Ponca/src/Fitting/unorientedSphereFit.h
@@ -93,7 +93,7 @@ namespace Ponca
     protected:
         enum
         {
-            Check = Base::PROVIDES_ALGEBRAIC_SPHERE & Base::PROVIDES_MEAN_POSITION_DERIVATIVE &
+            Check = Base::PROVIDES_ALGEBRAIC_SPHERE && Base::PROVIDES_MEAN_POSITION_DERIVATIVE &&
                     Base::PROVIDES_PRIMITIVE_DERIVATIVE,
             PROVIDES_ALGEBRAIC_SPHERE_DERIVATIVE,
             PROVIDES_NORMAL_DERIVATIVE


### PR DESCRIPTION
Fix warnings introduced when bumping to cxx20, and which appears in the last release, which is unfortunate.

This fix is temporary as #293 will erase all this, but we need to publish a new release as this might affect downstream users.