### PR TITLE
[common] Adapt `PONCA_ASSERT` macro to CUDA

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ This release will introduce a refactoring of the requirement library using cpp20
     - [fitting] Fix warnings introduced when bumping to cxx20 (#303)
     - [spatialPartitioning] Fix regression introduced by the CUDA kdtree update (#306)
     - [common] Fix PONCA_ASSERT macro on MSVC and clang (#309)
+    - [common] Adapt PONCA_ASSERT macro to CUDA (#311)
 
 - Cmake
     - [all] Eigen is now always for transitive linking (#302)

--- a/Ponca/src/Common/Macro.h
+++ b/Ponca/src/Common/Macro.h
@@ -14,7 +14,7 @@
 #define PONCA_XSTR(S) #S
 #define PONCA_STR(S) PONCA_XSTR(S)
 
-#ifdef __CUDACC__
+#ifdef __CUDA_ARCH__
 #    define PONCA_ABORT asm("trap;");
 #elif defined(_MSC_VER)
 #    define PONCA_ABORT __debugbreak();
@@ -30,7 +30,7 @@
     PONCA_ABORT       \
     PONCA_MACRO_END
 
-#ifdef __CUDACC__
+#ifdef __CUDA_ARCH__
 #    define PONCA_PRINT_ERROR(MSG)                              \
         PONCA_MACRO_START                                       \
         printf("%s:%i: [Error] %s\n", __FILE__, __LINE__, MSG); \

--- a/Ponca/src/Common/Macro.h
+++ b/Ponca/src/Common/Macro.h
@@ -14,7 +14,9 @@
 #define PONCA_XSTR(S) #S
 #define PONCA_STR(S) PONCA_XSTR(S)
 
-#if defined(_MSC_VER)
+#ifdef __CUDACC__
+#    define PONCA_ABORT asm("trap;");
+#elif defined(_MSC_VER)
 #    define PONCA_ABORT __debugbreak();
 #elif defined(__clang__) || defined(__GNUC__)
 #    define PONCA_ABORT __builtin_trap();
@@ -28,17 +30,27 @@
     PONCA_ABORT       \
     PONCA_MACRO_END
 
-#define PONCA_PRINT_ERROR(MSG)                                       \
-    PONCA_MACRO_START                                                \
-    fprintf(stderr, "%s:%i: [Error] %s\n", __FILE__, __LINE__, MSG); \
-    fflush(stderr);                                                  \
-    PONCA_MACRO_END
-
-#define PONCA_PRINT_WARNING(MSG)                                       \
-    PONCA_MACRO_START                                                  \
-    fprintf(stderr, "%s:%i: [Warning] %s\n", __FILE__, __LINE__, MSG); \
-    fflush(stderr);                                                    \
-    PONCA_MACRO_END
+#ifdef __CUDACC__
+#    define PONCA_PRINT_ERROR(MSG)                              \
+        PONCA_MACRO_START                                       \
+        printf("%s:%i: [Error] %s\n", __FILE__, __LINE__, MSG); \
+        PONCA_MACRO_END
+#    define PONCA_PRINT_WARNING(MSG)                              \
+        PONCA_MACRO_START                                         \
+        printf("%s:%i: [Warning] %s\n", __FILE__, __LINE__, MSG); \
+        PONCA_MACRO_END
+#else
+#    define PONCA_PRINT_ERROR(MSG)                                       \
+        PONCA_MACRO_START                                                \
+        fprintf(stderr, "%s:%i: [Error] %s\n", __FILE__, __LINE__, MSG); \
+        fflush(stderr);                                                  \
+        PONCA_MACRO_END
+#    define PONCA_PRINT_WARNING(MSG)                                       \
+        PONCA_MACRO_START                                                  \
+        fprintf(stderr, "%s:%i: [Warning] %s\n", __FILE__, __LINE__, MSG); \
+        fflush(stderr);                                                    \
+        PONCA_MACRO_END
+#endif
 
 // turnoff warning
 #define PONCA_UNUSED(VAR)         \

--- a/Ponca/src/Fitting/cncFormulaEigen.h
+++ b/Ponca/src/Fitting/cncFormulaEigen.h
@@ -61,6 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <Ponca/src/Common/Assert.h>
 #include <Eigen/Dense>
 
 namespace Ponca::internal
@@ -310,8 +311,8 @@ namespace Ponca::internal
 
             // SelfAdjointEigenSolver returns sorted eigenvalues, no
             // need to reorder the eigenvectors.
-            assert(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
-            assert(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
+            PONCA_ASSERT(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
+            PONCA_ASSERT(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
             VectorType v1 = eigensolver.eigenvectors().col(1);
             VectorType v2 = eigensolver.eigenvectors().col(0);
             return std::pair<VectorType, VectorType>(v1, v2);
@@ -341,8 +342,8 @@ namespace Ponca::internal
             {
                 // SelfAdjointEigenSolver returns sorted eigenvalues, no
                 // need to reorder the eigenvectors.
-                assert(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
-                assert(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
+                PONCA_ASSERT(eigensolver.eigenvalues()(0) <= eigensolver.eigenvalues()(1));
+                PONCA_ASSERT(eigensolver.eigenvalues()(1) <= eigensolver.eigenvalues()(2));
                 VectorType v1 = eigensolver.eigenvectors().col(0);
                 VectorType v2 = eigensolver.eigenvectors().col(1);
                 return std::make_tuple(-eigensolver.eigenvalues()(0), -eigensolver.eigenvalues()(1), v1, v2);

--- a/Ponca/src/Fitting/cncFormulaEigen.h
+++ b/Ponca/src/Fitting/cncFormulaEigen.h
@@ -61,7 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include <Ponca/src/Common/Assert.h>
+#include "../Common/Assert.h"
 #include <Eigen/Dense>
 
 namespace Ponca::internal

--- a/Ponca/src/Fitting/weightFunc.h
+++ b/Ponca/src/Fitting/weightFunc.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <Ponca/src/Common/Assert.h>
+#include "../Common/Assert.h"
 #include "./defines.h"
 #include PONCA_MULTIARCH_INCLUDE_CU_STD(utility)
 

--- a/Ponca/src/Fitting/weightFunc.h
+++ b/Ponca/src/Fitting/weightFunc.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <Ponca/src/Common/Assert.h>
 #include "./defines.h"
 #include PONCA_MULTIARCH_INCLUDE_CU_STD(utility)
 
@@ -196,16 +197,14 @@ namespace Ponca
                                               const Scalar& _t           = Scalar(1.))
             : NeighborhoodFrame(_evalPos), m_t(_t)
         {
-            //\todo manage that assert on __host__ and __device__
-            // assert(_t > Scalar(0));
+            PONCA_ASSERT(_t > Scalar(0));
         }
 
         ///! \copydoc DistWeightFunc
         PONCA_MULTIARCH inline DistWeightFunc(const DataPoint& _evalPoint, const Scalar& _t = Scalar(1.))
             : NeighborhoodFrame(_evalPoint.pos()), m_t(_t)
         {
-            //\todo manage that assert on __host__ and __device__
-            // assert(_t > Scalar(0));
+            PONCA_ASSERT(_t > Scalar(0));
         }
 
         /*!

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -18,8 +18,7 @@
 #include <vector>
 
 #include <Eigen/Geometry> // aabb
-
-#include "../../Common/Assert.h"
+#include <Ponca/src/Common/Assert.h>
 
 #include "Query/kdTreeNearestQueries.h"
 #include "Query/kdTreeKNearestQueries.h"

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.h
@@ -18,7 +18,8 @@
 #include <vector>
 
 #include <Eigen/Geometry> // aabb
-#include <Ponca/src/Common/Assert.h>
+
+#include "../../Common/Assert.h"
 
 #include "Query/kdTreeNearestQueries.h"
 #include "Query/kdTreeKNearestQueries.h"

--- a/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
@@ -12,8 +12,8 @@
 #include "Query/knnGraphRangeQuery.h"
 
 #include "../KdTree/kdTree.h"
+#include "../../Common/Assert.h"
 
-#include <Ponca/src/Common/Assert.h>
 #include <memory>
 
 namespace Ponca

--- a/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
+++ b/Ponca/src/SpatialPartitioning/KnnGraph/knnGraph.h
@@ -13,6 +13,7 @@
 
 #include "../KdTree/kdTree.h"
 
+#include <Ponca/src/Common/Assert.h>
 #include <memory>
 
 namespace Ponca
@@ -87,7 +88,7 @@ namespace Ponca
             const int cloudSize = kdtree.pointCount();
             {
                 const int samplesSize = kdtree.sampleCount();
-                eigen_assert(cloudSize == samplesSize);
+                PONCA_ASSERT(cloudSize == samplesSize);
             }
 
             m_indices.resize(cloudSize * m_k, -1);


### PR DESCRIPTION
Fix #310 by taking into account `#ifdef __CUDA_ARCH__`
The program is simply aborted with `asm("trap;")` if we are on the device CUDA. We now can ensure that the program is stopped if we encounter an error on either the host or the device, unlike `assert` which doesn't terminate abruptly the CUDA kernel.