### PR TITLE
Auto release on tag push

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: build/install
         run: zip -r ../../ponca-${{ matrix.config.name }}.zip .
 
-      - name: Zipping install directory (Linux/Mac)
+      - name: Zipping install directory (MSVC)
         if: runner.os == 'Windows'
         working-directory: build/install
         run: Compress-Archive -Path * -DestinationPath ../../ponca-${{ matrix.config.name }}.zip

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract CHANGELOG info
+        id: changelog
+        shell: bash
+        run: |
+          CONTENT=$(awk '/^-+$/{count++; if(count==2) exit} count==1{lines++; if(lines>2) print}' CHANGELOG)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+      - name: Create Release
+        uses: actions/create-release@v1
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.changelog.outputs.content }}
+          draft:      ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -61,7 +61,9 @@ jobs:
         id: changelog
         shell: bash
         run: |
-          CONTENT=$(awk '/^-+$/{count++; if(count==2) exit} count==1{lines++; if(lines>2) print}' CHANGELOG)
+          # Looks for the block that contains the refname (without the v if it exists)
+          # If the version is not found, we redirect the user to the CHANGELOG file
+          CONTENT=$(awk -v version='${{ github.ref_name }}' 'BEGIN { sub(/^v/, "", version); version = tolower(version) } /^---/ { if (found) { exit } } found  { print } tolower($0) ~ tolower(version) { found = 1 } END { if (!found) print "For information about changes, see CHANGELOG file." }' CHANGELOG)
           echo "content<<EOF" >> $GITHUB_OUTPUT
           echo "$CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -7,10 +7,55 @@ name: Create Release
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { name: "Ubuntu",  os: ubuntu-latest, icon: "Linux" }
+          - { name: "MacOS",   os: macos-latest, icon: "Apple" }
+          - { name: "Windows", os: windows-latest, icon: "Windows"}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          path: src
+      
+      - name: CMake
+        run: |
+          mkdir build && cd build
+          cmake ../src -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DCMAKE_Fortran_COMPILER="" -DPONCA_CONFIGURE_EXAMPLES=OFF -DPONCA_CONFIGURE_DOC=OFF -DPONCA_CONFIFURE_TESTS=OFF
+
+      - name: Build
+        run: |
+          cmake --build build/
+
+      - name: Making relocatble CMake Install
+        run: |
+          cmake --install build/
+
+      - name: Zipping install directory (Linux/Mac)
+        if: runner.os != 'Windows'
+        working-directory: build/install
+        run: zip -r ../../ponca-${{ matrix.config.name }}.zip .
+
+      - name: Zipping install directory (Linux/Mac)
+        if: runner.os == 'Windows'
+        working-directory: build/install
+        run: Compress-Archive -Path * -DestinationPath ../../ponca-${{ matrix.config.name }}.zip
+
+
+      - name: Saving folders
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.config.name }}
+          path: ponca-${{ matrix.config.name }}.zip
+
+
+  release:
+    runs-on: "ubuntu-latest"
+    needs: build
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@master
 
       - name: Extract CHANGELOG info
         id: changelog
@@ -20,15 +65,21 @@ jobs:
           echo "content<<EOF" >> $GITHUB_OUTPUT
           echo "$CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          
+
+      - name: Getting install folders
+        uses: actions/download-artifact@v7
+        with: 
+          path: all
+
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.content }}
-          draft:      ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+          draft: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'RC') }}
+          artifacts: "all/MacOS/ponca-MacOS.zip,all/Ubuntu/ponca-Ubuntu.zip,all/Windows/ponca-Windows.zip"
+          allowUpdates: true # In case something went wrong :) 
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ This release will introduce a refactoring of the requirement library using cpp20
     - [ci] Formatter now checks for cuda files (#332, #315)
     - [ci] Speed-up coverage compilation by switching to release mode (#337)
     - [sycl] add AdaptiveCPP in CI to compile examples (#312)
+    - [ci] New action that automatically create releases (#333)
 
 - Examples
     - [spatialPartitioning] Add a cuda example with the KnnGraph (#301, #323)


### PR DESCRIPTION
This PR proposes to create github release for Ponca when a new tag is pushed (#44). It automatically parse the changelog in order to create the following release. At the time of writting this (the tag/release name is a dummy one for test purposes): 

<img width="497" height="731" alt="image" src="https://github.com/user-attachments/assets/db1d5bc3-da9a-4885-bfd7-257ff96043ee" />

[https://github.com/BDoignies/ponca/releases](https://github.com/BDoignies/ponca/releases)

Here are the rules:
* It looks for the text between the first set between "----". 
* It removes the first line (usually just the version name which is redondant)
* Prerelease and draft are infered from the tag name (alpha/beta within the name).

Assisted by: Claude (free version) for the awk command syntax.