### PR TITLE
[spatialPartitioning] Reset buffers before constructing a KdTree

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ This release will introduce a refactoring of the requirement library using cpp20
     - [fitting] projectDescent is now a separate class from Basket (#298)
     - [spatialPartitioning] Rework KnnGraph API for compilation and query on the GPU (#301)
     - [spatialPartitioning] Replace KnnGraph query containers with custom Stack and HashSet structure (#301)
+    - [spatialPartitioning] Fix a bug when re-building an existing KdTree (#320)
     - [common] Rename LimitedPriorityQueue, and update to work in CUDA (#301)
     - [common] Added Bitset and Hashset data-structures (also CUDA-compatible) (#301)
 

--- a/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
+++ b/Ponca/src/SpatialPartitioning/KdTree/kdTree.hpp
@@ -121,6 +121,9 @@ PONCA_MULTIARCH_HOST inline void KdTreeBase<Traits>::buildWithSampling(PointUser
     PONCA_DEBUG_ASSERT(static_cast<IndexType>(Base::pointCount()) <= Base::MAX_POINT_COUNT);
     Base::m_leaf_count = 0;
 
+    // Reset buffers.
+    Base::m_bufs = typename Base::Buffers();
+
     // Move, copy or convert input samples
     c(std::forward<PointUserContainer>(points), Base::m_bufs.points);
     Base::m_bufs.points_size = Base::m_bufs.points.size();


### PR DESCRIPTION
Fix a bug when trying to update a Kdtree : previous buffers were not destructed.
For most converters that rely on inserting new components (including the DefaultConverter), this means that the previous points were kept, in addition to the new ones.