### PR TITLE
Autodiff 

### DIFF
--- a/Ponca/src/Fitting/Basket/basket.h
+++ b/Ponca/src/Fitting/Basket/basket.h
@@ -95,7 +95,23 @@ namespace Ponca
             using type = Ext<BSKP, BSKNF, Type, BasketType>;
         };
 
-        /*!
+        template<typename T>
+        concept HasBase = requires { typename T::Base; };
+
+        template<int Type, typename BasketExt, typename BasketType, template <class, class, int, typename> class Ext, template<class, class, int, typename> class... Exts>
+        struct BasketAutoDiffAggregateImpl
+        {
+            using type = typename BasketDiffAggregateImpl<Type, BasketType, Ext, Exts...>::type;
+        };
+
+
+        template<int Type, HasBase BasketExt, typename BasketType, template <class, class, int, typename> class Ext, template<class, class, int, typename> class... Exts>
+        struct BasketAutoDiffAggregateImpl<Type, BasketExt, BasketType, Ext, Exts...>
+        {
+            using type = typename BasketAutoDiffAggregateImpl<Type, typename BasketExt::Base, typename BasketExt::template DiffExtType<BSKP, BSKNF, Type, BasketType>, Ext, Exts...>::type;
+        };
+
+                /*!
          * \brief Internal class used to build the BasketDiff structure
          * Uses BasketDiffAggregateImpl to unroll the CRTP variadic list
          *
@@ -107,6 +123,11 @@ namespace Ponca
         struct BasketDiffAggregate : BasketDiffAggregateImpl<Type, BasketType, BasketDiffUnitBase, Exts...>
         {
         };
+
+        template <typename BasketType, int Type, template <class, class, int, typename> class... Exts>
+        struct BasketAutoDiffAggregate : BasketAutoDiffAggregateImpl<Type, BasketType, BasketType, BasketDiffUnitBase, Exts...>
+        { };
+
     } // namespace internal
 #endif
 
@@ -213,13 +234,13 @@ namespace Ponca
               template <class, class, int, typename> class... Exts>
     class BasketDiff
         : public BasketComputeObject<BasketDiff<BasketType, Type, Ext0, Exts...>,
-                                     typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type>
+                                     typename internal::BasketAutoDiffAggregate<BasketType, Type, Ext0, Exts...>::type>
     {
     private:
         using Self = BasketDiff;
 
     public:
-        using Base = typename internal::BasketDiffAggregate<BasketType, Type, Ext0, Exts...>::type;
+        using Base = typename internal::BasketAutoDiffAggregate<BasketType, Type, Ext0, Exts...>::type;
         /// Neighbor Filter
         using NeighborFilter = BSKNF;
         /// Point type used for computation

--- a/Ponca/src/Fitting/Basket/basketUnit.h
+++ b/Ponca/src/Fitting/Basket/basketUnit.h
@@ -14,7 +14,11 @@
 
 namespace Ponca
 {
-
+    template <class DataPoint, class _NFilter, int Type, typename T>
+    class NoDerivative : public T
+    {
+        PONCA_FITTING_DECLARE_DEFAULT_TYPES
+    };
     /*!
         \brief Base class of any computation unit of a Basket
 

--- a/Ponca/src/Fitting/defines.h
+++ b/Ponca/src/Fitting/defines.h
@@ -48,12 +48,14 @@
 
 /// Declare the following defaults types: Base, Scalar, VectorType, NeighborFilter
 #define PONCA_FITTING_DECLARE_DEFAULT_TYPES                                                  \
-protected:                                                                                   \
+public:                                                                                      \
     using Base = T; /*!< \brief Base class of the procedure*/                                \
 public:                                                                                      \
     using Scalar         = typename DataPoint::Scalar;    /*!< \brief Alias to scalar type*/ \
     using VectorType     = typename Base::VectorType;     /*!< \brief Alias to vector type*/ \
-    using NeighborFilter = typename Base::NeighborFilter; /*!< \brief Alias to the filter applied on the neighbors */
+    using NeighborFilter = typename Base::NeighborFilter; /*!< \brief Alias to the filter applied on the neighbors */ \
+    template <typename _P, typename _NF, int _Type, typename _T>                                                      \
+    using DiffExtType = NoDerivative<_P, _NF, _Type,  _T>;
 
 /// Declare the following defaults types: Base, Scalar, VectorType, NeighborFilter
 #define PONCA_FITTING_DECLARE_MATRIX_TYPE \


### PR DESCRIPTION
Proposal for #106 , which adds the ability for Basket Extensions to indicate their derivative type.

For now, this first commits only introduce the Basket template side (`defines.h` will not have the type written yet). In its current form, each type would be required to provide a `DiffExtType` (cannot use `DiffType`, but this could be changed) in the following form:

```c++
template <typename _P, typename _NF, int _Type, typename _T> // P and NF could be reused from the base class
using DiffExtType = TheDerivativeClass<_P, _NF, _Type, _T>;
```

`NoDerivative` is a new type that indicates there are no derivatives. I am not exactly sure whether this type is needed or not. With concepts, we might be able to simply skip the ones for which `T::DiffExtType` does not exist.

One mandatory change however: `Base` must be accessible. The main reason is that when the extension list is provided, the types are not complete: you give a `CovariancePlaneFit`, not a `CovariancePlaneFit<Point, Filter, OTHER>`. Hence, we cannot access any subtype; we need the complete type for this.

The solution I provide here is to recurse through the `Base` chain. Because the Basket type has effectively been instantiated, each extension is complete. This does, however, require `Base` to be public.

Any remarks @nmellado?
