### PR TITLE
[spatialPartitioning] Set kdtree buffer size after container conversion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,9 +6,10 @@ Current head (v.2.0.alpha3 RC)
 This release will introduce a refactoring of the requirement library using cpp20::concepts.
 
 - Bug-fixes and code improvements
-   - [Fitting] Fix warnings introduced when bumping to cxx20 (#303)
+    - [Fitting] Fix warnings introduced when bumping to cxx20 (#303)
 - Cmake
     - [all] Eigen is now always for transitive linking (#302)
+    - [spatialPartitioning] Fix regression introduced by the CUDA kdtree update (#306)
 - CI/Actions
     - [ci] Fix Issue with Eigen build in buildAsSubmodule (#299)
     - [ci] New github action for checking CPM installation (#302)

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -123,10 +123,10 @@ PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildWithSampling(PointUser
 
     // Move, copy or convert input samples
     c(std::forward<PointUserContainer>(points), Base::m_bufs.points);
-    Base::m_bufs.points_size = points.size();
+    Base::m_bufs.points_size = Base::m_bufs.points.size();
 
-    Base::m_bufs.indices_size = sampling.size();
-    Base::m_bufs.indices      = std::move(sampling);
+    Base::m_bufs.indices      = std::forward<IndexUserContainer>(sampling);
+    Base::m_bufs.indices_size = Base::m_bufs.indices.size();
 
     Base::m_bufs.nodes.reserve(4 * Base::pointCount() / Base::m_min_cell_size);
     Base::m_bufs.nodes.emplace_back();


### PR DESCRIPTION
- Fix regression #305 by setting the buffer size after the container conversion
- Avoid Forwarding reference warning